### PR TITLE
Fixes a symmetrical bug in which the binary reader and writer did not…

### DIFF
--- a/ionc/ion_timestamp_impl.h
+++ b/ionc/ion_timestamp_impl.h
@@ -91,6 +91,15 @@ iERR _ion_timestamp_equals_helper(const ION_TIMESTAMP *ptime1, const ION_TIMESTA
 iERR ion_timestamp_instant_equals(const ION_TIMESTAMP *ptime1, const ION_TIMESTAMP *ptime2,
                                   BOOL *is_equal, decContext *pcontext);
 
+/**
+ * Convert ptime to UTC (i.e. the pout's local offset will be +00:00 unless ptime's local offset is unknown,
+ * in which case pout's local offset will be -00:00).
+ * @param ptime - The timestamp to convert to UTC.
+ * @param pout - The resulting UTC timestamp (may be the same reference as ptime).
+ * @return IERR_OK, unless ptime is an invalid timestamp.
+ */
+iERR _ion_timestamp_to_utc(const ION_TIMESTAMP *ptime, ION_TIMESTAMP *pout);
+
 #ifdef __cplusplus
 }
 #endif

--- a/ionc/ion_writer_binary.c
+++ b/ionc/ion_writer_binary.c
@@ -794,6 +794,7 @@ iERR _ion_writer_binary_write_timestamp_without_fraction_helper(ION_WRITER *pwri
 {
     iENTER;
     ION_STREAM *pstream = pwriter->_typed_writer.binary._value_stream;
+    ION_TIMESTAMP ptime_utc; // Upon UTC conversion, do not overwrite the user input.
 
     ASSERT(pstream != NULL);
 
@@ -805,6 +806,9 @@ iERR _ion_writer_binary_write_timestamp_without_fraction_helper(ION_WRITER *pwri
     // first we write out the local offset (and we write a -0 if it is not known)
     if (HAS_TZ_OFFSET(ptime)) {
         IONCHECK(ion_binary_write_var_int_64(pstream, ptime->tz_offset));
+        IONCHECK(_ion_timestamp_initialize(&ptime_utc));
+        IONCHECK(_ion_timestamp_to_utc(ptime, &ptime_utc)); // Binary timestamps are stored in UTC with local offset intact.
+        ptime = &ptime_utc;
     }
     else {
         ION_PUT( pstream, ION_BINARY_VAR_INT_NEGATIVE_ZERO );

--- a/test/ion_assert.cpp
+++ b/test/ion_assert.cpp
@@ -271,3 +271,21 @@ BOOL assertIonEventStreamEq(IonEventStream *expected, IonEventStream *actual, AS
     ION_EXIT_ASSERTIONS;
 }
 
+std::string _bytesToHexString(const BYTE *bytes, SIZE len) {
+    std::stringstream ss;
+    ss << std::hex;
+    for (int i = 0; i < len; ++i) {
+        ss << std::setfill('0') << std::setw(2) << (int)bytes[i] << " ";
+    }
+    return ss.str();
+}
+
+void assertBytesEqual(const char *expected, SIZE expected_len, const BYTE *actual, SIZE actual_len) {
+    ASSERT_EQ(expected_len, actual_len);
+    BOOL bytes_not_equal = memcmp((BYTE *)expected, actual, (size_t)actual_len);
+    if (bytes_not_equal) {
+        ASSERT_FALSE(bytes_not_equal) << _bytesToHexString((BYTE *)expected, expected_len) << " vs. " << std::endl
+                                      << _bytesToHexString(actual, actual_len);
+    }
+}
+

--- a/test/ion_assert.h
+++ b/test/ion_assert.h
@@ -242,4 +242,9 @@ BOOL assertIonEventsEq(IonEventStream *stream_expected, size_t index_expected, I
  */
 BOOL assertIonEventStreamEq(IonEventStream *expected, IonEventStream *actual, ASSERTION_TYPE assertion_type);
 
+/**
+ * Tests that the given bytes are equal.
+ */
+void assertBytesEqual(const char *expected, SIZE expected_len, const BYTE *actual, SIZE actual_len);
+
 #endif

--- a/test/test_ion_binary.cpp
+++ b/test/test_ion_binary.cpp
@@ -59,3 +59,38 @@ TEST(IonWriterAddAnnotation, SameInTextAndBinary) {
     ION_ASSERT_OK(read_value_stream_from_bytes(text_data, text_len, &text_stream, NULL));
     assertIonEventStreamEq(&binary_stream, &text_stream, ASSERTION_TYPE_NORMAL);
 }
+
+TEST(IonBinaryTimestampStoredInUTC, WriterConvertsToUTC) {
+    hWRITER writer = NULL;
+    ION_STREAM *ion_stream = NULL;
+    BYTE *result;
+    SIZE result_len;
+    ION_TIMESTAMP timestamp;
+
+    ION_ASSERT_OK(ion_timestamp_for_minute(&timestamp, 2008, 3, 1, 0, 0));
+    ION_ASSERT_OK(ion_timestamp_set_local_offset(&timestamp, 1));
+
+    ION_ASSERT_OK(ion_test_new_writer(&writer, &ion_stream, TRUE));
+    ION_ASSERT_OK(ion_writer_write_timestamp(writer, &timestamp));
+    ION_ASSERT_OK(ion_test_writer_get_bytes(writer, ion_stream, &result, &result_len));
+
+    // Expected: 2008-02-29T23:59 with offset of +1 minutes.
+    assertBytesEqual("\xE0\x01\x00\xEA\x67\x81\x0F\xD8\x82\x9D\x97\xBB", 12, result, result_len);
+}
+
+TEST(IonBinaryTimestampStoredInUTC, ReaderConvertsFromUTC) {
+    hREADER reader;
+    BYTE *timestamp = (BYTE *)"\xE0\x01\x00\xEA\x67\x81\x0F\xD8\x82\x9D\x97\xBB";
+    ION_TYPE actual_type;
+    ION_TIMESTAMP expected, actual;
+    ION_ASSERT_OK(ion_timestamp_for_minute(&expected, 2008, 3, 1, 0, 0));
+    ION_ASSERT_OK(ion_timestamp_set_local_offset(&expected, 1));
+
+    ION_ASSERT_OK(ion_reader_open_buffer(&reader, timestamp, 12, NULL));
+    ION_ASSERT_OK(ion_reader_next(reader, &actual_type));
+    ASSERT_EQ(tid_TIMESTAMP, actual_type);
+    ION_ASSERT_OK(ion_reader_read_timestamp(reader, &actual));
+    ION_ASSERT_OK(ion_reader_close(reader));
+
+    ASSERT_TRUE(assertIonTimestampEq(&expected, &actual));
+}


### PR DESCRIPTION
… convert timestamps from/to UTC on de/serialization.

This is (unfortunately) required by the spec. The bug did not surface in roundtrips because it was completely symmetrical in the reader and writer. Added a test case.