### PR TITLE
Fixes a bug that caused superfluous timestamp local offsets to be read and written for timestamps with less than minute precision.

### DIFF
--- a/ionc/inc/ion_timestamp.h
+++ b/ionc/inc/ion_timestamp.h
@@ -262,9 +262,10 @@ ION_API_EXPORT iERR ion_timestamp_get_local_offset(ION_TIMESTAMP *ptime, int *p_
 ION_API_EXPORT iERR ion_timestamp_unset_local_offset(ION_TIMESTAMP *ptime);
 
 /**
- * Changes the local offset of a timestamp.
- * Afterwards, ion_timestamp_has_local_offset will be true, and
- * ion_timestamp_get_local_offset will be the given offset..
+ * Changes the local offset of a timestamp. If the timestamp has less than minute precision,
+ * the given offset is ignored and the timestamp is unchanged.
+ * If the timestamp is changed, ion_timestamp_has_local_offset will be true, and
+ * ion_timestamp_get_local_offset will be the given offset.
  *
  * @param ptime the timestamp to alter.
  * @param offset_minutes the new local offset, in (positive or negative)

--- a/ionc/ion_timestamp_impl.h
+++ b/ionc/ion_timestamp_impl.h
@@ -34,7 +34,8 @@ extern "C" {
 #define ION_TT_BIT_TZ    0x80
 #define ION_TS_SUB_DATE  (ION_TT_BIT_MIN | ION_TT_BIT_SEC | ION_TT_BIT_FRAC)
 
-#define HAS_TZ_OFFSET(pt) IS_FLAG_ON((pt)->precision, ION_TT_BIT_TZ)
+// If, somehow, the timestamp has coarser than minute precision AND it has a known offset, ignore the offset.
+#define HAS_TZ_OFFSET(pt) (IS_FLAG_ON((pt)->precision, ION_TT_BIT_TZ) && IS_FLAG_ON((pt)->precision, ION_TT_BIT_MIN))
 
 GLOBAL int JULIAN_DAY_PER_MONTH[2][12]
 #ifdef INIT_STATICS

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(all_tests
     test_vectors.cpp
     test_ion_binary.cpp
     test_ion_text.cpp
+    test_ion_values.cpp
 )
 
 include_directories(

--- a/test/ion_test_util.cpp
+++ b/test/ion_test_util.cpp
@@ -48,3 +48,26 @@ iERR ion_string_from_cstr(const char *cstr, ION_STRING *out) {
     out->length = (SIZE)strlen(cstr);
     iRETURN;
 }
+
+iERR ion_test_new_text_reader(const char *ion_text, hREADER *reader) {
+    iENTER;
+
+    size_t buffer_length = strlen(ion_text);
+    BYTE* buffer = (BYTE *)calloc(buffer_length, sizeof(BYTE));
+    memcpy((char *)(&buffer[0]), ion_text, buffer_length);
+
+    ION_READER_OPTIONS options;
+    memset(&options, 0, sizeof(options));
+    options.return_system_values = TRUE;
+
+    IONCHECK(ion_reader_open_buffer(reader, buffer, buffer_length, &options));
+    iRETURN;
+}
+
+iERR ion_read_string_as_chars(hREADER reader, char **out) {
+    iENTER;
+    ION_STRING ion_string;
+    IONCHECK(ion_reader_read_string(reader, &ion_string));
+    *out = ion_string_strdup(&ion_string);
+    iRETURN;
+}

--- a/test/ion_test_util.h
+++ b/test/ion_test_util.h
@@ -46,4 +46,21 @@ iERR ion_test_writer_get_bytes(hWRITER writer, ION_STREAM *ion_stream, BYTE **ou
  */
 iERR ion_string_from_cstr(const char *cstr, ION_STRING *out);
 
+/**
+ * Initializes and opens a new in-memory reader over the given string of Ion text.
+ * @param ion_text - the Ion text to read.
+ * @param reader - the reader to initialize and open.
+ * @return IERR_OK, unless the reader fails to open.
+ */
+iERR ion_test_new_text_reader(const char *ion_text, hREADER *reader);
+
+/**
+ * Reads the Ion string at the given reader's current position and assigns its contents
+ * to a char *.
+ * @param reader - the reader from which to read the string.
+ * @param out - output parameter for the copied string.
+ * @return IERR_OK, unless the read or the copy fails.
+ */
+iERR ion_read_string_as_chars(hREADER reader, char **out);
+
 #endif //IONC_ION_TEST_UTIL_H

--- a/test/test_ion_values.cpp
+++ b/test/test_ion_values.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2009-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+#include "ion_assert.h"
+#include "ion_helpers.h"
+#include "ion_test_util.h"
+
+
+TEST(IonTimestamp, IgnoresSuperfluousOffset) {
+    ION_TIMESTAMP expected1, expected2, actual;
+    BOOL has_local_offset;
+    int local_offset;
+
+    ION_ASSERT_OK(ion_timestamp_for_year(&expected1, 1));
+
+    ION_ASSERT_OK(ion_timestamp_for_year(&expected2, 1));
+    SET_FLAG_ON(expected2.precision, ION_TT_BIT_TZ);
+    expected2.tz_offset = 1;
+
+    ION_ASSERT_OK(ion_timestamp_for_year(&actual, 1));
+    ION_ASSERT_OK(ion_timestamp_set_local_offset(&actual, 1));
+    ION_ASSERT_OK(ion_timestamp_has_local_offset(&actual, &has_local_offset));
+    ION_ASSERT_OK(ion_timestamp_get_local_offset(&actual, &local_offset));
+
+    ASSERT_FALSE(has_local_offset);
+    ASSERT_EQ(0, actual.tz_offset);
+    ASSERT_EQ(0, local_offset);
+    ASSERT_TRUE(assertIonTimestampEq(&expected1, &actual));
+    ASSERT_TRUE(assertIonTimestampEq(&expected2, &actual)); // Equivalence ignores the superfluous offset as well.
+}


### PR DESCRIPTION
See https://github.com/amzn/ion-tests/pull/29 for more info. In addition to the test cases added here, ion-c passes the test vectors added in the linked ion-tests pull request.