### PR TITLE
Avoids switching on intptr_t in C++ tests. Aligns ION_TYPE and TID constants.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ test/all_tests
 tools/ionizer/ionizer
 tools/ionsymbols/ionsymbols
 build/
+cmake-build-debug/
+cmake-build-release/

--- a/ionc/inc/ion_types.h
+++ b/ionc/inc/ion_types.h
@@ -86,9 +86,9 @@ typedef struct ion_type    *ION_TYPE;
 #define tid_STRING       ((ION_TYPE) 0x800)
 #define tid_CLOB         ((ION_TYPE) 0x900)
 #define tid_BLOB         ((ION_TYPE) 0xA00)
-#define tid_STRUCT       ((ION_TYPE) 0xB00)
-#define tid_LIST         ((ION_TYPE) 0xC00)
-#define tid_SEXP         ((ION_TYPE) 0xD00)
+#define tid_LIST         ((ION_TYPE) 0xB00)
+#define tid_SEXP         ((ION_TYPE) 0xC00)
+#define tid_STRUCT       ((ION_TYPE) 0xD00)
 #define tid_DATAGRAM     ((ION_TYPE) 0xF00)
 
 #define tid_none_INT       ION_TYPE_INT(tid_none)

--- a/ionc/ion_writer.c
+++ b/ionc/ion_writer.c
@@ -787,7 +787,7 @@ iERR ion_writer_write_typed_null(hWRITER hwriter, ION_TYPE type)
 
     if (!hwriter) FAILWITH(IERR_BAD_HANDLE);
     pwriter = HANDLE_TO_PTR(hwriter, ION_WRITER);
-    if (type < tid_NULL || type > tid_SEXP) FAILWITH(IERR_INVALID_ARG);
+    if (type < tid_NULL || type > tid_STRUCT) FAILWITH(IERR_INVALID_ARG);
 
     IONCHECK(_ion_writer_write_typed_null_helper(pwriter, type));
 

--- a/test/gather_vectors.cpp
+++ b/test/gather_vectors.cpp
@@ -81,9 +81,12 @@ inline BOOL directory_exists(std::string path) {
 }
 
 inline std::string find_ion_tests_path() {
-    // IDEs typically perform in-source builds, in which case this will be executed directly from the tests directory.
-    // For out-of-source builds (such as the one performed by the build-release.sh script), this will be run from
-    // build/release/test. This attempts to locate the ion-tests directory from both locations.
+    // IDEs typically perform in-source builds, in which case this will be executed directly from either the root or the
+    // tests directory. Common out-of-source builds, including those performed by build-release.sh script, will be run
+    // from build/release/test. This attempts to locate the ion-tests directory from those locations.
+    if (directory_exists("ion-tests")) {
+        return "ion-tests";
+    }
     std::string from_test_directory = join_path(/*ion-c*/"..", "ion-tests");
     if (directory_exists(from_test_directory)) {
         return from_test_directory;
@@ -92,6 +95,11 @@ inline std::string find_ion_tests_path() {
     test_concat_filenames(&from_build_directory, 5, /*test*/"..", /*release*/"..", /*build*/"..", /*ion-c*/"..", "ion-tests");
     if (directory_exists(from_build_directory)) {
         return from_build_directory;
+    }
+    std::string from_out_of_source_test_directory;
+    test_concat_filenames(&from_out_of_source_test_directory, 3, /*e.g., cmake-build-debug*/"..", /*..ion-c*/"..", "ion-tests");
+    if (directory_exists(from_out_of_source_test_directory)) {
+        return from_out_of_source_test_directory;
     }
     return "";
 }

--- a/test/ion_test_util.h
+++ b/test/ion_test_util.h
@@ -21,6 +21,11 @@
 #define ION_ASSERT_FAIL(x) ASSERT_FALSE(IERR_OK == (x))
 
 /**
+ * Converts an ION_TYPE to a switchable int representing the given type's ID.
+ */
+#define ION_TID_INT(type) (int)(ION_TYPE_INT(type) >> 8)
+
+/**
  * Initializes and opens a new in-memory writer.
  * @param writer - the writer to initialize and open.
  * @param ion_stream - output parameter for the underlying in-memory stream.


### PR DESCRIPTION
Successful build/test runs:
* MacOS 10.11.6 with clang-800.0.42.1
* AL2012.03 with gcc 4.4.6 20110731