### PR TITLE
Implements read support for appending symbols to the current local symbol table.

### DIFF
--- a/ionc/inc/ion_reader.h
+++ b/ionc/inc/ion_reader.h
@@ -242,7 +242,6 @@ ION_API_EXPORT iERR ion_reader_open                    (hREADER *p_hreader
                                                        ,ION_STREAM *p_stream
                                                        ,ION_READER_OPTIONS *p_options);
 ION_API_EXPORT iERR ion_reader_get_catalog             (hREADER hreader, hCATALOG *p_hcatalog);
-ION_API_EXPORT iERR ion_reader_get_symbol_table        (hREADER hreader, hSYMTAB  *p_hsymtab);
 
 /** moves the stream position to the specified offset. Resets the 
  *  the state of the reader to be at the top level. As long as the

--- a/ionc/ion_reader_impl.h
+++ b/ionc/ion_reader_impl.h
@@ -241,11 +241,12 @@ iERR _ion_reader_read_partial_string_helper(ION_READER *preader, BOOL accept_par
 
 iERR _ion_reader_close_helper(ION_READER *preader);
 
-iERR _ion_reader_allocate_temp_pool                 ( ION_READER *preader );
-iERR _ion_reader_reset_temp_pool                    ( ION_READER *preader);
-iERR _ion_reader_get_new_local_symbol_table_owner   (ION_READER *preader, void **p_owner);
+iERR _ion_reader_allocate_temp_pool                 (ION_READER *preader);
+iERR _ion_reader_reset_temp_pool                    (ION_READER *preader);
+iERR _ion_reader_allocate_pool_owner                (void **p_owner);
 iERR _ion_reader_free_local_symbol_table            (ION_READER *preader);
 iERR _ion_reader_reset_local_symbol_table           (ION_READER *preader);
+iERR _ion_reader_process_possible_symbol_table      (ION_READER *preader, BOOL *is_symbol_table);
 
 iERR _ion_reader_get_position_helper(ION_READER *preader, int64_t *p_bytes, int32_t *p_line, int32_t *p_offset);
 

--- a/ionc/ion_reader_text.c
+++ b/ionc/ion_reader_text.c
@@ -556,9 +556,6 @@ iERR _ion_reader_text_check_for_system_values_to_skip_or_process(ION_READER *pre
     iENTER;
     ION_TEXT_READER  *text = &preader->typed_reader.text;
     BOOL              is_system_value = FALSE;
-    BOOL              is_shared_symbol_table, is_local_symbol_table;
-    ION_SYMBOL_TABLE *system, *local = NULL;
-    void             *owner = NULL;
 
     // we only look for system values at the top level,
     ASSERT(text->_current_container == tid_DATAGRAM);
@@ -593,50 +590,7 @@ iERR _ion_reader_text_check_for_system_values_to_skip_or_process(ION_READER *pre
         }
     }
     else if (ist == IST_STRUCT && text->_annotation_count > 0) { // an annotated struct is a candidate for a symbol table
-        /*
-         * When we see a local symbol table (which would be a struct appropriately annotated
-         * we will process this if the caller hasn't asked to have system values returned.
-         * If they have, then we just return it and it's their problem to read and set the
-         * local symbol table. This is not the same as the Java impl.
-         */
-        
-        // TODO - this should be done with flags set while we're
-        // recognizing the annotations below (in the fullness of time)
-        // TODO in accordance with the spec, only check the FIRST annotation.
-        IONCHECK(_ion_reader_text_has_annotation(preader, &ION_SYMBOL_SYMBOL_TABLE_STRING, &is_local_symbol_table));
-            
-        // if we return system values we don't process them
-        if (is_local_symbol_table && preader->options.return_system_values != TRUE) { 
-            // this is a local symbol table and the user has not *insisted* we return system values, so we process it
-            IONCHECK(_ion_symbol_table_get_system_symbol_helper(&system, ION_SYSTEM_VERSION));
-            IONCHECK(_ion_reader_get_new_local_symbol_table_owner(preader, &owner )); // this owner will be _local_symtab_pool
-            // fake the state values so the symbol table load helper will "next" properly
-            preader->typed_reader.text._state = IPS_BEFORE_CONTAINER;
-            preader->typed_reader.text._value_type = tid_STRUCT;
-            IONCHECK(_ion_symbol_table_load_helper(preader, owner, system, &local));
-            if (local == NULL) {
-                FAILWITH(IERR_NOT_A_SYMBOL_TABLE);
-            }
-            preader->_current_symtab = local;
-            is_system_value = TRUE;
-        }
-        else if (preader->options.return_shared_symbol_tables != TRUE) { 
-            // it wasn't a local symbol table, it might still be a shared symbol table, 
-            // but we only process this if the user did not tell us to return shared symbol tables
-            IONCHECK(_ion_reader_text_has_annotation(preader, &ION_SYMBOL_SHARED_SYMBOL_TABLE_STRING, &is_shared_symbol_table));
-            if (is_shared_symbol_table) {
-                IONCHECK(_ion_symbol_table_get_system_symbol_helper(&system, ION_SYSTEM_VERSION));
-                // fake the state values so the symbol table load helper will "next" properly
-                preader->typed_reader.text._state = IPS_BEFORE_CONTAINER;
-                preader->typed_reader.text._value_type = tid_STRUCT;
-                IONCHECK(_ion_symbol_table_load_helper(preader, preader->_catalog->owner, system, &local));
-                if (local == NULL) {
-                    FAILWITH(IERR_NOT_A_SYMBOL_TABLE);
-                }
-                IONCHECK(_ion_catalog_add_symbol_table_helper(preader->_catalog, local));
-                is_system_value = TRUE;
-            }
-        }
+        IONCHECK(_ion_reader_process_possible_symbol_table(preader, &is_system_value));
     }
 
     *p_is_system_value = is_system_value;

--- a/ionc/ion_symbol_table_impl.h
+++ b/ionc/ion_symbol_table_impl.h
@@ -109,7 +109,6 @@ iERR _ion_symbol_local_copy_same_owner(void *context, void *dst, void *src, int3
 iERR _ion_symbol_local_copy_new_owner(void *context, void *dst, void *src, int32_t data_size);
 iERR _ion_symbol_table_local_import_copy_new_owner(void *context, void *dst, void *src, int32_t data_size);
 iERR _ion_symbol_table_local_import_copy_same_owner(void *context, void *dst, void *src, int32_t data_size);
-iERR _ion_symbol_table_create_substitute(ION_SYMBOL_TABLE_IMPORT* import, ION_CATALOG* catalog, ION_SYMBOL_TABLE** result);
 
 #define INDEX_IS_ACTIVE(symtab) ((symtab)->by_id_max > 0)
 iERR         _ion_symbol_table_initialize_indices_helper(ION_SYMBOL_TABLE *symtab);


### PR DESCRIPTION
This is achieved by cloning the previous local symbol table (if necessary) and appending new symbols to the clone.

Also makes a few improvements around symbol table handling:
* Consolidates the text and binary readers' potential symbol table processing logic into `_ion_reader_process_possible_symbol_table`. Previously, the two readers used different logic, which led to the binary reader not supporting adding shared symbol tables to the catalog and using the incorrect local symbol table owning pool.
* In accordance with the spec, any value in the symbols list that is null or is not a string is treated as a valid SID mapping with unknown text.
* A symbol table struct must not declare more than one `symbols` or `imports` list. Allowing this could lead to inconsistent mappings since struct fields are unordered.

Testing: passes all existing tests as well as the new LST-append and null slot vectors added in https://github.com/amzn/ion-tests/pull/35 . Once that PR is merged, ion-c's ion-tests submodule will be pointed to the latest revision.