### PR TITLE
Consolidates and improves symbol handling.

### DIFF
--- a/ionc/inc/ion_reader.h
+++ b/ionc/inc/ion_reader.h
@@ -300,6 +300,7 @@ ION_API_EXPORT iERR ion_reader_get_type            (hREADER hreader, ION_TYPE *p
 ION_API_EXPORT iERR ion_reader_has_any_annotations (hREADER hreader, BOOL *p_has_any_annotations);
 ION_API_EXPORT iERR ion_reader_has_annotation      (hREADER hreader, iSTRING annotation, BOOL *p_annotation_found);
 ION_API_EXPORT iERR ion_reader_is_null             (hREADER hreader, BOOL *p_is_null);
+ION_API_EXPORT iERR ion_reader_is_in_struct        (hREADER preader, BOOL *p_is_in_struct);
 ION_API_EXPORT iERR ion_reader_get_field_name      (hREADER hreader, iSTRING p_str);
 ION_API_EXPORT iERR ion_reader_get_field_sid       (hREADER hreader, SID *p_sid);
 ION_API_EXPORT iERR ion_reader_get_annotations     (hREADER hreader, iSTRING p_strs, SIZE max_count, SIZE *p_count);

--- a/ionc/inc/ion_reader.h
+++ b/ionc/inc/ion_reader.h
@@ -346,6 +346,14 @@ ION_API_EXPORT iERR ion_reader_read_decimal        (hREADER hreader, decQuad *p_
  * @return IERR_NULL_VALUE if the current value is null.timestamp.
  */
 ION_API_EXPORT iERR ion_reader_read_timestamp      (hREADER hreader, iTIMESTAMP p_value);
+
+/** Read the local symbol ID of the current symbol value.
+ * NOTE: use of this function is discouraged, as it can have different results for text and binary data. In Ion text,
+ * which is not required to explicitly include a local symbol table, known symbols are not necessarily assigned symbol
+ * IDs. For those symbols, this function would return UNKNOWN_SID even though the text is known.
+ * Prefer `ion_reader_read_string`, which provides an ION_STRING for which ION_STRING_IS_NULL() will evaluate to TRUE
+ * if the current symbol value's text is unknown.
+ */
 ION_API_EXPORT iERR ion_reader_read_symbol_sid     (hREADER hreader, SID *p_value);
 
 /**

--- a/ionc/inc/ion_reader.h
+++ b/ionc/inc/ion_reader.h
@@ -307,6 +307,7 @@ ION_API_EXPORT iERR ion_reader_get_annotations     (hREADER hreader, iSTRING p_s
 ION_API_EXPORT iERR ion_reader_get_annotation_sids (hREADER hreader, SID *p_sids, SIZE max_count, SIZE *p_count);
 ION_API_EXPORT iERR ion_reader_get_annotation_count(hREADER hreader, SIZE *p_count);
 ION_API_EXPORT iERR ion_reader_get_an_annotation   (hREADER hreader, int idx, iSTRING p_strs);
+ION_API_EXPORT iERR ion_reader_get_an_annotation_sid(hREADER hreader, int idx, SID *p_sid);
 ION_API_EXPORT iERR ion_reader_read_null           (hREADER hreader, ION_TYPE *p_value);
 ION_API_EXPORT iERR ion_reader_read_bool           (hREADER hreader, BOOL *p_value);
 

--- a/ionc/inc/ion_symbol_table.h
+++ b/ionc/inc/ion_symbol_table.h
@@ -56,7 +56,6 @@ typedef enum _ION_SYMBOL_TABLE_TYPE {
 
 #define ION_SYS_SYMBOL_MAX_ID_UNDEFINED    -1
 
-#define ION_SYS_SID_UNKNOWN                0 /* not necessarily NULL */
 #define ION_SYS_SID_ION                    1 /* "$ion" */
 #define ION_SYS_SID_IVM                    2 /* "$ion_1_0"  aka ion type marker */
 #define ION_SYS_SID_SYMBOL_TABLE           3 /* "$ion_symbol_table" */
@@ -67,6 +66,7 @@ typedef enum _ION_SYMBOL_TABLE_TYPE {
 #define ION_SYS_SID_MAX_ID                 8 /* "max_id" */
 #define ION_SYS_SID_SHARED_SYMBOL_TABLE    9 /* "$ion_shared_symbol_table" */
 
+#define ION_SYS_STRLEN_ZERO                 2 /* "$0" */
 #define ION_SYS_STRLEN_ION                  4 /* "$ion" */
 #define ION_SYS_STRLEN_IVM                  8 /* "$ion_1_0" */
 #define ION_SYS_STRLEN_SYMBOL_TABLE        17 /* "$ion_symbol_table" */
@@ -76,6 +76,11 @@ typedef enum _ION_SYMBOL_TABLE_TYPE {
 #define ION_SYS_STRLEN_SYMBOLS              7 /* "symbols" */
 #define ION_SYS_STRLEN_MAX_ID               6 /* "max_id" */
 
+GLOBAL BYTE ION_SYMBOL_ZERO_BYTES[]
+#ifdef INIT_STATICS
+= { '$', '0', 0 }
+#endif
+;
 GLOBAL BYTE ION_SYMBOL_ION_BYTES[]
 #ifdef INIT_STATICS
 = { '$', 'i', 'o', 'n', 0 }
@@ -124,6 +129,14 @@ GLOBAL BYTE ION_SYMBOL_SHARED_SYMBOL_TABLE_BYTES[]
 ;
 
 
+GLOBAL ION_STRING ION_SYMBOL_ZERO_STRING
+#ifdef INIT_STATICS
+= {
+    ION_SYS_STRLEN_ZERO,
+    ION_SYMBOL_ZERO_BYTES
+}
+#endif
+;
 GLOBAL ION_STRING ION_SYMBOL_ION_STRING
 #ifdef INIT_STATICS
 = {

--- a/ionc/inc/ion_symbol_table.h
+++ b/ionc/inc/ion_symbol_table.h
@@ -66,7 +66,6 @@ typedef enum _ION_SYMBOL_TABLE_TYPE {
 #define ION_SYS_SID_MAX_ID                 8 /* "max_id" */
 #define ION_SYS_SID_SHARED_SYMBOL_TABLE    9 /* "$ion_shared_symbol_table" */
 
-#define ION_SYS_STRLEN_ZERO                 2 /* "$0" */
 #define ION_SYS_STRLEN_ION                  4 /* "$ion" */
 #define ION_SYS_STRLEN_IVM                  8 /* "$ion_1_0" */
 #define ION_SYS_STRLEN_SYMBOL_TABLE        17 /* "$ion_symbol_table" */
@@ -76,11 +75,6 @@ typedef enum _ION_SYMBOL_TABLE_TYPE {
 #define ION_SYS_STRLEN_SYMBOLS              7 /* "symbols" */
 #define ION_SYS_STRLEN_MAX_ID               6 /* "max_id" */
 
-GLOBAL BYTE ION_SYMBOL_ZERO_BYTES[]
-#ifdef INIT_STATICS
-= { '$', '0', 0 }
-#endif
-;
 GLOBAL BYTE ION_SYMBOL_ION_BYTES[]
 #ifdef INIT_STATICS
 = { '$', 'i', 'o', 'n', 0 }
@@ -129,14 +123,6 @@ GLOBAL BYTE ION_SYMBOL_SHARED_SYMBOL_TABLE_BYTES[]
 ;
 
 
-GLOBAL ION_STRING ION_SYMBOL_ZERO_STRING
-#ifdef INIT_STATICS
-= {
-    ION_SYS_STRLEN_ZERO,
-    ION_SYMBOL_ZERO_BYTES
-}
-#endif
-;
 GLOBAL ION_STRING ION_SYMBOL_ION_STRING
 #ifdef INIT_STATICS
 = {
@@ -252,6 +238,13 @@ ION_API_EXPORT iERR ion_symbol_table_set_max_sid        (hSYMTAB hsymtab, SID ma
 
 ION_API_EXPORT iERR ion_symbol_table_get_imports        (hSYMTAB hsymtab, ION_COLLECTION **p_imports);
 ION_API_EXPORT iERR ion_symbol_table_add_import         (hSYMTAB hsymtab, ION_SYMBOL_TABLE_IMPORT *pimport);
+
+/**
+ * Imports one symbol table into another. NOTE: the imported symbol table must be accessible through the parent symbol
+ * table's catalog, otherwise all of its symbols will be considered to have unknown text.
+ * @param hsymtab - The symbol table into which the imported symbol table will be incorporated.
+ * @param hsymtab_import - The symbol table to import.
+ */
 ION_API_EXPORT iERR ion_symbol_table_import_symbol_table(hSYMTAB hsymtab, hSYMTAB hsymtab_import);
 
 ION_API_EXPORT iERR ion_symbol_table_find_by_name       (hSYMTAB hsymtab, iSTRING name, SID *p_sid);

--- a/ionc/ion_catalog.c
+++ b/ionc/ion_catalog.c
@@ -246,7 +246,6 @@ iERR _ion_catalog_find_best_match_helper(ION_CATALOG *pcatalog, ION_STRING *name
 
     ASSERT(pcatalog != NULL);
     ASSERT(!ION_STRING_IS_NULL(name));
-    ASSERT(p_psymtab != NULL);
 
     // check for the system table first (mostly because it's not
     // really in the list of symbol tables in the catalog)
@@ -286,7 +285,7 @@ iERR _ion_catalog_find_best_match_helper(ION_CATALOG *pcatalog, ION_STRING *name
         // should manually validate that the max_id isn't also undefined.
         FAILWITHMSG(IERR_INVALID_SYMBOL_TABLE, "Invalid symbol table import: found undefined max_id without exact match.")
     }
-    *p_psymtab = best;
+    if (p_psymtab) *p_psymtab = best;
     SUCCEED();
 
     iRETURN;

--- a/ionc/ion_reader.c
+++ b/ionc/ion_reader.c
@@ -872,7 +872,22 @@ iERR _ion_reader_get_an_annotation_helper(ION_READER *preader, int32_t idx, ION_
     iRETURN;
 }
 
-// TODO make public?
+iERR ion_reader_get_an_annotation_sid(hREADER hreader, int idx, SID *p_sid)
+{
+    iENTER;
+    ION_READER *preader;
+
+    if (!hreader) FAILWITH(IERR_INVALID_ARG);
+    preader = HANDLE_TO_PTR(hreader, ION_READER);
+    if (idx < 0) FAILWITH(IERR_INVALID_ARG);
+    if (!p_sid) FAILWITH(IERR_INVALID_ARG);
+
+
+    IONCHECK(_ion_reader_get_an_annotation_sid_helper(preader, idx, p_sid));
+
+    iRETURN;
+}
+
 iERR _ion_reader_get_an_annotation_sid_helper(ION_READER *preader, int32_t idx, SID *p_sid)
 {
     iENTER;
@@ -1526,7 +1541,6 @@ iERR ion_reader_read_string(hREADER hreader, iSTRING p_value)
     if (!p_value) FAILWITH(IERR_INVALID_ARG);
 
     IONCHECK(_ion_reader_read_string_helper(preader, &str));
-    // TODO guarantee that only symbol values can be ION_STRING_IS_NULL
     ION_STRING_ASSIGN(p_value, &str);
     iRETURN;
 }

--- a/ionc/ion_reader.c
+++ b/ionc/ion_reader.c
@@ -1042,10 +1042,6 @@ iERR _ion_reader_get_field_sid_helper(ION_READER *preader, SID *p_sid)
         FAILWITH(IERR_INVALID_STATE);
     }
 
-    if (*p_sid <= UNKNOWN_SID) {
-        FAILWITH(IERR_INVALID_SYMBOL);
-    }
-
     iRETURN;
 }
 
@@ -1486,6 +1482,28 @@ iERR _ion_reader_read_symbol_sid_helper(ION_READER *preader, SID *p_value)
         break;
     case ion_type_unknown_reader:
     default:
+        FAILWITH(IERR_INVALID_STATE);
+    }
+
+    iRETURN;
+}
+
+iERR _ion_reader_read_symbol_helper(ION_READER *preader, ION_SYMBOL *p_symbol)
+{
+    iENTER;
+
+    ASSERT(preader);
+    ASSERT(p_symbol);
+
+    switch(preader->type) {
+        case ion_type_text_reader:
+            IONCHECK(_ion_reader_text_read_symbol(preader, p_symbol));
+            break;
+        case ion_type_binary_reader:
+            IONCHECK(_ion_reader_binary_read_symbol(preader, p_symbol));
+            break;
+        case ion_type_unknown_reader:
+        default:
         FAILWITH(IERR_INVALID_STATE);
     }
 

--- a/ionc/ion_reader_binary.c
+++ b/ionc/ion_reader_binary.c
@@ -509,7 +509,7 @@ iERR _ion_reader_binary_has_annotation(ION_READER *preader, ION_STRING *annotati
     binary = &preader->typed_reader.binary;
 
     // now translate the users string into a local sid (since they gave us a string
-    IONCHECK(_ion_symbol_table_local_find_by_name(preader->_current_symtab, annotation, &user_sid, NULL, FALSE));
+    IONCHECK(_ion_symbol_table_find_by_name_helper(preader->_current_symtab, annotation, &user_sid, NULL, FALSE));
     if (user_sid == UNKNOWN_SID) {
         goto return_value;
     }

--- a/ionc/ion_reader_impl.h
+++ b/ionc/ion_reader_impl.h
@@ -139,6 +139,7 @@ typedef struct _ion_reader_binary
     int64_t         _value_start;
     ION_TYPE        _value_type;
     SID             _value_field_id;
+    SID             _value_symbol_id; // The SID of the pending symbol value.
     int             _value_tid;
     int32_t         _value_len;
 
@@ -293,6 +294,7 @@ iERR _ion_reader_binary_read_double         (ION_READER *preader, double *p_valu
 iERR _ion_reader_binary_read_decimal        (ION_READER *preader, decQuad *p_value);
 iERR _ion_reader_binary_read_timestamp      (ION_READER *preader, iTIMESTAMP p_value);
 iERR _ion_reader_binary_read_symbol_sid     (ION_READER *preader, SID *p_value);
+iERR _ion_reader_binary_read_symbol_sid_helper(ION_READER *preader, ION_BINARY_READER *binary, SID *p_value);
 
 iERR _ion_reader_binary_get_string_length   (ION_READER *preader, SIZE *p_length);
 iERR _ion_reader_binary_read_string_bytes   (ION_READER *preader, BOOL accept_partial, BYTE *p_buf, SIZE buf_max, SIZE *p_length);

--- a/ionc/ion_reader_impl.h
+++ b/ionc/ion_reader_impl.h
@@ -71,7 +71,7 @@ typedef struct _ion_reader_text
      *
      */
     SIZE                  _annotation_count;               // number of annotations on this value
-    ION_SYMBOL           *_annotation_string_pool;         // preallocated set of ION_STRING to hold annotations
+    ION_SYMBOL           *_annotation_string_pool;         // preallocated set of ION_SYMBOL to hold annotations
     SIZE                  _annotation_string_pool_length;  // max number of annotations, size of string pool as count
     BYTE                 *_annotation_value_next;          // position in annotation value buffer for the next annotation value
     BYTE                 *_annotation_value_buffer;        // preallocate buffer to hold all annotation character for all annotations of the current value
@@ -228,6 +228,7 @@ iERR _ion_reader_read_double_helper(ION_READER *preader, double *p_value);
 iERR _ion_reader_read_decimal_helper(ION_READER *preader, decQuad *p_value);
 iERR _ion_reader_read_timestamp_helper(ION_READER *preader, ION_TIMESTAMP *p_value);
 iERR _ion_reader_read_symbol_sid_helper(ION_READER *preader, SID *p_value);
+iERR _ion_reader_read_symbol_helper(ION_READER *preader, ION_SYMBOL *p_symbol);
 
 iERR _ion_reader_get_string_length_helper(ION_READER *preader, SIZE *p_length);
 iERR _ion_reader_read_string_helper(ION_READER *preader, ION_STRING *p_value);
@@ -296,6 +297,7 @@ iERR _ion_reader_binary_read_decimal        (ION_READER *preader, decQuad *p_val
 iERR _ion_reader_binary_read_timestamp      (ION_READER *preader, iTIMESTAMP p_value);
 iERR _ion_reader_binary_read_symbol_sid     (ION_READER *preader, SID *p_value);
 iERR _ion_reader_binary_read_symbol_sid_helper(ION_READER *preader, ION_BINARY_READER *binary, SID *p_value);
+iERR _ion_reader_binary_read_symbol         (ION_READER *preader, ION_SYMBOL *p_symbol);
 
 iERR _ion_reader_binary_get_string_length   (ION_READER *preader, SIZE *p_length);
 iERR _ion_reader_binary_read_string_bytes   (ION_READER *preader, BOOL accept_partial, BYTE *p_buf, SIZE buf_max, SIZE *p_length);

--- a/ionc/ion_reader_impl.h
+++ b/ionc/ion_reader_impl.h
@@ -202,6 +202,7 @@ iERR _ion_reader_initialize(ION_READER *preader, BYTE *version_buffer, SIZE vers
 
 iERR _ion_reader_get_catalog_helper(ION_READER *preader, ION_CATALOG **p_pcatalog);
 iERR _ion_reader_get_symbol_table_helper(ION_READER *preader, ION_SYMBOL_TABLE **p_psymtab);
+iERR _ion_reader_set_symbol_table_helper(ION_READER *preader, ION_SYMBOL_TABLE *symtab);
 iERR _ion_reader_next_helper(ION_READER *preader, ION_TYPE *p_value_type);
 iERR _ion_reader_step_in_helper(ION_READER *preader);
 iERR _ion_reader_step_out_helper(ION_READER *preader);
@@ -241,6 +242,7 @@ iERR _ion_reader_close_helper(ION_READER *preader);
 iERR _ion_reader_allocate_temp_pool                 ( ION_READER *preader );
 iERR _ion_reader_reset_temp_pool                    ( ION_READER *preader);
 iERR _ion_reader_get_new_local_symbol_table_owner   (ION_READER *preader, void **p_owner);
+iERR _ion_reader_free_local_symbol_table            (ION_READER *preader);
 iERR _ion_reader_reset_local_symbol_table           (ION_READER *preader);
 
 iERR _ion_reader_get_position_helper(ION_READER *preader, int64_t *p_bytes, int32_t *p_line, int32_t *p_offset);
@@ -264,7 +266,6 @@ iERR _ion_reader_binary_reset               (ION_READER *preader, int parent_tid
 iERR _ion_reader_binary_close               (ION_READER *preader);
 
 iERR _ion_reader_binary_next                (ION_READER *preader, ION_TYPE *p_value_type);
-iERR _ion_reader_binary_set_symbol_table    (ION_READER *preader, ION_SYMBOL_TABLE *symtab);
 iERR _ion_reader_binary_get_local_symbol_table_helper(ION_READER *preader, ION_SYMBOL_TABLE **pplocal );
 iERR _ion_reader_binary_step_in             (ION_READER *preader);
 iERR _ion_reader_binary_step_out            (ION_READER *preader);

--- a/ionc/ion_reader_impl.h
+++ b/ionc/ion_reader_impl.h
@@ -59,7 +59,7 @@ typedef struct _ion_reader_text
      *  to field name buffer length.
      *
      */
-    ION_STRING            _field_name;
+    ION_SYMBOL            _field_name;
     BYTE                 *_field_name_buffer;
     SIZE                  _field_name_buffer_length;
     
@@ -71,7 +71,7 @@ typedef struct _ion_reader_text
      *
      */
     SIZE                  _annotation_count;               // number of annotations on this value
-    ION_STRING           *_annotation_string_pool;         // preallocated set of ION_STRING to hold annotations
+    ION_SYMBOL           *_annotation_string_pool;         // preallocated set of ION_STRING to hold annotations
     SIZE                  _annotation_string_pool_length;  // max number of annotations, size of string pool as count
     BYTE                 *_annotation_value_next;          // position in annotation value buffer for the next annotation value
     BYTE                 *_annotation_value_buffer;        // preallocate buffer to hold all annotation character for all annotations of the current value
@@ -210,6 +210,7 @@ iERR _ion_reader_has_any_annotations_helper(ION_READER *preader, BOOL *p_has_ann
 iERR _ion_reader_has_annotation_helper(ION_READER *preader, ION_STRING *annotation, BOOL *p_annotation_found);
 iERR _ion_reader_get_annotation_count_helper(ION_READER *preader, int32_t *p_count);
 iERR _ion_reader_get_an_annotation_helper(ION_READER *preader, int32_t idx, ION_STRING *p_str);
+iERR _ion_reader_get_an_annotation_sid_helper(ION_READER *preader, int32_t idx, SID *p_sid);
 iERR _ion_reader_is_null_helper(ION_READER *preader, BOOL *p_is_null);
 iERR _ion_reader_get_field_name_helper(ION_READER *preader, ION_STRING **p_pstr);
 iERR _ion_reader_get_field_sid_helper(ION_READER *preader, SID *p_sid);
@@ -275,6 +276,7 @@ iERR _ion_reader_binary_has_any_annotations (ION_READER *preader, BOOL *p_has_an
 iERR _ion_reader_binary_has_annotation      (ION_READER *preader, iSTRING annotation, BOOL *p_annotation_found);
 iERR _ion_reader_binary_get_annotation_count(ION_READER *preader, int32_t *p_count);
 iERR _ion_reader_binary_get_an_annotation   (ION_READER *preader, int32_t idx, ION_STRING *p_str);
+iERR _ion_reader_binary_get_an_annotation_sid(ION_READER *preader, int32_t idx, SID *p_sid);
 
 iERR _ion_reader_binary_get_field_name     (ION_READER *preader, ION_STRING **pstr);
 iERR _ion_reader_binary_get_field_sid      (ION_READER *preader, SID *p_sid);

--- a/ionc/ion_reader_text.c
+++ b/ionc/ion_reader_text.c
@@ -178,30 +178,6 @@ iERR _ion_reader_text_reset_value(ION_READER *preader)
     iRETURN;
 }
 
-iERR _ion_reader_text_set_symbol_table(ION_READER *preader, ION_SYMBOL_TABLE *symtab)
-{
-    iENTER;
-    ION_TEXT_READER  *text = &preader->typed_reader.text;
-    ION_SYMBOL_TABLE *clone, *system;
-
-    ASSERT(preader);
-    ASSERT(preader->type == ion_type_text_reader);
-    ASSERT(symtab);
-    
-    IONCHECK(_ion_symbol_table_get_system_symbol_helper(&system, ION_SYSTEM_VERSION));
-
-    if (symtab != NULL && symtab != system && symtab->owner != preader)
-    {
-        IONCHECK(_ion_symbol_table_clone_with_owner_helper(&clone, symtab, preader, system));
-        symtab = clone;
-    }
-
-    preader->_current_symtab = symtab;
-    SUCCEED();
-
-    iRETURN;
-}
-
 iERR _ion_reader_text_close(ION_READER *preader)
 {
     iENTER;
@@ -602,8 +578,6 @@ iERR _ion_reader_text_check_for_system_values_to_skip_or_process(ION_READER *pre
                     // we clear out any previous local symbol table and set the symbol
                     // table to be the appropriate system symbol table
                     IONCHECK(_ion_reader_reset_local_symbol_table(preader));
-                    IONCHECK(_ion_symbol_table_get_system_symbol_helper(&system, ION_SYSTEM_VERSION));
-                    preader->_current_symtab = system;
                     is_system_value = TRUE;
                 }
             }
@@ -619,6 +593,7 @@ iERR _ion_reader_text_check_for_system_values_to_skip_or_process(ION_READER *pre
         
         // TODO - this should be done with flags set while we're
         // recognizing the annotations below (in the fullness of time)
+        // TODO in accordance with the spec, only check the FIRST annotation.
         IONCHECK(_ion_reader_text_has_annotation(preader, &ION_SYMBOL_SYMBOL_TABLE_STRING, &is_local_symbol_table));
             
         // if we return system values we don't process them

--- a/ionc/ion_reader_text.c
+++ b/ionc/ion_reader_text.c
@@ -70,15 +70,16 @@ iERR _ion_reader_text_open(ION_READER *preader)
 
     IONCHECK(_ion_reader_text_open_alloc_buffered_string(preader
         , preader->options.symbol_threshold
-        , &(text->_field_name)
+        , &(text->_field_name.value)
         , &(text->_field_name_buffer)
         , &(text->_field_name_buffer_length)
     ));
+    text->_field_name.sid = UNKNOWN_SID;
 
     text->_annotation_string_pool_length = preader->options.max_annotation_count;  // max number of annotations, size of string pool as count
     text->_annotation_value_buffer_length = preader->options.max_annotation_buffered + (preader->options.max_annotation_count * sizeof(BYTE));
 
-    text->_annotation_string_pool = (ION_STRING *)ion_alloc_with_owner(preader, text->_annotation_string_pool_length * sizeof(ION_STRING));
+    text->_annotation_string_pool = (ION_SYMBOL *)ion_alloc_with_owner(preader, text->_annotation_string_pool_length * sizeof(ION_SYMBOL));
     if (!text->_annotation_string_pool) {
         FAILWITH(IERR_NO_MEMORY);
     }
@@ -162,7 +163,10 @@ iERR _ion_reader_text_reset_value(ION_READER *preader)
     text->_annotation_count         =  0;
     text->_annotation_value_next    =  text->_annotation_value_buffer;
 
-    ION_STRING_INIT(&text->_field_name);
+    ION_STRING_INIT(&text->_field_name.value);
+    text->_field_name.add_count = 0;
+    text->_field_name.sid = UNKNOWN_SID;
+    text->_field_name.psymtab = NULL;
 
     text->_value_type               =  tid_none;
     text->_value_sub_type           =  IST_NONE;
@@ -319,28 +323,33 @@ iERR _ion_reader_text_next(ION_READER *preader, ION_TYPE *p_value_type)
     iRETURN;
 }
 
-iERR _ion_reader_text_intern_symbol(ION_READER *preader, ION_STRING *symbol_name, ION_SYMBOL **psym) {
+iERR _ion_reader_text_intern_symbol(ION_READER *preader, ION_STRING *symbol_name, ION_SYMBOL **psym, BOOL parse_symbol_identifiers) {
     iENTER;
 
     SID               sid;
     ION_SYMBOL       *sym;
-    ION_SYMBOL_TABLE *clone;
+    ION_SYMBOL_TABLE *clone, *symbols;
     BOOL              is_locked;
 
     ASSERT(psym);
 
-    IONCHECK(_ion_symbol_table_local_find_by_name(preader->_current_symtab, symbol_name, &sid, &sym));
+    IONCHECK(_ion_reader_text_get_symbol_table(preader, &symbols));
+    IONCHECK(_ion_symbol_table_local_find_by_name(symbols, symbol_name, &sid, &sym, parse_symbol_identifiers));
     if (!sym || sid <= UNKNOWN_SID) {
-        IONCHECK(_ion_symbol_table_is_locked_helper(preader->_current_symtab, &is_locked));
+        IONCHECK(_ion_symbol_table_is_locked_helper(symbols, &is_locked));
         if (is_locked) {
-            IONCHECK(_ion_symbol_table_clone_with_owner_helper(&clone, preader->_current_symtab, preader, preader->_current_symtab->system_symbol_table));
-            preader->_current_symtab = clone;
+            IONCHECK(_ion_symbol_table_clone_with_owner_helper(&clone, symbols, preader, symbols->system_symbol_table));
+            symbols = clone;
             // clear the name and version as this is now a local symbol
-            ION_STRING_INIT(&preader->_current_symtab->name);
-            preader->_current_symtab->version = 0;
+            ION_STRING_INIT(&symbols->name);
+            symbols->version = 0;
+            preader->_current_symtab = symbols;
         }
-        IONCHECK(_ion_symbol_table_add_symbol_helper(preader->_current_symtab, symbol_name, &sid));
-        IONCHECK(ion_symbol_table_get_local_symbol(preader->_current_symtab, sid, &sym));
+        sid = symbols->max_id + 1;
+        IONCHECK(_ion_symbol_table_local_add_symbol_helper(symbols, symbol_name, sid, symbols, &sym));
+        if (sym) {
+            sym->add_count++;
+        }
     }
 
     *psym = sym;
@@ -378,21 +387,24 @@ iERR _ion_reader_text_load_fieldname(ION_READER *preader, ION_SUB_TYPE *p_ist)
                                            , text->_field_name_buffer
                                            , text->_field_name_buffer_length
                                            , ist
-                                           , &text->_field_name.length
+                                           , &text->_field_name.value.length
                                            , &eos_encountered
         ));
         if (!eos_encountered) {
             FAILWITH(IERR_TOKEN_TOO_LONG);
         }
 
+        text->_field_name.value.value = text->_field_name_buffer;
+        IONCHECK(_ion_reader_text_intern_symbol(preader, &text->_field_name.value, &sym, ist != IST_SYMBOL_QUOTED));
+        ION_STRING_ASSIGN(&text->_field_name.value, &sym->value); // TODO is a copy actually necessary here?
+        text->_field_name.sid = sym->sid;
+        text->_field_name.psymtab = sym->psymtab;
+        text->_field_name.add_count = sym->add_count;
+
         IONCHECK(_ion_scanner_next(&text->_scanner, &ist));
         if (ist != IST_SINGLE_COLON) {
             FAILWITH(IERR_INVALID_FIELDNAME);
         }
-        // this name the field name non-null
-        text->_field_name.value = text->_field_name_buffer;
-        IONCHECK(_ion_reader_text_intern_symbol(preader, &text->_field_name, &sym));
-        ION_STRING_ASSIGN(&text->_field_name, &sym->value);
     }
 
     // we need this to see if we hit the end of the struct
@@ -401,12 +413,23 @@ iERR _ion_reader_text_load_fieldname(ION_READER *preader, ION_SUB_TYPE *p_ist)
     iRETURN;
 }
 
+iERR _ion_reader_text_intern_symbol_value(ION_READER *preader, ION_SYMBOL **p_sym, BOOL parse_symbol_identifiers)
+{
+    iENTER;
+    ION_STRING str;
+    ION_TEXT_READER *text = &preader->typed_reader.text;
+    str.value = text->_scanner._value_buffer;
+    str.length = text->_scanner._value_image.length;
+    IONCHECK(_ion_reader_text_intern_symbol(preader, &str, p_sym, parse_symbol_identifiers));
+    iRETURN;
+}
+
 iERR _ion_reader_text_load_utas(ION_READER *preader, ION_SUB_TYPE *p_ist)
 {
     iENTER;
     ION_TEXT_READER *text = &preader->typed_reader.text;
     ION_SUB_TYPE     ist = IST_NONE;
-    ION_STRING      *str;
+    ION_SYMBOL      *str;
     ION_SYMBOL      *sym;
     SIZE             remaining;
     BYTE            *next_dst;
@@ -472,6 +495,7 @@ iERR _ion_reader_text_load_utas(ION_READER *preader, ION_SUB_TYPE *p_ist)
                 }
                 text->_scanner._value_image.value = text->_scanner._value_buffer;
                 text->_scanner._value_location = SVL_VALUE_IMAGE;
+                IONCHECK(_ion_reader_text_intern_symbol_value(preader, &sym, ist != IST_SYMBOL_QUOTED));
                 break;
             }
 
@@ -487,21 +511,24 @@ iERR _ion_reader_text_load_utas(ION_READER *preader, ION_SUB_TYPE *p_ist)
             }
             str = &text->_annotation_string_pool[text->_annotation_count++];
 
-            str->value = text->_scanner._value_buffer;
-            str->length = text->_scanner._value_image.length;
-            IONCHECK(_ion_reader_text_intern_symbol(preader, str, &sym));
+            str->value.value = text->_scanner._value_buffer;
+            str->value.length = text->_scanner._value_image.length;
+            IONCHECK(_ion_reader_text_intern_symbol(preader, &str->value, &sym, ist != IST_SYMBOL_QUOTED));
+            str->sid = sym->sid;
+            str->psymtab = sym->psymtab;
+            str->add_count = sym->add_count;
 
             // now we check to make sure we have buffer space left for the
             // characters (as bytes of utf8) and a "bonus" null terminator (for safety)
             if (remaining < sym->value.length) {
                FAILWITH(IERR_BUFFER_TOO_SMALL);
             }
-            str->value  = next_dst;
-            str->length = sym->value.length;
-            memcpy(next_dst, sym->value.value, str->length);
-            str->value[str->length] = '\0'; // remember we should be writing into the annotation value buffer
-            next_dst  += str->length + 1;   // +1 for the null terminator
-            remaining -=  str->length + 1; 
+            str->value.value  = next_dst;
+            str->value.length = sym->value.length;
+            memcpy(next_dst, sym->value.value, str->value.length);
+            str->value.value[str->value.length] = '\0'; // remember we should be writing into the annotation value buffer
+            next_dst  += str->value.length + 1;   // +1 for the null terminator
+            remaining -=  str->value.length + 1;
         }
         // we have reached the first bytes of the actual value (after any fieldname or any annotations)
 
@@ -980,7 +1007,7 @@ iERR _ion_reader_text_has_annotation(ION_READER *preader, ION_STRING *annotation
 {
     iENTER;
     ION_TEXT_READER  *text = &preader->typed_reader.text;
-    ION_STRING       *str;
+    ION_SYMBOL       *str;
     SIZE              count;
     BOOL              found = FALSE;
 
@@ -996,7 +1023,7 @@ iERR _ion_reader_text_has_annotation(ION_READER *preader, ION_STRING *annotation
     // on a single value - there's something wrong and slow is a fine response
     count = text->_annotation_count;
     for (str = text->_annotation_string_pool; count--; str++) { // postfix decrement count since we only stop after we saw the last one
-        if (ION_STRING_EQUALS(str, annotation)) {
+        if (ION_STRING_EQUALS(&str->value, annotation)) {
             found = TRUE;
             break;
         }
@@ -1029,7 +1056,7 @@ iERR _ion_reader_text_get_an_annotation(ION_READER *preader, int32_t idx, ION_ST
 {
     iENTER;
     ION_TEXT_READER  *text = &preader->typed_reader.text;
-    ION_STRING       *str;
+    ION_SYMBOL       *str;
 
     ASSERT(preader && preader->type == ion_type_text_reader);
     ASSERT(p_str != NULL);
@@ -1044,7 +1071,34 @@ iERR _ion_reader_text_get_an_annotation(ION_READER *preader, int32_t idx, ION_ST
 
     // get a pointer to our string header in the annotation string pool
     str = text->_annotation_string_pool + idx;
-    IONCHECK(ion_string_copy_to_owner(preader->_temp_entity_pool, p_str, str));
+    IONCHECK(ion_string_copy_to_owner(preader->_temp_entity_pool, p_str, &str->value));
+    if (str->sid == 0) {
+        ION_STRING_INIT(p_str); // This nulls the string, because symbol 0 has no text representation.
+    }
+
+    iRETURN;
+}
+
+iERR _ion_reader_text_get_an_annotation_sid(ION_READER *preader, int32_t idx, SID *p_sid)
+{
+    iENTER;
+    ION_TEXT_READER  *text = &preader->typed_reader.text;
+    ION_SYMBOL       *str;
+
+    ASSERT(preader && preader->type == ion_type_text_reader);
+    ASSERT(p_sid != NULL);
+
+    if (text->_state == IPS_ERROR || text->_state == IPS_NONE) {
+        FAILWITH(IERR_INVALID_STATE);
+    }
+
+    if (idx < 0 || idx >= text->_annotation_count) {
+        FAILWITH(IERR_INVALID_ARG);
+    }
+
+    // get a pointer to our string header in the annotation string pool
+    str = text->_annotation_string_pool + idx;
+    *p_sid = str->sid;
 
     iRETURN;
 }
@@ -1053,7 +1107,8 @@ iERR _ion_reader_text_get_annotations(ION_READER *preader, ION_STRING *p_strs, i
 {
     iENTER;
     ION_TEXT_READER  *text = &preader->typed_reader.text;
-    ION_STRING       *src, *dst;
+    ION_SYMBOL       *src;
+    ION_STRING       *dst;
     int32_t           idx;
 
     ASSERT(preader && preader->type == ion_type_text_reader);
@@ -1071,7 +1126,10 @@ iERR _ion_reader_text_get_annotations(ION_READER *preader, ION_STRING *p_strs, i
     src = text->_annotation_string_pool;
     dst = p_strs;
     for (idx = 0; idx < text->_annotation_count; idx++) {
-        IONCHECK(ion_string_copy_to_owner(preader->_temp_entity_pool, dst, src));
+        IONCHECK(ion_string_copy_to_owner(preader->_temp_entity_pool, dst, &src->value));
+        if (src->sid == 0) {
+            ION_STRING_INIT(dst); // This nulls the string, because symbol 0 has no text representation.
+        }
         dst++;
         src++;
     }
@@ -1095,7 +1153,12 @@ iERR _ion_reader_text_get_field_name(ION_READER *preader, ION_STRING **p_pstr)
 
     // TODO: I'm not sure I like this. The caller is getting a pointer 
     //       into the middle of the parser struct
-    *p_pstr = &text->_field_name;
+    if (text->_field_name.sid == 0) {
+        *p_pstr = NULL;
+    }
+    else {
+        *p_pstr = &text->_field_name.value;
+    }
 
     iRETURN;
 }
@@ -1119,8 +1182,6 @@ iERR _ion_reader_text_get_field_sid(ION_READER *preader, SID *p_sid)
 {
     iENTER;
     ION_TEXT_READER  *text = &preader->typed_reader.text;
-    ION_SYMBOL_TABLE *symtab;
-    SID               sid;
 
     ASSERT(preader && preader->type == ion_type_text_reader);
     ASSERT(p_sid);
@@ -1129,48 +1190,7 @@ iERR _ion_reader_text_get_field_sid(ION_READER *preader, SID *p_sid)
         FAILWITH(IERR_INVALID_STATE);
     }
 
-    if (ION_STRING_IS_NULL(&text->_field_name)) {
-        *p_sid = UNKNOWN_SID;
-        SUCCEED();
-    }
-
-    IONCHECK(_ion_reader_get_symbol_table_helper(preader, &symtab));
-    if (!symtab) {
-        FAILWITH(IERR_PARSER_INTERNAL);
-    }
-    ASSERT(!(ION_STRING_IS_NULL(&text->_field_name)));
-    IONCHECK(_ion_symbol_table_local_find_by_name(preader->_current_symtab, &text->_field_name, &sid, NULL));
-    if (sid == UNKNOWN_SID) {
-        // TODO: if we don't find the symbol, do we want to create an updatable local 
-        //       symbol table and add the field name to it?  maybe later.
-
-        // TODO FAIL?
-    }
-
-    *p_sid = sid;
-    iRETURN;
-}
-
-iERR _ion_reader_get_annotations(ION_READER *preader, ION_STRING *p_strs, SIZE max_count, SIZE *p_count)
-{
-    iENTER;
-    ION_TEXT_READER  *text = &preader->typed_reader.text;
-    SIZE              ii, count;
-
-    ASSERT(preader);
-    ASSERT(p_strs);
-    ASSERT(p_count);
-
-    count = text->_annotation_count;
-    if (max_count < count) {
-        FAILWITH(IERR_INVALID_ARG);
-    }
-
-    for (ii = 0; ii<count; ii++) {
-        p_strs[ii] = text->_annotation_string_pool[ii];
-    }
-    *p_count = count;
-
+    *p_sid = text->_field_name.sid;;
     iRETURN;
 }
 
@@ -1178,9 +1198,7 @@ iERR _ion_reader_text_get_annotation_sids(ION_READER *preader, SID *p_sids, SIZE
 {
     iENTER;
     ION_TEXT_READER  *text = &preader->typed_reader.text;
-    ION_STRING       *str;
-    ION_SYMBOL_TABLE *symtab;
-    SID               sid = 0;
+    ION_SYMBOL       *str;
     SIZE              ii, count;
 
     ASSERT(preader);
@@ -1192,16 +1210,9 @@ iERR _ion_reader_text_get_annotation_sids(ION_READER *preader, SID *p_sids, SIZE
         FAILWITH(IERR_INVALID_ARG);
     }
 
-    IONCHECK(_ion_reader_get_symbol_table_helper(preader, &symtab));
-    if (!symtab) {
-        FAILWITH(IERR_PARSER_INTERNAL);
-    }
-
-    // now we look all the annoations up in the symbol table
     for (ii = 0; ii<count; ii++) {
         str = &text->_annotation_string_pool[ii];
-        IONCHECK(_ion_symbol_table_local_find_by_name(preader->_current_symtab, str, &sid, NULL));
-        p_sids[ii] = sid;
+        p_sids[ii] = str->sid;
     }
     *p_count = count;
 
@@ -1679,8 +1690,8 @@ iERR _ion_reader_text_read_symbol_sid(ION_READER *preader, SID *p_value)
     ASSERT(text->_scanner._value_image.length > 0);
     ASSERT(text->_scanner._value_image.value[text->_scanner._value_image.length] == 0);
 
-    IONCHECK(_ion_symbol_table_local_find_by_name(preader->_current_symtab, &text->_scanner._value_image, p_value, NULL));
-
+    IONCHECK(_ion_symbol_table_local_find_by_name(preader->_current_symtab, &text->_scanner._value_image, p_value, NULL,
+                                                  text->_value_sub_type != IST_SYMBOL_QUOTED));
 
     iRETURN;
 }
@@ -1723,16 +1734,14 @@ iERR _ion_reader_text_get_string_length(ION_READER *preader, SIZE *p_length)
     *p_length = text->_scanner._value_image.length;
 
     iRETURN;
-}       
+}
 
 iERR _ion_reader_text_read_string(ION_READER *preader, ION_STRING *p_user_str)
 {
     iENTER;
     ION_TEXT_READER  *text = &preader->typed_reader.text;
-    ION_SYMBOL_TABLE *symbols, *clone;
-    ION_STRING       *pname, *user_str = &text->_scanner._value_image;
-    SID               sid;
-    BOOL              is_locked;
+    ION_STRING       *user_str = &text->_scanner._value_image;
+    ION_SYMBOL       *sym;
 
     ASSERT(preader);
     ASSERT(p_user_str);
@@ -1757,31 +1766,18 @@ iERR _ion_reader_text_read_string(ION_READER *preader, ION_STRING *p_user_str)
     IONCHECK(_ion_reader_text_load_string_in_value_buffer(preader));
 
     if (text->_value_sub_type->base_type == tid_SYMBOL) {
-        // we have to "wash" the value through a symbol table to address
-        // cases like $007
-        IONCHECK(_ion_reader_text_get_symbol_table(preader, &symbols));
-        // with delegation: IONCHECK(_ion_symbol_table_find_by_name_helper(symbols, user_str, &sid));
-        IONCHECK(_ion_symbol_table_local_find_by_name(symbols, user_str, &sid, NULL));
-
-        if (sid <= UNKNOWN_SID) { // i.e. symbol was not found
-            IONCHECK(_ion_symbol_table_is_locked_helper(symbols, &is_locked));
-            if (is_locked) {
-                IONCHECK(_ion_symbol_table_clone_with_owner_helper(&clone, symbols, preader, symbols->system_symbol_table));
-                symbols = clone;
-                // clear the name and version as this is now a local symbol
-                ION_STRING_INIT(&symbols->name);
-                symbols->version = 0;
-                preader->_current_symtab = symbols;
-            }
-            IONCHECK(_ion_symbol_table_add_symbol_helper(symbols, user_str, &sid));
+        IONCHECK(_ion_reader_text_intern_symbol(preader, user_str, &sym, text->_value_sub_type != IST_SYMBOL_QUOTED));
+        ASSERT(sym && sym->sid > UNKNOWN_SID); // Success to this point means the symbol is defined.
+        if (sym->sid == 0) { // Symbol zero has no text image.
+            ION_STRING_INIT(p_user_str); // ION_STRING_IS_NULL(p_user_str) will now evaluate to TRUE.
         }
         else {
-            IONCHECK(_ion_symbol_table_find_by_sid_helper(symbols, sid, &pname));
-            user_str = pname;
+            ION_STRING_ASSIGN(p_user_str, &sym->value);
         }
     }
-
-    ION_STRING_ASSIGN(p_user_str, user_str);
+    else {
+        ION_STRING_ASSIGN(p_user_str, user_str);
+    }
 
     iRETURN;
 }       

--- a/ionc/ion_reader_text.h
+++ b/ionc/ion_reader_text.h
@@ -322,6 +322,7 @@ iERR _ion_reader_text_read_double               (ION_READER *preader, double *p_
 iERR _ion_reader_text_read_decimal              (ION_READER *preader, decQuad *p_value);
 iERR _ion_reader_text_read_timestamp            (ION_READER *preader, ION_TIMESTAMP *p_value);
 iERR _ion_reader_text_read_symbol_sid           (ION_READER *preader, SID *p_value);
+iERR _ion_reader_text_read_symbol               (ION_READER *preader, ION_SYMBOL *p_symbol);
 
 // get string functions, these work over value of type string or type symbol
 // get length FORCES the value to read into the value_image buffer (which may not be desirable)

--- a/ionc/ion_reader_text.h
+++ b/ionc/ion_reader_text.h
@@ -280,7 +280,6 @@ iERR _ion_reader_text_open                      (ION_READER *preader);
 iERR _ion_reader_text_open_alloc_buffered_string(ION_READER *preader, SIZE len, ION_STRING *p_string, BYTE **p_buf, SIZE *p_buf_len);
 iERR _ion_reader_text_reset                     (ION_READER *preader, ION_TYPE parent_tid, POSITION local_end);
 iERR _ion_reader_text_reset_value               (ION_READER *preader);
-iERR _ion_reader_text_set_symbol_table          (ION_READER *preader, ION_SYMBOL_TABLE *symtab);
 iERR _ion_reader_text_close                     (ION_READER *preader);
 
 // support for "next" functions

--- a/ionc/ion_reader_text.h
+++ b/ionc/ion_reader_text.h
@@ -302,6 +302,7 @@ iERR _ion_reader_text_has_any_annotations       (ION_READER *preader, BOOL *p_ha
 iERR _ion_reader_text_has_annotation            (ION_READER *preader, ION_STRING *annotation, BOOL *p_annotation_found);
 iERR _ion_reader_text_get_annotation_count      (ION_READER *preader, int32_t *p_count);
 iERR _ion_reader_text_get_an_annotation         (ION_READER *preader, int32_t idx, ION_STRING *p_str);
+iERR _ion_reader_text_get_an_annotation_sid     (ION_READER *preader, int32_t idx, SID *p_sid);
 iERR _ion_reader_text_get_field_name            (ION_READER *preader, ION_STRING **p_pstr);
 iERR _ion_reader_text_get_symbol_table          (ION_READER *preader, ION_SYMBOL_TABLE **p_return);
 iERR _ion_reader_text_get_field_sid             (ION_READER *preader, SID *p_sid);

--- a/ionc/ion_symbol_table.c
+++ b/ionc/ion_symbol_table.c
@@ -422,6 +422,7 @@ iERR _ion_symbol_table_local_load_symbol_list(ION_READER *preader, hOWNER owner,
         if (type == tid_EOF) break;
         if (type != tid_STRING) continue; // all symbol fields in the symbol struct have string values
 
+        ION_STRING_INIT(&str);
         IONCHECK(_ion_reader_read_string_helper(preader, &str));
 
         sym = (ION_SYMBOL *)_ion_collection_append(psymbol_list);

--- a/ionc/ion_symbol_table_impl.h
+++ b/ionc/ion_symbol_table_impl.h
@@ -75,6 +75,7 @@ iERR _ion_symbol_table_set_name_helper(ION_SYMBOL_TABLE *symtab, ION_STRING *nam
 iERR _ion_symbol_table_set_version_helper(ION_SYMBOL_TABLE *symtab, int32_t version);
 iERR _ion_symbol_table_set_max_sid_helper(ION_SYMBOL_TABLE *symtab, SID max_id);
 iERR _ion_symbol_table_get_imports_helper(ION_SYMBOL_TABLE *symtab, ION_COLLECTION **p_imports);
+iERR _ion_symbol_table_parse_possible_symbol_identifier(ION_SYMBOL_TABLE *symtab, ION_STRING *name, SID *p_sid, ION_SYMBOL **p_sym, BOOL *p_is_symbol_identifier);
 iERR _ion_symbol_table_find_by_name_helper(ION_SYMBOL_TABLE *symtab, ION_STRING *name, SID *p_sid, ION_SYMBOL **p_sym, BOOL symbol_identifiers_as_sids);
 iERR _ion_symbol_table_find_by_sid_helper(ION_SYMBOL_TABLE *symtab, SID sid, ION_STRING **p_name);
 iERR _ion_symbol_table_find_symbol_by_sid_helper(ION_SYMBOL_TABLE *symtab, SID sid, ION_SYMBOL **p_sym);
@@ -91,6 +92,10 @@ iERR _ion_symbol_table_close_helper(ION_SYMBOL_TABLE *symtab);
 
 // local function forward reference declarations
 iERR _ion_symbol_table_local_make_system_symbol_table_helper(int32_t version);
+
+// The text reader doesn't automatically provide SIDs for known symbols. This forces a by-name lookup to the system
+// symbol table in those cases.
+iERR _ion_symbol_table_get_field_sid_force(ION_READER *preader, SID *fld_sid);
 
 iERR _ion_symbol_table_local_load_import_list   (ION_READER *preader, hOWNER owner, ION_COLLECTION *pimport_list);
 iERR _ion_symbol_table_local_load_symbol_struct (ION_READER *preader, hOWNER owner, ION_COLLECTION *psymbol_list);

--- a/ionc/ion_symbol_table_impl.h
+++ b/ionc/ion_symbol_table_impl.h
@@ -55,7 +55,7 @@ struct _ion_symbol_table_import
 // "locals" in ion_symbol_table.c
 iERR _ion_symbol_table_local_find_by_name(ION_SYMBOL_TABLE *symtab, ION_STRING *name, SID *p_sid, ION_SYMBOL **p_sym,
                                           BOOL symbol_identifiers_as_sids);
-BOOL _ion_symbol_needs_quotes(ION_STRING *p_str, BOOL system_identifiers_need_quotes);
+BOOL _ion_symbol_needs_quotes(ION_STRING *p_str, BOOL symbol_identifiers_need_quotes);
 
 // internal (pointer based helpers) functions for symbol tables (in ion_symbol_table.c)
 iERR _ion_symbol_table_open_helper(ION_SYMBOL_TABLE **p_psymtab, hOWNER owner, ION_SYMBOL_TABLE *psystem);
@@ -82,7 +82,7 @@ iERR _ion_symbol_table_find_by_sid_helper(ION_SYMBOL_TABLE *symtab, SID sid, ION
 iERR _ion_symbol_table_get_unknown_symbol_name(ION_SYMBOL_TABLE *symtab, SID sid, ION_STRING **p_name);
 iERR _ion_symbol_table_find_by_sid_force(ION_SYMBOL_TABLE *symtab, SID sid, ION_STRING **p_name);
 iERR _ion_symbol_table_is_symbol_known_helper(ION_SYMBOL_TABLE *symtab, SID sid, BOOL *p_is_known);
-iERR _ion_symbol_table_add_symbol_helper(ION_SYMBOL_TABLE *symtab, ION_STRING *name, SID *p_sid, BOOL parse_symbol_identifiers);
+iERR _ion_symbol_table_add_symbol_helper(ION_SYMBOL_TABLE *symtab, ION_STRING *name, SID *p_sid);
 iERR _ion_symbol_table_add_symbol_and_sid_helper(ION_SYMBOL_TABLE *symtab, ION_STRING *name, SID sid, ION_SYMBOL_TABLE *symbol_owning_table);
 iERR _ion_symbol_table_close_helper(ION_SYMBOL_TABLE *symtab);
 

--- a/ionc/ion_symbol_table_impl.h
+++ b/ionc/ion_symbol_table_impl.h
@@ -33,14 +33,15 @@ struct _ion_symbol_table
     BOOL                has_local_symbols;
     ION_STRING          name;
     int32_t             version;
-    int32_t             max_id;
+    int32_t             max_id;         // the max SID of this symbol tables symbols, including shared symbols.
+    int32_t             min_local_id;   // the lowest local SID. Only valid if has_local_symbols is TRUE. by_id[0] holds this symbol.
     ION_COLLECTION      import_list;    // collection of ION_SYMBOL_TABLE_IMPORT
     ION_COLLECTION      symbols;        // collection of ION_SYMBOL
     ION_SYMBOL_TABLE   *system_symbol_table;
 
-    int32_t             by_id_max;      // largest sid that can be stored, this is 1 less than the number of entries allocated since sids are 1 based and we don't use the 0-th array element
-    ION_SYMBOL        **by_id;
-    ION_INDEX           by_name;
+    int32_t             by_id_max;      // current size of by_id, which holds the local symbols, but NOT necessarily the number of declared local symbols.
+    ION_SYMBOL        **by_id;          // the local symbols. Accessing shared symbols requires delegate lookups to the imports.
+    ION_INDEX           by_name;        // the local symbols (by name).
 
 };
 
@@ -53,8 +54,7 @@ struct _ion_symbol_table_import
 };
 
 // "locals" in ion_symbol_table.c
-iERR _ion_symbol_table_local_find_by_name(ION_SYMBOL_TABLE *symtab, ION_STRING *name, SID *p_sid, ION_SYMBOL **p_sym,
-                                          BOOL symbol_identifiers_as_sids);
+iERR _ion_symbol_table_local_find_by_name(ION_SYMBOL_TABLE *symtab, ION_STRING *name, SID *p_sid, ION_SYMBOL **p_sym);
 BOOL _ion_symbol_needs_quotes(ION_STRING *p_str, BOOL symbol_identifiers_need_quotes);
 
 // internal (pointer based helpers) functions for symbol tables (in ion_symbol_table.c)
@@ -62,7 +62,6 @@ iERR _ion_symbol_table_open_helper(ION_SYMBOL_TABLE **p_psymtab, hOWNER owner, I
 iERR _ion_symbol_table_clone_with_owner_helper(ION_SYMBOL_TABLE **p_pclone, ION_SYMBOL_TABLE *orig, hOWNER owner, ION_SYMBOL_TABLE *system_symtab);
 iERR _ion_symbol_table_get_system_symbol_helper(ION_SYMBOL_TABLE **pp_system_table, int32_t version);
 //iERR _ion_symbol_table_load_import_list_helper(ION_READER *preader, hOWNER owner, ION_SYMBOL_TABLE_IMPORT **p_head);
-iERR _ion_symbol_table_load_symbol_struct_helper(ION_READER *preader, hOWNER owner, ION_SYMBOL **p_listhead);
 iERR _ion_symbol_table_load_symbol_list_helper(ION_READER *preader, hOWNER owner, ION_SYMBOL **p_listhead);
 iERR _ion_symbol_table_load_helper(ION_READER *preader, hOWNER owner, ION_SYMBOL_TABLE *system_symtab, ION_SYMBOL_TABLE **p_psymtab);
 iERR _ion_symbol_table_unload_helper(ION_SYMBOL_TABLE *symtab, ION_WRITER *pwriter);
@@ -76,14 +75,14 @@ iERR _ion_symbol_table_set_name_helper(ION_SYMBOL_TABLE *symtab, ION_STRING *nam
 iERR _ion_symbol_table_set_version_helper(ION_SYMBOL_TABLE *symtab, int32_t version);
 iERR _ion_symbol_table_set_max_sid_helper(ION_SYMBOL_TABLE *symtab, SID max_id);
 iERR _ion_symbol_table_get_imports_helper(ION_SYMBOL_TABLE *symtab, ION_COLLECTION **p_imports);
-iERR _ion_symbol_table_add_import_helper(ION_SYMBOL_TABLE *symtab, ION_SYMBOL_TABLE_IMPORT *pimport, ION_CATALOG *pcatalog);
-// with delegation use: iERR _ion_symbol_table_find_by_name_helper(ION_SYMBOL_TABLE *symtab, ION_STRING *name, SID *p_sid);
+iERR _ion_symbol_table_find_by_name_helper(ION_SYMBOL_TABLE *symtab, ION_STRING *name, SID *p_sid, ION_SYMBOL **p_sym, BOOL symbol_identifiers_as_sids);
 iERR _ion_symbol_table_find_by_sid_helper(ION_SYMBOL_TABLE *symtab, SID sid, ION_STRING **p_name);
+iERR _ion_symbol_table_find_symbol_by_sid_helper(ION_SYMBOL_TABLE *symtab, SID sid, ION_SYMBOL **p_sym);
 iERR _ion_symbol_table_get_unknown_symbol_name(ION_SYMBOL_TABLE *symtab, SID sid, ION_STRING **p_name);
 iERR _ion_symbol_table_find_by_sid_force(ION_SYMBOL_TABLE *symtab, SID sid, ION_STRING **p_name);
+void _ion_symbol_table_allocate_symbol_unknown_text(ION_SYMBOL_TABLE *symtab, SID sid, ION_SYMBOL **p_symbol);
 iERR _ion_symbol_table_is_symbol_known_helper(ION_SYMBOL_TABLE *symtab, SID sid, BOOL *p_is_known);
 iERR _ion_symbol_table_add_symbol_helper(ION_SYMBOL_TABLE *symtab, ION_STRING *name, SID *p_sid);
-iERR _ion_symbol_table_add_symbol_and_sid_helper(ION_SYMBOL_TABLE *symtab, ION_STRING *name, SID sid, ION_SYMBOL_TABLE *symbol_owning_table);
 iERR _ion_symbol_table_close_helper(ION_SYMBOL_TABLE *symtab);
 
 #define DEFAULT_SYMBOL_TABLE_SID_MULTIPLIER  2
@@ -98,8 +97,7 @@ iERR _ion_symbol_table_local_load_symbol_struct (ION_READER *preader, hOWNER own
 iERR _ion_symbol_table_local_load_symbol_list   (ION_READER *preader, hOWNER owner, ION_COLLECTION *psymbol_list);
 
 iERR _ion_symbol_table_import_symbol_table_helper(ION_SYMBOL_TABLE *symtab, ION_SYMBOL_TABLE *import_symtab);
-// iERR _ion_symbol_table_local_incorporate_import (ION_SYMBOL_TABLE *symtab, ION_SYMBOL_TABLE_IMPORT *import, ION_CATALOG *pcatalog);
-iERR _ion_symbol_table_local_incorporate_symbols(ION_SYMBOL_TABLE *symtab, ION_SYMBOL_TABLE *import, int32_t import_max_id);
+iERR _ion_symbol_table_local_incorporate_symbols(ION_SYMBOL_TABLE *symtab, ION_CATALOG *catalog, ION_STRING *import_name, int32_t import_version, int32_t import_max_id);
 iERR _ion_symbol_table_local_add_symbol_helper(ION_SYMBOL_TABLE *symtab, ION_STRING *name, SID sid, ION_SYMBOL_TABLE *symbol_owning_table, ION_SYMBOL **p_psym);
 
 iERR _ion_symbol_local_copy_same_owner(void *context, void *dst, void *src, int32_t data_size);

--- a/ionc/ion_symbol_table_impl.h
+++ b/ionc/ion_symbol_table_impl.h
@@ -53,10 +53,9 @@ struct _ion_symbol_table_import
 };
 
 // "locals" in ion_symbol_table.c
-iERR _ion_symbol_table_local_find_by_name(ION_SYMBOL_TABLE *symtab, ION_STRING *name, SID *p_sid, ION_SYMBOL **p_sym);
-BOOL _ion_symbol_needs_quotes_string(ION_STRING *p_str);
-BOOL _ion_symbol_needs_quotes_cstr(char *cp);
-BOOL _ion_symbol_needs_quotes_cstr_length(char *cp, SIZE length);
+iERR _ion_symbol_table_local_find_by_name(ION_SYMBOL_TABLE *symtab, ION_STRING *name, SID *p_sid, ION_SYMBOL **p_sym,
+                                          BOOL symbol_identifiers_as_sids);
+BOOL _ion_symbol_needs_quotes(ION_STRING *p_str, BOOL system_identifiers_need_quotes);
 
 // internal (pointer based helpers) functions for symbol tables (in ion_symbol_table.c)
 iERR _ion_symbol_table_open_helper(ION_SYMBOL_TABLE **p_psymtab, hOWNER owner, ION_SYMBOL_TABLE *psystem);
@@ -80,8 +79,10 @@ iERR _ion_symbol_table_get_imports_helper(ION_SYMBOL_TABLE *symtab, ION_COLLECTI
 iERR _ion_symbol_table_add_import_helper(ION_SYMBOL_TABLE *symtab, ION_SYMBOL_TABLE_IMPORT *pimport, ION_CATALOG *pcatalog);
 // with delegation use: iERR _ion_symbol_table_find_by_name_helper(ION_SYMBOL_TABLE *symtab, ION_STRING *name, SID *p_sid);
 iERR _ion_symbol_table_find_by_sid_helper(ION_SYMBOL_TABLE *symtab, SID sid, ION_STRING **p_name);
+iERR _ion_symbol_table_get_unknown_symbol_name(ION_SYMBOL_TABLE *symtab, SID sid, ION_STRING **p_name);
+iERR _ion_symbol_table_find_by_sid_force(ION_SYMBOL_TABLE *symtab, SID sid, ION_STRING **p_name);
 iERR _ion_symbol_table_is_symbol_known_helper(ION_SYMBOL_TABLE *symtab, SID sid, BOOL *p_is_known);
-iERR _ion_symbol_table_add_symbol_helper(ION_SYMBOL_TABLE *symtab, ION_STRING *name, SID *p_sid);
+iERR _ion_symbol_table_add_symbol_helper(ION_SYMBOL_TABLE *symtab, ION_STRING *name, SID *p_sid, BOOL parse_symbol_identifiers);
 iERR _ion_symbol_table_add_symbol_and_sid_helper(ION_SYMBOL_TABLE *symtab, ION_STRING *name, SID sid, ION_SYMBOL_TABLE *symbol_owning_table);
 iERR _ion_symbol_table_close_helper(ION_SYMBOL_TABLE *symtab);
 

--- a/ionc/ion_writer.c
+++ b/ionc/ion_writer.c
@@ -166,6 +166,8 @@ iERR _ion_writer_open_helper(ION_WRITER **p_pwriter, ION_STREAM *stream, ION_WRI
         ASSERT( pwriter->symbol_table == NULL || pwriter->symbol_table == system );
 
         IONCHECK(_ion_symbol_table_open_helper(&psymtab, pwriter->_temp_entity_pool, system));
+        // TODO what is this for? Is it in the writer's catalog? If not, its symbols won't be included in the local symbol table.
+        // might need to manually add the symbols to the local symbol table
         IONCHECK(_ion_symbol_table_import_symbol_table_helper(psymtab, pwriter->options.encoding_psymbol_table));
 
         pwriter->symbol_table = psymtab;
@@ -420,7 +422,7 @@ iERR _ion_writer_set_symbol_table_helper(ION_WRITER *pwriter, ION_SYMBOL_TABLE *
         IONCHECK(_ion_symbol_table_get_name_helper(psymtab, &import.name));
         IONCHECK(_ion_symbol_table_get_version_helper(psymtab, &import.version));
         IONCHECK(_ion_symbol_table_get_max_sid_helper(psymtab, &import.max_id));
-        IONCHECK(_ion_symbol_table_add_import_helper(plocal, &import, pwriter->options.pcatalog));
+        IONCHECK(_ion_symbol_table_local_incorporate_symbols(plocal, plocal->catalog, &import.name, import.version, import.max_id));
         psymtab = plocal;
         break;
     case ist_LOCAL:

--- a/ionc/ion_writer.c
+++ b/ionc/ion_writer.c
@@ -1398,7 +1398,7 @@ iERR _ion_writer_start_container_helper(ION_WRITER *pwriter, ION_TYPE container_
     default:
         FAILWITH(IERR_INVALID_ARG);
     }
-
+    pwriter->depth++;
     iRETURN;
 }
 
@@ -1431,7 +1431,7 @@ iERR _ion_writer_finish_container_helper(ION_WRITER *pwriter)
     default:
         FAILWITH(IERR_INVALID_ARG);
     }
-
+    pwriter->depth--;
     iRETURN;
 }
 
@@ -1825,7 +1825,7 @@ iERR _ion_writer_make_symbol_helper(ION_WRITER *pwriter, ION_STRING *pstr, SID *
 
     // we'll remember what the top symbol is to see if add_symbol changes it
     old_max_id = psymtab->max_id;
-    IONCHECK( _ion_symbol_table_add_symbol_helper( psymtab, pstr, &sid, FALSE));
+    IONCHECK( _ion_symbol_table_add_symbol_helper( psymtab, pstr, &sid));
 
     // see if this symbol ended up changing the symbol list (if it already
     // was present the max_id doesn't change and we don't reuse 

--- a/ionc/ion_writer_binary.c
+++ b/ionc/ion_writer_binary.c
@@ -1004,6 +1004,9 @@ iERR _ion_writer_binary_write_string(ION_WRITER *pwriter, ION_STRING *pstr )
 iERR _ion_writer_binary_write_symbol_id(ION_WRITER *pwriter, SID sid)
 {
     iENTER;
+    if (sid == ION_SYS_SID_IVM && pwriter->depth == 0 && pwriter->annotation_count == 0) {
+        SUCCEED(); // At the top level, writing a symbol value that looks like the IVM is a no-op.
+    }
     int  len = ion_binary_len_uint_64(sid);
     ASSERT( len < ION_lnIsVarLen );
 

--- a/ionc/ion_writer_binary.c
+++ b/ionc/ion_writer_binary.c
@@ -228,7 +228,7 @@ iERR _ion_writer_binary_start_value(ION_WRITER *pwriter, int value_length)
     // write field name
     if (pwriter->_in_struct) {
         IONCHECK( _ion_writer_get_field_name_as_sid_helper(pwriter, &sid));
-        if (sid < 1) FAILWITH(IERR_INVALID_STATE);
+        if (sid <= UNKNOWN_SID) FAILWITH(IERR_INVALID_STATE);
         IONCHECK( ion_binary_write_var_uint_64( ostream, sid ));
         IONCHECK( _ion_writer_clear_field_name_helper(pwriter));
     }
@@ -1010,7 +1010,9 @@ iERR _ion_writer_binary_write_symbol_id(ION_WRITER *pwriter, SID sid)
     // Write symbol type descriptor and int value out and patch lens.
     IONCHECK( _ion_writer_binary_start_value( pwriter, ION_BINARY_TYPE_DESC_LENGTH + len ));
     ION_PUT( pwriter->_typed_writer.binary._value_stream, makeTypeDescriptor(TID_SYMBOL, len));
-    IONCHECK( ion_binary_write_uint_64( pwriter->_typed_writer.binary._value_stream, sid ));
+    if (sid > 0) {
+        IONCHECK(ion_binary_write_uint_64(pwriter->_typed_writer.binary._value_stream, sid));
+    }
     IONCHECK( _ion_writer_binary_patch_lengths( pwriter, len + ION_BINARY_TYPE_DESC_LENGTH ));
 
     iRETURN;

--- a/ionc/ion_writer_impl.h
+++ b/ionc/ion_writer_impl.h
@@ -243,7 +243,7 @@ iERR _ion_writer_free_temp_pool( ION_WRITER *pwriter );
 //
 // text writer interfaces in ion_writer_text.c
 //
-iERR _ion_writer_text_append_symbol_string(ION_STREAM *poutput, ION_STRING *p_str, BOOL as_ascii);
+iERR _ion_writer_text_append_symbol_string(ION_STREAM *poutput, ION_STRING *p_str, BOOL as_ascii, BOOL system_identifiers_need_quotes);
 iERR _ion_writer_text_append_ascii_cstr(ION_STREAM *poutput, char *cp);
 iERR _ion_writer_text_append_escape_sequence_string(ION_STREAM  *poutput, BYTE *cp, BYTE *limit, BYTE **p_next);
 iERR _ion_writer_text_append_escape_sequence_cstr_limit(ION_STREAM *poutput, char *cp, char *limit, char **p_next);

--- a/test/gather_vectors.cpp
+++ b/test/gather_vectors.cpp
@@ -133,7 +133,7 @@ std::vector<std::string> *skip_list() {
         add_to_skip(good_path, "utf16.ion");
         add_to_skip(good_path, "utf32.ion");
 
-        add_to_skip(good_path, "subfieldVarUInt32bit.ion"); // TODO the implementation currently caps SIDs at 32 bits. This contains a SID that overflows.
+        add_to_skip(good_path, "subfieldVarUInt32bit.ion"); // NOTE: the implementation caps SIDs at 32 bits. This contains a SID that overflows.
     }
     return &_skip_list;
 }

--- a/test/gather_vectors.cpp
+++ b/test/gather_vectors.cpp
@@ -132,6 +132,8 @@ std::vector<std::string> *skip_list() {
 
         add_to_skip(good_path, "utf16.ion");
         add_to_skip(good_path, "utf32.ion");
+
+        add_to_skip(good_path, "subfieldVarUInt32bit.ion"); // TODO the implementation currently caps SIDs at 32 bits. This contains a SID that overflows.
     }
     return &_skip_list;
 }

--- a/test/ion_assert.cpp
+++ b/test/ion_assert.cpp
@@ -26,16 +26,23 @@ char *ionIntToString(ION_INT *value) {
 }
 
 char *ionStringToString(ION_STRING *value) {
-    if (!value) {
-        return (char *)"NULL";
+    BYTE *src, *dst;
+    SIZE len;
+    if (value) {
+        src = value->value;
+        len = value->length;
     }
-    char *str = (char *)malloc(((size_t)value->length + 1) * sizeof(char));
-    if (!str) return NULL;
+    else {
+        src = (BYTE *)"NULL";
+        len = 4;
+    }
+    dst = (BYTE *)malloc(((size_t)len + 1) * sizeof(char));
+    if (!dst) return NULL;
 
-    memcpy(str, value->value, (size_t)value->length);
-    str[value->length] = 0;
+    memcpy(dst, src, (size_t)len);
+    dst[len] = 0;
 
-    return str;
+    return (char *)dst;
 }
 
 ::testing::AssertionResult assertIonStringEq(ION_STRING *expected, ION_STRING *actual) {

--- a/test/ion_assert.cpp
+++ b/test/ion_assert.cpp
@@ -289,3 +289,11 @@ void assertBytesEqual(const char *expected, SIZE expected_len, const BYTE *actua
     }
 }
 
+void assertStringsEqual(const char *expected, const char *actual, SIZE actual_len) {
+    BOOL strings_not_equal = strncmp(expected, actual, (size_t)actual_len);
+    if (strings_not_equal) {
+        ASSERT_FALSE(strings_not_equal) << std::string(expected) << " vs. " << std::endl
+                                        << std::string(actual, (unsigned long)actual_len);
+    }
+}
+

--- a/test/ion_assert.h
+++ b/test/ion_assert.h
@@ -247,4 +247,9 @@ BOOL assertIonEventStreamEq(IonEventStream *expected, IonEventStream *actual, AS
  */
 void assertBytesEqual(const char *expected, SIZE expected_len, const BYTE *actual, SIZE actual_len);
 
+/**
+ * Tests that the given strings are equal.
+ */
+void assertStringsEqual(const char *expected, const char *actual, SIZE actual_len);
+
 #endif

--- a/test/ion_event_stream.cpp
+++ b/test/ion_event_stream.cpp
@@ -217,6 +217,9 @@ iERR read_next_value(hREADER hreader, IonEventStream *stream, ION_TYPE t, BOOL i
             break;
         }
         case tid_SYMBOL_INT: // intentional fall-through
+            // TODO when vectors that contain symbols with unknown text are added, this will need to retrieve a full
+            // ION_SYMBOL (text and SID) for proper roundtripping. If the text is unknown, the SID needs to be written.
+            // see: _ion_writer_write_one_value_helper
         case tid_STRING_INT:
         {
             ION_STRING tmp;

--- a/test/ion_test_util.cpp
+++ b/test/ion_test_util.cpp
@@ -51,16 +51,8 @@ iERR ion_string_from_cstr(const char *cstr, ION_STRING *out) {
 
 iERR ion_test_new_text_reader(const char *ion_text, hREADER *reader) {
     iENTER;
-
     size_t buffer_length = strlen(ion_text);
-    BYTE* buffer = (BYTE *)calloc(buffer_length, sizeof(BYTE));
-    memcpy((char *)(&buffer[0]), ion_text, buffer_length);
-
-    ION_READER_OPTIONS options;
-    memset(&options, 0, sizeof(options));
-    options.return_system_values = TRUE;
-
-    IONCHECK(ion_reader_open_buffer(reader, buffer, buffer_length, &options));
+    IONCHECK(ion_reader_open_buffer(reader, (BYTE *)ion_text, (SIZE)buffer_length, NULL));
     iRETURN;
 }
 

--- a/test/test_ion_binary.cpp
+++ b/test/test_ion_binary.cpp
@@ -129,3 +129,144 @@ TEST(IonBinaryTimestamp, ReaderIgnoresSuperfluousOffset) {
 
     ASSERT_TRUE(assertIonTimestampEq(&expected, &actual));
 }
+
+TEST(IonBinarySymbol, WriterWritesSymbolValueThatLooksLikeSymbolZero) {
+    hWRITER writer = NULL;
+    ION_STREAM *ion_stream = NULL;
+    BYTE *result;
+    SIZE result_len;
+    ION_STRING symbol_zero;
+
+    ion_string_from_cstr("$0", &symbol_zero);
+
+    ION_ASSERT_OK(ion_test_new_writer(&writer, &ion_stream, TRUE));
+    ION_ASSERT_OK(ion_writer_write_symbol(writer, &symbol_zero));
+    ION_ASSERT_OK(ion_test_writer_get_bytes(writer, ion_stream, &result, &result_len));
+
+    // NOTE: the symbol value refers to \x0A (i.e. SID 10 -- a local symbol), NOT \x00 (SID 0). This is because the
+    // ion_writer_write_symbol API, which takes a string from the user, was used.
+    assertBytesEqual("\x71\x0A", 2, result + result_len - 2, 2);
+}
+
+TEST(IonBinarySymbol, WriterWritesSymbolValueSymbolZero) {
+    hWRITER writer = NULL;
+    ION_STREAM *ion_stream = NULL;
+    BYTE *result;
+    SIZE result_len;
+
+    ION_ASSERT_OK(ion_test_new_writer(&writer, &ion_stream, TRUE));
+    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 0));
+    ION_ASSERT_OK(ion_test_writer_get_bytes(writer, ion_stream, &result, &result_len));
+
+    // NOTE: symbol zero is NOT added to the local symbol table. Symbol zero is not present in ANY symbol table.
+    assertBytesEqual("\xE0\x01\x00\xEA\x70", 5, result, result_len);
+}
+
+TEST(IonBinarySymbol, WriterWritesAnnotationThatLooksLikeSymbolZero) {
+    hWRITER writer = NULL;
+    ION_STREAM *ion_stream = NULL;
+    BYTE *result;
+    SIZE result_len;
+    ION_STRING symbol_zero;
+
+    ion_string_from_cstr("$0", &symbol_zero);
+
+    ION_ASSERT_OK(ion_test_new_writer(&writer, &ion_stream, TRUE));
+    ION_ASSERT_OK(ion_writer_add_annotation(writer, &symbol_zero));
+    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 0));
+    ION_ASSERT_OK(ion_test_writer_get_bytes(writer, ion_stream, &result, &result_len));
+
+    // NOTE: the annotation refers to \x8A (i.e. SID 10 -- a local symbol), NOT \x80 (SID 0). This is because the
+    // ion_writer_add_annotation API, which takes a string from the user, was used.
+    assertBytesEqual("\xE3\x81\x8A\x70", 4, result + result_len - 4, 4);
+}
+
+TEST(IonBinarySymbol, WriterWritesAnnotationSymbolZero) {
+    hWRITER writer = NULL;
+    ION_STREAM *ion_stream = NULL;
+    BYTE *result;
+    SIZE result_len;
+
+    ION_ASSERT_OK(ion_test_new_writer(&writer, &ion_stream, TRUE));
+    ION_ASSERT_OK(ion_writer_add_annotation_sid(writer, 0));
+    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 0));
+    ION_ASSERT_OK(ion_test_writer_get_bytes(writer, ion_stream, &result, &result_len));
+
+    // NOTE: symbol zero is NOT added to the local symbol table. Symbol zero is not present in ANY symbol table.
+    assertBytesEqual("\xE0\x01\x00\xEA\xE3\x81\x80\x70", 8, result, result_len);
+}
+
+TEST(IonBinarySymbol, WriterWritesFieldNameThatLooksLikeSymbolZero) {
+    hWRITER writer = NULL;
+    ION_STREAM *ion_stream = NULL;
+    BYTE *result;
+    SIZE result_len;
+    ION_STRING symbol_zero;
+
+    ion_string_from_cstr("$0", &symbol_zero);
+
+    ION_ASSERT_OK(ion_test_new_writer(&writer, &ion_stream, TRUE));
+    ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
+    ION_ASSERT_OK(ion_writer_write_field_name(writer, &symbol_zero));
+    ION_ASSERT_OK(ion_writer_add_annotation(writer, &symbol_zero));
+    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 0));
+    ION_ASSERT_OK(ion_writer_finish_container(writer));
+    ION_ASSERT_OK(ion_test_writer_get_bytes(writer, ion_stream, &result, &result_len));
+
+    // NOTE: the field name and annotation refer to \x8A (i.e. SID 10 -- a local symbol), NOT \x80 (SID 0).
+    // This is due to use of APIs that accept a string from the user.
+    assertBytesEqual("\xD5\x8A\xE3\x81\x8A\x70", 6, result + result_len - 6, 6);
+}
+
+TEST(IonBinarySymbol, WriterWritesFieldNameSymbolZero) {
+    hWRITER writer = NULL;
+    ION_STREAM *ion_stream = NULL;
+    BYTE *result;
+    SIZE result_len;
+
+    ION_ASSERT_OK(ion_test_new_writer(&writer, &ion_stream, TRUE));
+    ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
+    ION_ASSERT_OK(ion_writer_write_field_sid(writer, 0));
+    ION_ASSERT_OK(ion_writer_add_annotation_sid(writer, 0));
+    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 0));
+    ION_ASSERT_OK(ion_writer_finish_container(writer));
+    ION_ASSERT_OK(ion_test_writer_get_bytes(writer, ion_stream, &result, &result_len));
+
+    // NOTE: symbol zero is NOT added to the local symbol table. Symbol zero is not present in ANY symbol table.
+    assertBytesEqual("\xE0\x01\x00\xEA\xD5\x80\xE3\x81\x80\x70", 10, result, result_len);
+}
+
+TEST(IonBinarySymbol, ReaderReadsSymbolValueZeroAsString) {
+    hREADER reader;
+    BYTE *symbol_zero = (BYTE *)"\xE0\x01\x00\xEA\x70";
+    ION_TYPE actual_type;
+    ION_STRING actual;
+
+    ION_ASSERT_OK(ion_reader_open_buffer(&reader, symbol_zero, 5, NULL));
+    ION_ASSERT_OK(ion_reader_next(reader, &actual_type));
+    ASSERT_EQ(tid_SYMBOL, actual_type);
+    ION_ASSERT_OK(ion_reader_read_string(reader, &actual));
+    ION_ASSERT_OK(ion_reader_close(reader));
+    ASSERT_TRUE(ION_STRING_IS_NULL(&actual));
+}
+
+TEST(IonBinarySymbol, ReaderReadsSymbolValueZeroAsSID) {
+    hREADER reader;
+    BYTE *symbol_zero = (BYTE *)"\xE0\x01\x00\xEA\x70";
+    ION_TYPE actual_type;
+    SID actual;
+    hSYMTAB symbol_table;
+    ION_STRING *symbol_value;
+
+    ION_ASSERT_OK(ion_reader_open_buffer(&reader, symbol_zero, 5, NULL));
+    ION_ASSERT_OK(ion_reader_next(reader, &actual_type));
+    ASSERT_EQ(tid_SYMBOL, actual_type);
+    ION_ASSERT_OK(ion_reader_read_symbol_sid(reader, &actual));
+    ION_ASSERT_OK(ion_reader_close(reader));
+
+    ASSERT_EQ(0, actual);
+
+    ION_ASSERT_OK(ion_reader_get_symbol_table(reader, &symbol_table));
+    ION_ASSERT_OK(ion_symbol_table_find_by_sid(symbol_table, 0, &symbol_value));
+    ASSERT_TRUE(ION_STRING_IS_NULL(symbol_value));
+}

--- a/test/test_ion_text.cpp
+++ b/test/test_ion_text.cpp
@@ -73,5 +73,244 @@ TEST(IonTextTimestamp, WriterIgnoresSuperfluousOffset) {
     ION_ASSERT_OK(ion_writer_write_timestamp(writer, &timestamp));
     ION_ASSERT_OK(ion_test_writer_get_bytes(writer, ion_stream, &result, &result_len));
 
-    ASSERT_STREQ("0001T", (char *)result);
+    assertStringsEqual("0001T", (char *)result, result_len);
+}
+
+TEST(IonTextSymbol, WriterWritesSymbolValueZero) {
+    hWRITER writer = NULL;
+    ION_STREAM *ion_stream = NULL;
+    BYTE *result;
+    SIZE result_len;
+    ION_STRING symbol_zero;
+
+    ion_string_from_cstr("$0", &symbol_zero);
+
+    ION_ASSERT_OK(ion_test_new_writer(&writer, &ion_stream, FALSE));
+    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 0));
+    ION_ASSERT_OK(ion_writer_write_symbol(writer, &symbol_zero));
+    ION_ASSERT_OK(ion_test_writer_get_bytes(writer, ion_stream, &result, &result_len));
+
+    assertStringsEqual("$0\n'$0'", (char *)result, result_len);
+}
+
+TEST(IonTextSymbol, WriterWritesSymbolAnnotationZero) {
+    hWRITER writer = NULL;
+    ION_STREAM *ion_stream = NULL;
+    BYTE *result;
+    SIZE result_len;
+    ION_STRING symbol_zero;
+
+    ion_string_from_cstr("$0", &symbol_zero);
+
+    ION_ASSERT_OK(ion_test_new_writer(&writer, &ion_stream, FALSE));
+
+    ION_ASSERT_OK(ion_writer_add_annotation(writer, &symbol_zero));
+    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 0));
+
+    ION_ASSERT_OK(ion_writer_add_annotation_sid(writer, 0));
+    ION_ASSERT_OK(ion_writer_add_annotation_sid(writer, 0));
+    ION_ASSERT_OK(ion_writer_write_symbol(writer, &symbol_zero));
+
+    ION_ASSERT_OK(ion_test_writer_get_bytes(writer, ion_stream, &result, &result_len));
+
+    assertStringsEqual("'$0'::$0\n$0::$0::'$0'", (char *)result, result_len);
+}
+
+TEST(IonTextSymbol, WriterWritesSymbolFieldNameZero) {
+    hWRITER writer = NULL;
+    ION_STREAM *ion_stream = NULL;
+    BYTE *result;
+    SIZE result_len;
+    ION_STRING symbol_zero;
+
+    ion_string_from_cstr("$0", &symbol_zero);
+
+    ION_ASSERT_OK(ion_test_new_writer(&writer, &ion_stream, FALSE));
+    ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
+
+    ION_ASSERT_OK(ion_writer_write_field_name(writer, &symbol_zero));
+    ION_ASSERT_OK(ion_writer_add_annotation(writer, &symbol_zero));
+    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 0));
+
+    ION_ASSERT_OK(ion_writer_write_field_sid(writer, 0));
+    ION_ASSERT_OK(ion_writer_add_annotation(writer, &symbol_zero));
+    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 0));
+
+    ION_ASSERT_OK(ion_writer_write_field_name(writer, &symbol_zero));
+    ION_ASSERT_OK(ion_writer_add_annotation_sid(writer, 0));
+    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 0));
+
+    ION_ASSERT_OK(ion_writer_write_field_sid(writer, 0));
+    ION_ASSERT_OK(ion_writer_add_annotation_sid(writer, 0));
+    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 0));
+
+    ION_ASSERT_OK(ion_writer_finish_container(writer));
+    ION_ASSERT_OK(ion_test_writer_get_bytes(writer, ion_stream, &result, &result_len));
+
+    assertStringsEqual("{'$0':'$0'::$0,$0:'$0'::$0,'$0':$0::$0,$0:$0::$0}", (char *)result, result_len);
+}
+
+TEST(IonTextSymbol, ReaderReadsSymbolValueSymbolZero) {
+    const char *ion_text = "$0 '$0'";
+    hREADER reader;
+    ION_TYPE type;
+    SID sid;
+    ION_STRING symbol_value;
+    char *symbol_value_str;
+
+    ION_ASSERT_OK(ion_test_new_text_reader(ion_text, &reader));
+
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_SYMBOL, type);
+    ION_ASSERT_OK(ion_reader_read_string(reader, &symbol_value));
+    ASSERT_TRUE(ION_STRING_IS_NULL(&symbol_value));
+    ION_ASSERT_OK(ion_reader_read_symbol_sid(reader, &sid));
+    ASSERT_EQ(0, sid); // Because it was unquoted, this represents symbol zero.
+
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_SYMBOL, type);
+    ION_ASSERT_OK(ion_reader_read_symbol_sid(reader, &sid));
+    ASSERT_EQ(10, sid); // This one just looks like symbol zero, but it's actually a user symbol with the text $0
+    ION_ASSERT_OK(ion_read_string_as_chars(reader, &symbol_value_str));
+    ASSERT_STREQ("$0", symbol_value_str);
+
+    ION_ASSERT_OK(ion_reader_close(reader));
+}
+
+TEST(IonTextSymbol, ReaderReadsAnnotationSymbolZero) {
+    const char *ion_text = "'$0'::$0 $0::'$0'";
+    hREADER reader;
+    ION_TYPE type;
+    SID symbol_value;
+    SID annotations[1];
+    ION_STRING annotation_strs[1];
+    SIZE num_annotations;
+
+    ION_ASSERT_OK(ion_test_new_text_reader(ion_text, &reader));
+
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_SYMBOL, type);
+    ION_ASSERT_OK(ion_reader_get_annotations(reader, annotation_strs, 1, &num_annotations));
+    ASSERT_EQ(1, num_annotations);
+    ASSERT_STREQ("$0", ion_string_strdup(&annotation_strs[0]));
+    ION_ASSERT_OK(ion_reader_get_annotation_sids(reader, annotations, 1, &num_annotations));
+    ASSERT_EQ(1, num_annotations);
+    ASSERT_EQ(10, annotations[0]); // This one just looks like symbol zero, but it's actually a user symbol with the text $0
+    ION_ASSERT_OK(ion_reader_read_symbol_sid(reader, &symbol_value));
+    ASSERT_EQ(0, symbol_value);
+
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_SYMBOL, type);
+    ION_ASSERT_OK(ion_reader_get_annotation_sids(reader, annotations, 1, &num_annotations));
+    ASSERT_EQ(1, num_annotations);
+    ASSERT_EQ(0, annotations[0]); // Because it was unquoted, this represents symbol zero.
+    ION_ASSERT_OK(ion_reader_get_annotations(reader, annotation_strs, 1, &num_annotations));
+    ASSERT_EQ(1, num_annotations);
+    ASSERT_TRUE(ION_STRING_IS_NULL(&annotation_strs[0]));
+    ION_ASSERT_OK(ion_reader_read_symbol_sid(reader, &symbol_value));
+    ASSERT_EQ(10, symbol_value);
+
+    ION_ASSERT_OK(ion_reader_close(reader));
+}
+
+TEST(IonTextSymbol, ReaderReadsFieldNameSymbolZero) {
+    const char *ion_text = "{'$0':'$0'::$0, $0:$0::'$0', $0:'$0'::$0}";
+    hREADER reader;
+    ION_TYPE type;
+    SID symbol_value, field_name;
+    ION_STRING field_name_str;
+    SID annotations[1];
+    SIZE num_annotations;
+
+    ION_ASSERT_OK(ion_test_new_text_reader(ion_text, &reader));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_STRUCT, type);
+    ION_ASSERT_OK(ion_reader_step_in(reader));
+
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_SYMBOL, type);
+    ION_ASSERT_OK(ion_reader_get_field_name(reader, &field_name_str));
+    ASSERT_STREQ("$0", ion_string_strdup(&field_name_str));
+    ION_ASSERT_OK(ion_reader_get_field_sid(reader, &field_name));
+    ASSERT_EQ(10, field_name); // This one just looks like symbol zero, but it's actually a user symbol with the text $0
+    ION_ASSERT_OK(ion_reader_get_annotation_sids(reader, annotations, 1, &num_annotations));
+    ASSERT_EQ(1, num_annotations);
+    ASSERT_EQ(10, annotations[0]);
+    ION_ASSERT_OK(ion_reader_read_symbol_sid(reader, &symbol_value));
+    ASSERT_EQ(0, symbol_value);
+
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_SYMBOL, type);
+    ION_ASSERT_OK(ion_reader_get_field_sid(reader, &field_name));
+    ASSERT_EQ(0, field_name); // Because it was unquoted, this represents symbol zero.
+    ION_ASSERT_OK(ion_reader_get_field_name(reader, &field_name_str));
+    ASSERT_TRUE(ION_STRING_IS_NULL(&field_name_str));
+    ION_ASSERT_OK(ion_reader_get_annotation_sids(reader, annotations, 1, &num_annotations));
+    ASSERT_EQ(1, num_annotations);
+    ASSERT_EQ(0, annotations[0]);
+    ION_ASSERT_OK(ion_reader_read_symbol_sid(reader, &symbol_value));
+    ASSERT_EQ(10, symbol_value);
+
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_SYMBOL, type);
+    ION_ASSERT_OK(ion_reader_get_field_name(reader, &field_name_str));
+    ASSERT_TRUE(ION_STRING_IS_NULL(&field_name_str));
+    ION_ASSERT_OK(ion_reader_get_field_sid(reader, &field_name));
+    ASSERT_EQ(0, field_name); // Because it was unquoted, this represents symbol zero.
+    ION_ASSERT_OK(ion_reader_get_annotation_sids(reader, annotations, 1, &num_annotations));
+    ASSERT_EQ(1, num_annotations);
+    ASSERT_EQ(10, annotations[0]);
+    ION_ASSERT_OK(ion_reader_read_symbol_sid(reader, &symbol_value));
+    ASSERT_EQ(0, symbol_value);
+
+    ION_ASSERT_OK(ion_reader_step_out(reader));
+    ION_ASSERT_OK(ion_reader_close(reader));
+}
+
+void ion_test_write_all_values(hREADER reader, BYTE **result, SIZE *result_len, BOOL to_binary) {
+    hWRITER writer = NULL;
+    ION_STREAM *ion_stream = NULL;
+
+    ION_ASSERT_OK(ion_test_new_writer(&writer, &ion_stream, to_binary));
+
+    ION_ASSERT_OK(ion_writer_write_all_values(writer, reader));
+
+    ION_ASSERT_OK(ion_reader_close(reader));
+    ION_ASSERT_OK(ion_test_writer_get_bytes(writer, ion_stream, result, result_len));
+}
+
+void ion_test_write_all_values_from_text(const char *ion_text, BYTE **result, SIZE *result_len, BOOL to_binary) {
+    hREADER reader;
+
+    ION_ASSERT_OK(ion_test_new_text_reader(ion_text, &reader));
+    ion_test_write_all_values(reader, result, result_len, to_binary);
+}
+
+void ion_test_write_all_values_from_binary(BYTE *ion_data, SIZE ion_data_len, BYTE **result, SIZE *result_len, BOOL to_binary) {
+    hREADER reader;
+
+    ION_ASSERT_OK(ion_reader_open_buffer(&reader, ion_data, ion_data_len, NULL));
+    ion_test_write_all_values(reader, result, result_len, to_binary);
+}
+
+TEST(IonTextSymbol, WriterWriteAllValuesPreservesSymbolZero) {
+    const char *ion_text = "{'$0':'$0'::$0,$0:$0::'$0',$0:'$0'::$0}";
+    const BYTE *ion_binary = (BYTE *)"\xDE\x90\x8A\xE3\x81\x8A\x70\x80\xE4\x81\x80\x71\x0A\x80\xE3\x81\x8A\x70";
+    const SIZE ion_binary_size = 18;
+
+    BYTE *result = NULL;
+    SIZE result_len;
+
+    ion_test_write_all_values_from_text(ion_text, &result, &result_len, FALSE);
+    assertStringsEqual(ion_text, (char *)result, result_len);
+
+    ion_test_write_all_values_from_text(ion_text, &result, &result_len, TRUE);
+    assertBytesEqual((const char *)ion_binary, ion_binary_size, result + result_len - ion_binary_size, ion_binary_size);
+
+    ion_test_write_all_values_from_binary(result, result_len, &result, &result_len, FALSE);
+    assertStringsEqual(ion_text, (char *)result, result_len);
+
+    ion_test_write_all_values_from_text(ion_text, &result, &result_len, TRUE);
+    ion_test_write_all_values_from_binary(result, result_len, &result, &result_len, TRUE);
+    assertBytesEqual((const char *)ion_binary, ion_binary_size, result + result_len - ion_binary_size, ion_binary_size);
 }


### PR DESCRIPTION
* Fixes symbol processing to never add system semantics to quoted symbol identifiers.
  * In Ion text, symbol identifiers have the form `$<int>`, and represent a SID mapping in the current symbol table context. When a quoted symbol token with the same form as a symbol identifier is encountered, it should be not be treated as a SID and should not have its text transformed. When the user uses a writer API to write a symbol from a given string and provides a string with the form of a symbol identifier, this symbol token should be written as a quoted symbol token so that readers do not treat this symbol with special semantics. If a user wants to write a symbol token with unknown text in range of the current symbol table context, he/she can use an API that accepts an integer symbol ID. If that ID maps to a symbol with unknown text, text writers will write an unquoted symbol identifier.
* Fixes a bug that caused top-level unannotated IVM-esque symbols not to be treated as a no-ops on read and write.
  * According to the spec, there are several top-level symbol values that look like the IVM, but are treated as a no-op, including:
    * Any symbol identifier that maps to a symbol with the text `$ion_1_0`, including `$2`.
    * `'$ion_1_0'`, a quoted symbol with the same text as the IVM.
* Consolidates all symbol table processing logic in ion_symbol_table.c. Previously, much of this logic was needlessly duplicated in the binary reader (~400 lines deleted).
* Fixes a bug that prevented correct handling of not-found shared symbol table imports; uses delegate (non-flattened) symbol table lookups to avoid allocating NULL slots for not-found imports.
  * Previously, entering a new symbol table context involved copying all symbols from the system table and shared tables into a flattened collection within the local table, and appending any local symbol tables encountered later. This technique, which is costly upon switching symbol table contexts (especially for system symbols, which don't change (yet)), failed to handle not-found shared imports correctly, and would have required allocating NULL slots for all not-found symbols. Using delegate lookups (where the local symbol table simply refers to the system table and any shared tables, and queries them in the correct order) solves these problems.
* Removes the need for the text reader to query/create a local symbol table for symbols with known text; adds internal APIs to read symbol values as ION_SYMBOL, which enables correct roundtripping of symbols with unknown text.
  * Previously, encountering a symbol token in Ion text involved interning that symbol into a local symbol table context. This is only actually required for symbol identifiers, which don't represent the literal symbol text. All other text symbols have their text represented verbatim in the encoding, and do not require costly lookups or interning.
  * In order to correctly roundtrip a symbol with unknown text, its symbol ID is needed. Existing APIs enabled reading of the current symbol value's SID or text, but not both. Calling both would cause invalid state because the readers expect only one call to a `ion_reader_read*` API per call to `ion_reader_next`. The new function, which returns both in the form of an ION_SYMBOL, remains internal for now (it is used by `ion_writer_write_all_values`, which roundtrips all values from the given reader). We can make it public at a later date if necessary.