### PR TITLE
Adds vertical tab and form feed to the list of legal whitespace characters.

### DIFF
--- a/ionc/ion_reader_text.h
+++ b/ionc/ion_reader_text.h
@@ -256,7 +256,7 @@ extern "C" {
 #define FCF_IS_CONTAINER 0x0100
 
 // numeric stop characters
-#define NUMERIC_STOP_CHARACTERS "{}[](),\"\' \t\n\r"
+#define NUMERIC_STOP_CHARACTERS "{}[](),\"\' \t\n\r\v\f"
 
 #define IST_FOLLOW_STATE( iii )     ((iii)->follow_state)
 #define IST_BASE_TYPE( iii )        ((iii)->base_type)

--- a/ionc/ion_scanner.c
+++ b/ionc/ion_scanner.c
@@ -541,6 +541,8 @@ iERR _ion_scanner_read_past_whitespace(ION_SCANNER *scanner, int *p_char)
         case '\0':
         case ' ':
         case '\t':
+        case '\v': /* Vertical tab */
+        case '\f': /* Form feed */
         case NEW_LINE_3: /* carraige return */
         case NEW_LINE_2: /* carraige return, newline  */
         case NEW_LINE_1: /* newline */
@@ -571,6 +573,8 @@ iERR _ion_scanner_read_past_lob_whitespace(ION_SCANNER *scanner, int *p_char)
         case '\0':
         case ' ':
         case '\t':
+        case '\v': /* Vertical tab */
+        case '\f': /* Form feed */
         case NEW_LINE_3: /* carraige return */
         case NEW_LINE_2: /* carraige return, newline  */
         case NEW_LINE_1: /* newline */


### PR DESCRIPTION
The [grammar](https://amzn.github.io/ion-docs/grammar/IonText.g4.txt) defines these characters as legal whitespace.