### PR TITLE
Decouples ION_SYMBOL_TABLE from ION_CATALOG; decouples ION_SYMBOL from ION_SYMBOL_TABLE.

### DIFF
--- a/ionc/inc/ion_catalog.h
+++ b/ionc/inc/ion_catalog.h
@@ -24,13 +24,32 @@ extern "C" {
 
 // Ion Symbol Catalog implementation
 //
+
+/**
+ * Allocates a new catalog with itself as its memory owner. Must be freed using `ion_catalog_close`.
+ * @param p_hcatalog - Pointer to a handle to the newly-allocated catalog.
+ */
 ION_API_EXPORT iERR ion_catalog_open                      (hCATALOG *p_hcatalog);
+
+/**
+ * Allocates a new catalog with the given owner as its memory owner.
+ * @param p_hcatalog - Pointer to a handle to the newly-allocated catalog.
+ * @param owner - Handle to the new catalog's memory owner. If NULL, the resulting catalog is its own memory owner and
+ *  must be freed using `ion_catalog_close`.
+ */
 ION_API_EXPORT iERR ion_catalog_open_with_owner           (hCATALOG *p_hcatalog, hOWNER owner);
 ION_API_EXPORT iERR ion_catalog_get_symbol_table_count    (hCATALOG hcatalog, int32_t *p_count);
 ION_API_EXPORT iERR ion_catalog_add_symbol_table          (hCATALOG hcatalog, hSYMTAB symtab);
 ION_API_EXPORT iERR ion_catalog_find_symbol_table         (hCATALOG hcatalog, iSTRING name, long version, hSYMTAB *p_symtab);
 ION_API_EXPORT iERR ion_catalog_find_best_match           (hCATALOG hcatalog, iSTRING name, long version, hSYMTAB *p_symtab); // or newest version of a symtab pass in version == 0
 ION_API_EXPORT iERR ion_catalog_release_symbol_table      (hCATALOG hcatalog, hSYMTAB symtab);
+
+/**
+ * If the given catalog is its own memory owner, its memory and everything it owns is freed. If the given catalog has an
+ * external owner and that owner has not been freed, this does nothing; this catalog will be freed when its memory owner
+ * is freed. If the given symbol table has an external owner which has been freed, the behavior of this function is
+ * undefined.
+ */
 ION_API_EXPORT iERR ion_catalog_close                     (hCATALOG hcatalog);
 
 #ifdef __cplusplus

--- a/ionc/inc/ion_reader.h
+++ b/ionc/inc/ion_reader.h
@@ -45,12 +45,6 @@ typedef struct _ion_reader_options
      */
     BOOL return_system_values;
 
-    /** If true the reader will look for shared symbol tables and add them to the catalog and treat them as system values.
-     * A better name might be add_shared_symbol_tables_to_catalog. // TODO: Code refactoring.
-     *
-     */
-    BOOL return_shared_symbol_tables;
-
     /** Character to be treated as new line for line counting, defaults to '\n'
      *
      */
@@ -105,7 +99,7 @@ typedef struct _ion_reader_options
      */
     BOOL skip_character_validation;
 
-    /** Handle to catalog of shared symbol tables for the reader to use
+    /** Handle to catalog of shared symbol tables for the reader to use. If NULL, will be treated as empty.
      *
      */
     ION_CATALOG *pcatalog;

--- a/ionc/inc/ion_symbol_table.h
+++ b/ionc/inc/ion_symbol_table.h
@@ -26,8 +26,7 @@ struct _ion_symbol
 {
     SID               sid;
     ION_STRING        value;
-    // TODO the need for these is not clear. Consider removal.
-    ION_SYMBOL_TABLE *psymtab;
+    // TODO this is only needed for symbol usage metrics. Consider removal.
     int32_t           add_count;
 };
 

--- a/ionc/inc/ion_symbol_table.h
+++ b/ionc/inc/ion_symbol_table.h
@@ -26,6 +26,7 @@ struct _ion_symbol
 {
     SID               sid;
     ION_STRING        value;
+    // TODO the need for these is not clear. Consider removal.
     ION_SYMBOL_TABLE *psymtab;
     int32_t           add_count;
 };
@@ -219,17 +220,58 @@ GLOBAL char *SYSTEM_SYMBOLS []
 
 /**
  * Allocates a new local symbol table.
+ * @param p_hsymtab - Pointer to a handle to the newly-allocated symbol table.
+ * @param owner - Handle to the new symbol table's memory owner. If NULL, the resulting symbol table is its own memory
+ *  owner and must be freed using `ion_symbol_table_close`.
  */
 ION_API_EXPORT iERR ion_symbol_table_open               (hSYMTAB *p_hsymtab, hOWNER owner);
 
 /**
- * Allocates a new local symbol table of the given type.
+ * Allocates a new local symbol table of the given type (i.e. shared or local).
+ * @param p_hsymtab - Pointer to a handle to the newly-allocated symbol table.
+ * @param owner - Handle to the new symbol table's memory owner. If NULL, the resulting symbol table is its own memory
+ *  owner and must be freed using `ion_symbol_table_close`.
  */
 ION_API_EXPORT iERR ion_symbol_table_open_with_type     (hSYMTAB *p_hsymtab, hOWNER owner, ION_SYMBOL_TABLE_TYPE type);
+
+/**
+ * Clones the given symbol table, using that symbol table's memory owner as the owner of the newly allocated symbol
+ * table.
+ * @param hsymtab - They symbol table to clone.
+ * @param p_hclone - Pointer to a handle to the newly-allocated symbol table clone.
+ */
 ION_API_EXPORT iERR ion_symbol_table_clone              (hSYMTAB hsymtab, hSYMTAB *p_hclone);
+
+/**
+ * Clones the given symbol table, using the given owner as the newly-allocated symbol table's memory owner.
+ * @param hsymtab - They symbol table to clone.
+ * @param p_hclone - Pointer to a handle to the newly-allocated symbol table clone.
+ * @param owner - Handle to the new symbol table's memory owner. If NULL, the resulting symbol table is its own memory
+ *  owner and must be freed using `ion_symbol_table_close`.
+ */
 ION_API_EXPORT iERR ion_symbol_table_clone_with_owner   (hSYMTAB hsymtab, hSYMTAB *p_hclone, hOWNER owner);
+
+/**
+ * Gets the global system symbol table for the given Ion version. This global system symbol table must never be closed.
+ * @param p_hsystem_table - Pointer to a handle to the global system symbol table.
+ * @param version - The Ion version. Currently, must be 1.
+ */
 ION_API_EXPORT iERR ion_symbol_table_get_system_table   (hSYMTAB *p_hsystem_table, int32_t version);
+
+/**
+ * Deserializes a symbol table (shared or local) from the given reader.
+ * @param hreader - The reader, positioned at the start of the symbol table struct.
+ * @param owner - Handle to the new symbol table's memory owner. If NULL, the resulting symbol table is its own memory
+ *  owner and must be freed using `ion_symbol_table_close`.
+ * @param p_hsymtab - Pointer to a handle to the newly-allocated symbol table.
+ */
 ION_API_EXPORT iERR ion_symbol_table_load               (hREADER hreader, hOWNER owner, hSYMTAB *p_hsymtab);
+
+/**
+ * Serializes a symbol table (shared or local) using the given writer.
+ * @param hsymtab - The symbol table to serialize.
+ * @param hwriter - The writer (text or binary).
+ */
 ION_API_EXPORT iERR ion_symbol_table_unload             (hSYMTAB hsymtab, hWRITER hwriter);
 
 ION_API_EXPORT iERR ion_symbol_table_lock               (hSYMTAB hsymtab);
@@ -245,13 +287,22 @@ ION_API_EXPORT iERR ion_symbol_table_set_version        (hSYMTAB hsymtab, int32_
 ION_API_EXPORT iERR ion_symbol_table_set_max_sid        (hSYMTAB hsymtab, SID max_id);
 
 ION_API_EXPORT iERR ion_symbol_table_get_imports        (hSYMTAB hsymtab, ION_COLLECTION **p_imports);
-ION_API_EXPORT iERR ion_symbol_table_add_import         (hSYMTAB hsymtab, ION_SYMBOL_TABLE_IMPORT *pimport);
 
 /**
- * Imports one symbol table into another. NOTE: the imported symbol table must be accessible through the parent symbol
- * table's catalog, otherwise all of its symbols will be considered to have unknown text.
- * @param hsymtab - The symbol table into which the imported symbol table will be incorporated.
- * @param hsymtab_import - The symbol table to import.
+ * Imports a shared symbol table into a local symbol table, given a description of the import and the catalog in which
+ * it can be found.
+ * NOTE: the best match for the described shared symbol table import that is available in the catalog will be used. If
+ * no match is found, all of the import's symbols will be considered to have unknown text.
+ * @param hsymtab - The local symbol table into which the imported symbol table will be incorporated.
+ * @param pimport - The description of the shared symbol table to be imported.
+ * @param catalog - The catalog to query for the matching shared symbol table.
+ */
+ION_API_EXPORT iERR ion_symbol_table_add_import         (hSYMTAB hsymtab, ION_SYMBOL_TABLE_IMPORT_DESCRIPTOR *pimport, hCATALOG catalog);
+
+/**
+ * Imports a shared symbol table into a local symbol table.
+ * @param hsymtab - The local symbol table into which the imported symbol table will be incorporated.
+ * @param hsymtab_import - The shared symbol table to import.
  */
 ION_API_EXPORT iERR ion_symbol_table_import_symbol_table(hSYMTAB hsymtab, hSYMTAB hsymtab_import);
 
@@ -263,10 +314,15 @@ ION_API_EXPORT iERR ion_symbol_table_get_symbol         (hSYMTAB hsymtab, SID si
 ION_API_EXPORT iERR ion_symbol_table_get_local_symbol   (hSYMTAB hsymtab, SID sid, ION_SYMBOL **p_sym); // get symbols by sid, iterate from 1 to max_sid - returns only locally defined symbols
 
 ION_API_EXPORT iERR ion_symbol_table_add_symbol         (hSYMTAB hsymtab, iSTRING name, SID *p_sid);
-// TODO: do we want this? iERR ion_symbol_table_add_symbol_and_sid   (hSYMTAB hsymtab, iSTRING name, SID sid);
 
+/**
+ * If the given symbol table is its own memory owner, its memory and everything it owns is freed. If the given symbol
+ * table has an external owner and that owner has not been freed, this does nothing; this symbol table will be freed
+ * when its memory owner is freed. If the given symbol table has an external owner which has been freed, the behavior of
+ * this function is undefined.
+ * NOTE: Symbol tables constructed and returned by readers and writers are owned by those readers and writers.
+ */
 ION_API_EXPORT iERR ion_symbol_table_close              (hSYMTAB hsymtab);
-ION_API_EXPORT iERR ion_symbol_table_free_system_table  ();
 
 ION_API_EXPORT const char *ion_symbol_table_type_to_str (ION_SYMBOL_TABLE_TYPE t);
 

--- a/ionc/inc/ion_types.h
+++ b/ionc/inc/ion_types.h
@@ -122,7 +122,10 @@ typedef struct _ion_catalog             ION_CATALOG;
 
 typedef struct _ion_string              ION_STRING;
 typedef struct _ion_symbol              ION_SYMBOL;
-typedef struct _ion_symbol_table_import ION_SYMBOL_TABLE_IMPORT;
+
+typedef struct _ion_symbol_table_import_descriptor ION_SYMBOL_TABLE_IMPORT_DESCRIPTOR;
+typedef struct _ion_symbol_table_import            ION_SYMBOL_TABLE_IMPORT;
+
 typedef struct _ion_reader              ION_READER;
 typedef struct _ion_writer              ION_WRITER;
 typedef struct _ion_int                 ION_INT;

--- a/ionc/inc/ion_writer.h
+++ b/ionc/inc/ion_writer.h
@@ -88,6 +88,7 @@ typedef struct _ion_writer_options
     /** Pointer to the first element of an array of shared symbol tables that the writer will import into each new local
      *  symbol table context. The size of the array is specified by `encoding_psymbol_table_count`. The user owns the
      *  associated memory, and must ensure it stays in scope for the lifetime of the writer.
+     *  NOTE: the system symbol table is always used as the first import; it need not be provided here.
      */
     ION_SYMBOL_TABLE *encoding_psymbol_table;
 

--- a/ionc/ion_catalog.c
+++ b/ionc/ion_catalog.c
@@ -155,8 +155,6 @@ iERR _ion_catalog_add_symbol_table_helper(ION_CATALOG *pcatalog, ION_SYMBOL_TABL
     if (!ppsymtab) FAILWITH(IERR_NO_MEMORY);
     *ppsymtab = psymtab;
 
-    psymtab->catalog = pcatalog;
-
     iRETURN;
 }
 
@@ -316,7 +314,7 @@ iERR _ion_catalog_release_symbol_table_helper(ION_CATALOG *pcatalog, ION_SYMBOL_
     ASSERT(pcatalog != NULL);
     ASSERT(psymtab != NULL);
 
-    // if this symbol table is "foriegn" get "our copy" of the table
+    // if this symbol table is "foreign" get "our copy" of the table
     if (psymtab->owner != pcatalog->owner) {
         IONCHECK(_ion_catalog_find_symbol_table_helper(pcatalog, &psymtab->name, psymtab->version, &test));
         if (!test) {

--- a/ionc/ion_reader_binary.c
+++ b/ionc/ion_reader_binary.c
@@ -1148,7 +1148,6 @@ iERR _ion_reader_binary_read_symbol(ION_READER *preader, ION_SYMBOL *p_symbol)
         ION_STRING_ASSIGN(&p_symbol->value, text);
     }
     p_symbol->sid = sid;
-    p_symbol->psymtab = preader->_current_symtab;
     p_symbol->add_count = 1;
     iRETURN;
 }

--- a/ionc/ion_reader_binary.c
+++ b/ionc/ion_reader_binary.c
@@ -83,21 +83,6 @@ iERR _ion_reader_binary_reset(ION_READER *preader, int parent_tid, POSITION loca
     iRETURN;
 }
 
-iERR _ion_reader_binary_close(ION_READER *preader)
-{
-    iENTER;
-
-    // we need to free the local symbol table, if we allocated one
-    if (preader->_local_symtab_pool != NULL) {
-        ion_free_owner( preader->_local_symtab_pool );
-        preader->_local_symtab_pool = NULL;
-    }
-
-    SUCCEED();
-
-    iRETURN;
-}
-
 iERR _ion_reader_binary_next(ION_READER *preader, ION_TYPE *p_value_type)
 {
     iENTER;

--- a/ionc/ion_reader_impl.h
+++ b/ionc/ion_reader_impl.h
@@ -266,7 +266,6 @@ iERR _ion_reader_get_position_helper(ION_READER *preader, int64_t *p_bytes, int3
 //
 iERR _ion_reader_binary_open                (ION_READER *preader);
 iERR _ion_reader_binary_reset               (ION_READER *preader, int parent_tid, POSITION local_end);
-iERR _ion_reader_binary_close               (ION_READER *preader);
 
 iERR _ion_reader_binary_next                (ION_READER *preader, ION_TYPE *p_value_type);
 iERR _ion_reader_binary_get_local_symbol_table_helper(ION_READER *preader, ION_SYMBOL_TABLE **pplocal );

--- a/ionc/ion_reader_text.c
+++ b/ionc/ion_reader_text.c
@@ -167,7 +167,6 @@ iERR _ion_reader_text_reset_value(ION_READER *preader)
     ION_STRING_INIT(&text->_field_name.value);
     text->_field_name.add_count = 0;
     text->_field_name.sid = UNKNOWN_SID;
-    text->_field_name.psymtab = NULL;
 
     text->_value_type               =  tid_none;
     text->_value_sub_type           =  IST_NONE;
@@ -346,7 +345,6 @@ iERR _ion_reader_text_load_fieldname(ION_READER *preader, ION_SUB_TYPE *p_ist)
         if (sym) {
             ION_STRING_ASSIGN(&text->_field_name.value, &sym->value);
             text->_field_name.sid = sym->sid;
-            text->_field_name.psymtab = sym->psymtab;
             text->_field_name.add_count = sym->add_count;
         }
 
@@ -495,7 +493,6 @@ iERR _ion_reader_text_load_utas(ION_READER *preader, ION_SUB_TYPE *p_ist)
                 ASSERT(sym->sid > UNKNOWN_SID);
                 ION_STRING_ASSIGN(&str->value, &sym->value);
                 str->sid = sym->sid;
-                str->psymtab = sym->psymtab;
                 str->add_count = sym->add_count;
             }
 

--- a/ionc/ion_reader_text.c
+++ b/ionc/ion_reader_text.c
@@ -179,21 +179,6 @@ iERR _ion_reader_text_reset_value(ION_READER *preader)
     iRETURN;
 }
 
-iERR _ion_reader_text_close(ION_READER *preader)
-{
-    iENTER;
-
-    // we need to free the local symbol table, if we allocated one
-    if (preader->_local_symtab_pool != NULL) {
-        ion_free_owner( preader->_local_symtab_pool );
-        preader->_local_symtab_pool = NULL;
-    }
-
-    SUCCEED();
-
-    iRETURN;
-}
-
 /**
  *   public APIs for actual operations - starting with NEXT()
  *

--- a/ionc/ion_reader_text.h
+++ b/ionc/ion_reader_text.h
@@ -282,7 +282,6 @@ iERR _ion_reader_text_open                      (ION_READER *preader);
 iERR _ion_reader_text_open_alloc_buffered_string(ION_READER *preader, SIZE len, ION_STRING *p_string, BYTE **p_buf, SIZE *p_buf_len);
 iERR _ion_reader_text_reset                     (ION_READER *preader, ION_TYPE parent_tid, POSITION local_end);
 iERR _ion_reader_text_reset_value               (ION_READER *preader);
-iERR _ion_reader_text_close                     (ION_READER *preader);
 
 // support for "next" functions
 iERR _ion_reader_text_next                      (ION_READER *preader, ION_TYPE *p_value_type);

--- a/ionc/ion_symbol_table.c
+++ b/ionc/ion_symbol_table.c
@@ -81,7 +81,7 @@ iERR _ion_symbol_table_open_helper(ION_SYMBOL_TABLE **p_psymtab, hOWNER owner, I
     // create the system symbol table) we need to copy the system
     // symbols to seed our symbol list
     if (system) {
-        IONCHECK(_ion_symbol_table_local_incorporate_symbols(symtab, NULL, &system->name, system->version, system->max_id));
+        IONCHECK(_ion_symbol_table_local_incorporate_symbols(symtab, NULL, system->max_id));
     }
     *p_psymtab = symtab;
 
@@ -290,23 +290,6 @@ iERR _ion_symbol_table_local_make_system_symbol_table_helper(int32_t version)
     iRETURN;
 }
 
-iERR ion_symbol_table_free_system_table() 
-{
-    iENTER;
-    ION_SYMBOL_TABLE *psymtab = p_system_symbol_table_version_1;
-
-    if (!psymtab) {
-        SUCCEED();
-    }
-    p_system_symbol_table_version_1 = NULL;
-
-    // we don't free the system symbol table, since it isn't allocated
-    // see: smallLocalAllocationBlock() which has a small global buffer for this
-    // ion_free_owner(psymtab);
-
-    iRETURN;
-}
-
 iERR _ion_symbol_table_local_load_import_list(ION_READER *preader, hOWNER owner, ION_COLLECTION *pimport_list)
 {
     iENTER;
@@ -314,6 +297,8 @@ iERR _ion_symbol_table_local_load_import_list(ION_READER *preader, hOWNER owner,
     ION_TYPE   type;
     ION_STRING str;
     SID        fld_sid;
+
+    ASSERT(preader->_catalog != NULL);
 
     ION_STRING_INIT(&str);
 
@@ -325,7 +310,7 @@ iERR _ion_symbol_table_local_load_import_list(ION_READER *preader, hOWNER owner,
 
         import = (ION_SYMBOL_TABLE_IMPORT *)_ion_collection_append(pimport_list);
         memset(import, 0, sizeof(ION_SYMBOL_TABLE_IMPORT));
-        import->max_id = ION_SYS_SYMBOL_MAX_ID_UNDEFINED;
+        import->descriptor.max_id = ION_SYS_SYMBOL_MAX_ID_UNDEFINED;
 
         // step into the import struct
         IONCHECK(_ion_reader_step_in_helper(preader));
@@ -336,16 +321,16 @@ iERR _ion_symbol_table_local_load_import_list(ION_READER *preader, hOWNER owner,
             IONCHECK(_ion_symbol_table_get_field_sid_force(preader, &fld_sid));
             switch(fld_sid) {
             case ION_SYS_SID_NAME:     /* "name" */
-                if (!ION_STRING_IS_NULL(&import->name)) FAILWITHMSG(IERR_INVALID_SYMBOL_TABLE, "too many names in import list");
+                if (!ION_STRING_IS_NULL(&import->descriptor.name)) FAILWITHMSG(IERR_INVALID_SYMBOL_TABLE, "too many names in import list");
                 if (type == tid_STRING) {
                     IONCHECK(_ion_reader_read_string_helper(preader, &str));
-                    IONCHECK(ion_string_copy_to_owner(owner, &import->name, &str));
+                    IONCHECK(ion_string_copy_to_owner(owner, &import->descriptor.name, &str));
                 }
                 break;
             case ION_SYS_SID_VERSION:  /* "version" */
-                if (import->version) FAILWITHMSG(IERR_INVALID_SYMBOL_TABLE, "too many versions in import list");
+                if (import->descriptor.version) FAILWITHMSG(IERR_INVALID_SYMBOL_TABLE, "too many versions in import list");
                 if (type == tid_INT) {
-                    IONCHECK(_ion_reader_read_int32_helper(preader, &import->version));
+                    IONCHECK(_ion_reader_read_int32_helper(preader, &import->descriptor.version));
                 }
                 break;
             case ION_SYS_SID_MAX_ID:   /* "max_id" */
@@ -353,20 +338,26 @@ iERR _ion_symbol_table_local_load_import_list(ION_READER *preader, hOWNER owner,
                 // case, the following line won't trigger a failure. However, the spec doesn't clearly define what
                 // implementations must do when multiple of the same field is encountered in an import, so it doesn't
                 // seem worth it to address this now.
-                if (import->max_id != ION_SYS_SYMBOL_MAX_ID_UNDEFINED) FAILWITHMSG(IERR_INVALID_SYMBOL_TABLE, "too many max_id fields in import list");
+                if (import->descriptor.max_id != ION_SYS_SYMBOL_MAX_ID_UNDEFINED) FAILWITHMSG(IERR_INVALID_SYMBOL_TABLE, "too many max_id fields in import list");
                 BOOL is_null;
                 IONCHECK(ion_reader_is_null(preader, &is_null));
                 if (type == tid_INT && !is_null) {
-                    IONCHECK(_ion_reader_read_int32_helper(preader, &import->max_id));
+                    IONCHECK(_ion_reader_read_int32_helper(preader, &import->descriptor.max_id));
                 }
                 break;
             default:
                 break;
             }
         }
-        if (import->version < 1) {
-            import->version = 1;
+        if (import->descriptor.version < 1) {
+            import->descriptor.version = 1;
         }
+
+        if (ION_STRING_IS_NULL(&import->descriptor.name)) {
+            FAILWITHMSG(IERR_INVALID_SYMBOL_TABLE, "A shared symbol table must have a name.");
+        }
+
+        IONCHECK(_ion_catalog_find_best_match_helper(preader->_catalog, &import->descriptor.name, import->descriptor.version, import->descriptor.max_id, &import->shared_symbol_table));
         // step back out to the list of imports
         IONCHECK(_ion_reader_step_out_helper(preader));
     }
@@ -424,7 +415,6 @@ iERR ion_symbol_table_load(hREADER hreader, hOWNER owner, hSYMTAB *p_hsymtab)
 
 
     if (hreader   == NULL) FAILWITH(IERR_INVALID_ARG);
-    if (owner     == NULL) FAILWITH(IERR_INVALID_ARG);
     if (p_hsymtab == NULL) FAILWITH(IERR_INVALID_ARG);
 
     preader = HANDLE_TO_PTR(hreader, ION_READER);
@@ -483,7 +473,6 @@ iERR _ion_symbol_table_append(ION_READER *preader, hOWNER owner, ION_SYMBOL_TABL
                 appended_symbol->sid = UNKNOWN_SID; // This is assigned correctly later.
             }
         }
-        cloned->catalog = preader->_current_symtab->catalog;
         // This overwrites p_symtab's reference, which will be cleaned up when its owner is freed.
         *p_symtab = cloned;
     }
@@ -505,7 +494,6 @@ iERR _ion_symbol_table_load_helper(ION_READER *preader, hOWNER owner, ION_SYMBOL
     ION_COLLECTION_CURSOR    import_cursor, symbol_cursor;
 
     ASSERT(preader   != NULL);
-    ASSERT(owner     != NULL);
     ASSERT(p_psymtab != NULL);
 
     ION_STRING_INIT(&name);
@@ -528,6 +516,9 @@ iERR _ion_symbol_table_load_helper(ION_READER *preader, hOWNER owner, ION_SYMBOL
     else {
         IONCHECK(_ion_symbol_table_open_helper(&symtab, owner, system));
     }
+
+    owner = symtab->owner;
+    ASSERT(owner != NULL);
 
     // now we step into the struct that has the data we actually use to fill out the table
     IONCHECK(_ion_reader_step_in_helper(preader));
@@ -570,11 +561,7 @@ iERR _ion_symbol_table_load_helper(ION_READER *preader, hOWNER owner, ION_SYMBOL
                     for (;;) {
                         ION_COLLECTION_NEXT(import_cursor, import);
                         if (!import) break;
-                        if (!preader->_catalog) {
-                            IONCHECK(_ion_catalog_open_with_owner_helper(&preader->_catalog, preader));
-                        }
-                        IONCHECK(_ion_symbol_table_local_incorporate_symbols(symtab, preader->_catalog, &import->name,
-                                                                             import->version, import->max_id));
+                        IONCHECK(_ion_symbol_table_local_incorporate_symbols(symtab, import->shared_symbol_table, import->descriptor.max_id));
                     }
                     ION_COLLECTION_CLOSE(import_cursor);
                 }
@@ -653,8 +640,6 @@ iERR _ion_symbol_table_load_helper(ION_READER *preader, hOWNER owner, ION_SYMBOL
     }
 
     IONCHECK(_ion_symbol_table_initialize_indices_helper(symtab));
-
-    symtab->catalog = preader->_catalog;
 
     *p_psymtab = symtab;
 
@@ -738,17 +723,17 @@ iERR _ion_symbol_table_unload_helper(ION_SYMBOL_TABLE *symtab, ION_WRITER *pwrit
             if (!import) break;
         
             IONCHECK(_ion_writer_start_container_helper(pwriter, tid_STRUCT));
-            if (!ION_STRING_IS_NULL(&import->name)) {
+            if (!ION_STRING_IS_NULL(&import->descriptor.name)) {
                 IONCHECK(_ion_writer_write_field_sid_helper(pwriter, ION_SYS_SID_NAME));
-                IONCHECK(_ion_writer_write_string_helper(pwriter, &import->name));
+                IONCHECK(_ion_writer_write_string_helper(pwriter, &import->descriptor.name));
             }
-            if (import->version > 0) {
+            if (import->descriptor.version > 0) {
                 IONCHECK(_ion_writer_write_field_sid_helper(pwriter, ION_SYS_SID_VERSION));
-                IONCHECK(_ion_writer_write_int64_helper(pwriter, import->version));
+                IONCHECK(_ion_writer_write_int64_helper(pwriter, import->descriptor.version));
             }
-            if (import->max_id > 0) {
+            if (import->descriptor.max_id > 0) {
                 IONCHECK(_ion_writer_write_field_sid_helper(pwriter, ION_SYS_SID_MAX_ID));
-                IONCHECK(_ion_writer_write_int64_helper(pwriter, import->max_id));
+                IONCHECK(_ion_writer_write_int64_helper(pwriter, import->descriptor.max_id));
             }
             IONCHECK(_ion_writer_finish_container_helper(pwriter));
         }
@@ -1112,42 +1097,51 @@ iERR _ion_symbol_table_import_symbol_table_helper(ION_SYMBOL_TABLE *symtab, ION_
     if (!import) FAILWITH(IERR_NO_MEMORY);
 
     memset(import, 0, sizeof(ION_SYMBOL_TABLE_IMPORT));
-    import->max_id = import_symtab->max_id;
-    import->version = import_symtab->version;
-    IONCHECK(ion_string_copy_to_owner(symtab->owner, &import->name, &import_symtab->name));
+    import->descriptor.max_id = import_symtab->max_id;
+    import->descriptor.version = import_symtab->version;
+    IONCHECK(ion_string_copy_to_owner(symtab->owner, &import->descriptor.name, &import_symtab->name));
+    import->shared_symbol_table = import_symtab;
 
-    IONCHECK(_ion_symbol_table_local_incorporate_symbols(symtab, symtab->catalog, &import_symtab->name, import_symtab->version, import_symtab->max_id));
+    IONCHECK(_ion_symbol_table_local_incorporate_symbols(symtab, import_symtab, import_symtab->max_id));
 
     iRETURN;
 }
 
-iERR ion_symbol_table_add_import(hSYMTAB hsymtab, ION_SYMBOL_TABLE_IMPORT *p_import)
+iERR ion_symbol_table_add_import(hSYMTAB hsymtab, ION_SYMBOL_TABLE_IMPORT_DESCRIPTOR *p_import, hCATALOG hcatalog)
 {
     iENTER;
-    ION_SYMBOL_TABLE *symtab;
+    ION_SYMBOL_TABLE *symtab, *shared;
+    ION_CATALOG      *catalog;
 
     if (hsymtab == NULL) FAILWITH(IERR_INVALID_ARG);
+    if (hcatalog == NULL) FAILWITH(IERR_INVALID_ARG);
     symtab = HANDLE_TO_PTR(hsymtab, ION_SYMBOL_TABLE);
+    catalog = HANDLE_TO_PTR(hcatalog, ION_CATALOG);
     if (p_import == NULL) FAILWITH(IERR_INVALID_ARG);
     if (symtab->is_locked) FAILWITH(IERR_IS_IMMUTABLE);
     if (symtab->has_local_symbols) FAILWITH(IERR_HAS_LOCAL_SYMBOLS);
 
-    IONCHECK(_ion_symbol_table_local_incorporate_symbols(symtab, symtab->catalog, &p_import->name, p_import->version, p_import->max_id));
+    IONCHECK(_ion_catalog_find_best_match_helper(catalog, &p_import->name, p_import->version, p_import->max_id, &shared));
+
+    IONCHECK(_ion_symbol_table_import_symbol_table_helper(symtab, shared));
 
     iRETURN;
 }
 
-iERR _ion_symbol_table_local_incorporate_symbols(ION_SYMBOL_TABLE *symtab, ION_CATALOG *catalog,
-                                                 ION_STRING *import_name, int32_t import_version, int32_t import_max_id)
+iERR _ion_symbol_table_local_incorporate_symbols(ION_SYMBOL_TABLE *symtab, ION_SYMBOL_TABLE *shared, int32_t import_max_id)
 {
     iENTER;
+    ION_SYMBOL_TABLE_TYPE type;
+
     ASSERT(symtab != NULL);
     ASSERT(!symtab->is_locked);
     ASSERT(!symtab->has_local_symbols);
 
-    if (catalog) {
-        // Ensures this is a valid import. NOTE: doesn't ensure that the import is found in the catalog.
-        IONCHECK(_ion_catalog_find_best_match_helper(catalog, import_name, import_version, import_max_id, NULL));
+    if (shared) {
+        IONCHECK(ion_symbol_table_get_type(shared, &type));
+        if (type == ist_LOCAL || type == ist_EMPTY) {
+            FAILWITH(IERR_INVALID_ARG);
+        }
     }
     else if (import_max_id <= ION_SYS_SYMBOL_MAX_ID_UNDEFINED) {
         FAILWITH(IERR_INVALID_SYMBOL_TABLE);
@@ -1297,29 +1291,24 @@ iERR _ion_symbol_table_find_by_name_helper(ION_SYMBOL_TABLE *symtab, ION_STRING 
    IONCHECK(_ion_symbol_table_local_find_by_name(symtab->system_symbol_table, name, &sid, &sym));
 
     // first we have to look in the imported tables
-    // TODO:  make this smarter
-
-    // really if this is a local symbol table there should be only 1 import
-    // and if this is a shared (named) symbol table you only have to look
-    // locally since shared table have all the imported symbols in their list
-    if (sid == UNKNOWN_SID && symtab->catalog && !ION_COLLECTION_IS_EMPTY(&symtab->import_list)) {
+    if (sid == UNKNOWN_SID && !ION_COLLECTION_IS_EMPTY(&symtab->import_list)) {
         offset = symtab->system_symbol_table->max_id;
 
         ION_COLLECTION_OPEN(&symtab->import_list, import_cursor);
         for (;;) {
             ION_COLLECTION_NEXT(import_cursor, imp);
             if (!imp) break;
-            IONCHECK(_ion_catalog_find_best_match_helper(symtab->catalog, &imp->name, imp->version, imp->max_id, &imported));
+            imported = imp->shared_symbol_table;
             // If the import is not found, skip it -- its symbols have unknown text and therefore cannot be looked up by name.
             if (imported != NULL) {
                 IONCHECK(_ion_symbol_table_local_find_by_name(imported, name, &sid, &sym));
-                if (sid > imp->max_id) sid = UNKNOWN_SID;
+                if (sid > imp->descriptor.max_id) sid = UNKNOWN_SID;
                 if (sid != UNKNOWN_SID) {
                     sid += offset;
                     break;
                 }
             }
-            offset += imp->max_id;
+            offset += imp->descriptor.max_id;
         }
         ION_COLLECTION_CLOSE(import_cursor);
     }
@@ -1416,12 +1405,8 @@ iERR _ion_symbol_table_find_symbol_by_sid_helper(ION_SYMBOL_TABLE *symtab, SID s
             for (;;) {
                 ION_COLLECTION_NEXT(import_cursor, imp);
                 if (!imp) break;
-                if (sid - offset <= imp->max_id) {
-                    imported = NULL; // i.e. not found.
-                    if (symtab->catalog) {
-                        IONCHECK(_ion_catalog_find_best_match_helper(symtab->catalog, &imp->name, imp->version,
-                                                                     imp->max_id, &imported));
-                    }
+                if (sid - offset <= imp->descriptor.max_id) {
+                    imported = imp->shared_symbol_table;
                     if (imported == NULL) {
                         // The SID is in range, but the shared symbol table is not found. This symbol has unknown text.
                         // NOTE: 'symtab' isn't the true owner of this symbol -- the not-found import is. But since
@@ -1436,7 +1421,7 @@ iERR _ion_symbol_table_find_symbol_by_sid_helper(ION_SYMBOL_TABLE *symtab, SID s
                     ASSERT(sym);
                     break;
                 }
-                offset += imp->max_id;
+                offset += imp->descriptor.max_id;
             }
             ION_COLLECTION_CLOSE(import_cursor);
         }
@@ -1682,12 +1667,14 @@ iERR ion_symbol_table_close(hSYMTAB hsymtab)
 iERR _ion_symbol_table_close_helper(ION_SYMBOL_TABLE *symtab)
 {
     iENTER;
+    ION_SYMBOL_TABLE_TYPE table_type;
 
     ASSERT(symtab != NULL);
 
-    if (symtab->catalog) {
-        IONCHECK(_ion_catalog_release_symbol_table_helper(symtab->catalog, symtab));
-        symtab->catalog = NULL;
+    IONCHECK(ion_symbol_table_get_type(symtab, &table_type));
+
+    if (table_type == ist_SYSTEM) {
+        FAILWITH(IERR_INVALID_ARG);
     }
 
     if (symtab->owner == symtab) {
@@ -1859,7 +1846,7 @@ iERR _ion_symbol_table_local_import_copy_new_owner(void *context, void *dst, voi
     ASSERT(context);
 
     memcpy(import_dst, import_src, data_size);
-    IONCHECK(ion_string_copy_to_owner(context, &import_dst->name, &import_src->name));
+    IONCHECK(ion_string_copy_to_owner(context, &import_dst->descriptor.name, &import_src->descriptor.name));
 
     iRETURN;
 }
@@ -1875,7 +1862,7 @@ iERR _ion_symbol_table_local_import_copy_same_owner(void *context, void *dst, vo
     ASSERT(src);
 
     memcpy(import_dst, import_src, data_size);
-    ION_STRING_ASSIGN(&import_dst->name, &import_src->name);
+    ION_STRING_ASSIGN(&import_dst->descriptor.name, &import_src->descriptor.name);
 
     iRETURN;
 }

--- a/ionc/ion_symbol_table_impl.h
+++ b/ionc/ion_symbol_table_impl.h
@@ -109,7 +109,7 @@ iERR _ion_symbol_table_local_load_symbol_list   (ION_READER *preader, hOWNER own
 
 iERR _ion_symbol_table_import_symbol_table_helper(ION_SYMBOL_TABLE *symtab, ION_SYMBOL_TABLE *import_symtab);
 iERR _ion_symbol_table_local_incorporate_symbols(ION_SYMBOL_TABLE *symtab, ION_SYMBOL_TABLE *shared, int32_t import_max_id);
-iERR _ion_symbol_table_local_add_symbol_helper(ION_SYMBOL_TABLE *symtab, ION_STRING *name, SID sid, ION_SYMBOL_TABLE *symbol_owning_table, ION_SYMBOL **p_psym);
+iERR _ion_symbol_table_local_add_symbol_helper(ION_SYMBOL_TABLE *symtab, ION_STRING *name, SID sid, ION_SYMBOL **p_psym);
 
 iERR _ion_symbol_local_copy_same_owner(void *context, void *dst, void *src, int32_t data_size);
 iERR _ion_symbol_local_copy_new_owner(void *context, void *dst, void *src, int32_t data_size);

--- a/ionc/ion_symbol_table_impl.h
+++ b/ionc/ion_symbol_table_impl.h
@@ -28,7 +28,6 @@ extern "C" {
 struct _ion_symbol_table
 {
     void               *owner;          // this may be a reader, writer, catalog or itself
-    ION_CATALOG        *catalog;        // TODO a symbol table should support being in more than one catalog at once. Ideally, this reference would not be needed.
     BOOL                is_locked;
     BOOL                has_local_symbols;
     ION_STRING          name;
@@ -46,12 +45,18 @@ struct _ion_symbol_table
 
 };
 
-struct _ion_symbol_table_import
+struct _ion_symbol_table_import_descriptor
 {
     ION_STRING name;
     int32_t    version;
     int32_t    max_id;
 
+};
+
+struct _ion_symbol_table_import
+{
+    ION_SYMBOL_TABLE_IMPORT_DESCRIPTOR descriptor;  // Description of the import.
+    ION_SYMBOL_TABLE *shared_symbol_table;          // The resolved import. NULL if no match was found in the catalog.
 };
 
 // "locals" in ion_symbol_table.c
@@ -103,7 +108,7 @@ iERR _ion_symbol_table_local_load_symbol_struct (ION_READER *preader, hOWNER own
 iERR _ion_symbol_table_local_load_symbol_list   (ION_READER *preader, hOWNER owner, ION_COLLECTION *psymbol_list);
 
 iERR _ion_symbol_table_import_symbol_table_helper(ION_SYMBOL_TABLE *symtab, ION_SYMBOL_TABLE *import_symtab);
-iERR _ion_symbol_table_local_incorporate_symbols(ION_SYMBOL_TABLE *symtab, ION_CATALOG *catalog, ION_STRING *import_name, int32_t import_version, int32_t import_max_id);
+iERR _ion_symbol_table_local_incorporate_symbols(ION_SYMBOL_TABLE *symtab, ION_SYMBOL_TABLE *shared, int32_t import_max_id);
 iERR _ion_symbol_table_local_add_symbol_helper(ION_SYMBOL_TABLE *symtab, ION_STRING *name, SID sid, ION_SYMBOL_TABLE *symbol_owning_table, ION_SYMBOL **p_psym);
 
 iERR _ion_symbol_local_copy_same_owner(void *context, void *dst, void *src, int32_t data_size);

--- a/ionc/ion_writer_binary.c
+++ b/ionc/ion_writer_binary.c
@@ -1390,7 +1390,7 @@ iERR _ion_writer_binary_serialize_symbol_table(ION_SYMBOL_TABLE *psymtab, ION_ST
         for (;;) {
             ION_COLLECTION_NEXT(symbol_cursor, symbol);
             if (!symbol) break;
-            if (symbol->sid <= psymtab->flushed_max_id || symbol->psymtab != psymtab) continue;
+            if (symbol->sid <= psymtab->flushed_max_id) continue;
             symbol_list_len += ion_writer_binary_serialize_symbol_length(symbol);
         }
         ION_COLLECTION_CLOSE(symbol_cursor);
@@ -1511,7 +1511,7 @@ iERR _ion_writer_binary_serialize_symbol_table(ION_SYMBOL_TABLE *psymtab, ION_ST
         for (;;) {
             ION_COLLECTION_NEXT(symbol_cursor, symbol);
             if (!symbol) break;
-            if (symbol->sid <= psymtab->flushed_max_id || symbol->psymtab != psymtab) continue;
+            if (symbol->sid <= psymtab->flushed_max_id) continue;
             IONCHECK(ion_binary_write_string_with_td_byte(out, &symbol->value));
         }
         ION_COLLECTION_CLOSE(symbol_cursor);

--- a/ionc/ion_writer_binary.c
+++ b/ionc/ion_writer_binary.c
@@ -1367,7 +1367,7 @@ iERR _ion_writer_binary_serialize_symbol_table(ION_SYMBOL_TABLE *psymtab, ION_ST
             for (;;) {
                 ION_COLLECTION_NEXT(import_cursor, import);
                 if (!import) break;
-                import_len = ion_writer_binary_serialize_import_struct_length(import);
+                import_len = ion_writer_binary_serialize_import_struct_length(&import->descriptor);
                 if (import_len >= ION_lnIsVarLen) {
                     import_len += ion_binary_len_var_uint_64(import_len); // the overflow length if this is longer than 14
                 }
@@ -1476,7 +1476,7 @@ iERR _ion_writer_binary_serialize_symbol_table(ION_SYMBOL_TABLE *psymtab, ION_ST
                 ION_COLLECTION_NEXT(import_cursor, import);
                 if (!import) break;
 
-                import_len = ion_writer_binary_serialize_import_struct_length(import);
+                import_len = ion_writer_binary_serialize_import_struct_length(&import->descriptor);
                 if (import_len >= ION_lnIsVarLen) {
                     ION_PUT(out, makeTypeDescriptor(TID_STRUCT, ION_lnIsVarLen));
                     IONCHECK(ion_binary_write_var_uint_64(out, import_len));  // symtab has overflow length
@@ -1484,10 +1484,10 @@ iERR _ion_writer_binary_serialize_symbol_table(ION_SYMBOL_TABLE *psymtab, ION_ST
                     ION_PUT(out, makeTypeDescriptor(TID_STRUCT, import_len));
                 }
                 // now we write the name, version, and max id
-                IONCHECK(ion_binary_write_string_with_field_sid(out, ION_SYS_SID_NAME, &import->name));
-                IONCHECK(ion_binary_write_int32_with_field_sid(out, ION_SYS_SID_VERSION, import->version));
-                if (import->max_id > 0) {
-                    IONCHECK(ion_binary_write_int32_with_field_sid(out, ION_SYS_SID_MAX_ID, import->max_id));
+                IONCHECK(ion_binary_write_string_with_field_sid(out, ION_SYS_SID_NAME, &import->descriptor.name));
+                IONCHECK(ion_binary_write_int32_with_field_sid(out, ION_SYS_SID_VERSION, import->descriptor.version));
+                if (import->descriptor.max_id > 0) {
+                    IONCHECK(ion_binary_write_int32_with_field_sid(out, ION_SYS_SID_MAX_ID, import->descriptor.max_id));
                 }
             }
             ION_COLLECTION_CLOSE(import_cursor);
@@ -1525,7 +1525,7 @@ iERR _ion_writer_binary_serialize_symbol_table(ION_SYMBOL_TABLE *psymtab, ION_ST
     iRETURN;
 }
 
-int ion_writer_binary_serialize_import_struct_length(ION_SYMBOL_TABLE_IMPORT *import)
+int ion_writer_binary_serialize_import_struct_length(ION_SYMBOL_TABLE_IMPORT_DESCRIPTOR *import)
 {
     int len;
 

--- a/ionc/ion_writer_impl.h
+++ b/ionc/ion_writer_impl.h
@@ -107,6 +107,7 @@ typedef struct _ion_writer
     decContext         deccontext;                  // working context
 
     ION_CATALOG       *pcatalog;
+    ION_COLLECTION     _imported_symbol_tables; // Collection of ION_SYMBOL_TABLE*
     ION_SYMBOL_TABLE  *symbol_table;        // if there are local symbols defined this will be a seperately allocated table, and should be freed as we close the top level value
     BOOL               _local_symbol_table; // identifies the current symbol table as a symbol table that we'll have to free
     BOOL               _has_local_symbols;
@@ -317,7 +318,7 @@ iERR _ion_writer_binary_top_in_struct(ION_WRITER *bwriter, BOOL *p_is_in_struct)
 
 iERR _ion_writer_binary_flush_to_output(ION_WRITER *pwriter);
 iERR _ion_writer_binary_serialize_symbol_table(ION_SYMBOL_TABLE *psymtab, ION_STREAM *out, int *p_length);
-int   ion_writer_binary_serialize_import_struct_length(ION_SYMBOL_TABLE_IMPORT *import);
+int   ion_writer_binary_serialize_import_struct_length(ION_SYMBOL_TABLE_IMPORT_DESCRIPTOR *import);
 int   ion_writer_binary_serialize_symbol_length(ION_SYMBOL *symbol);
 
 #ifdef __cplusplus

--- a/test/test_ion_symbol.cpp
+++ b/test/test_ion_symbol.cpp
@@ -20,14 +20,101 @@
 // the BinaryAndTextTest fixture and receive the is_binary flag with both the TRUE and FALSE values.
 //INSTANTIATE_TEST_CASE_BOOLEAN_PARAM(IonSymbolTable);
 
-TEST(IonSymbolTable, WriterAppendsLocalSymbolsOnFlush) {
-    hWRITER writer;
-    ION_STREAM *stream;
-    ION_STRING sym1, sym2, sym3, sym4;
+#define ION_SYMBOL_TEST_DECLARE_WRITER \
+    hWRITER writer; \
+    ION_STREAM *stream; \
     SIZE bytes_flushed;
 
-    hREADER reader;
-    BYTE *result;
+#define _ION_SYMBOL_TEST_REWRITE_AND_ASSERT_WITH_CATALOG(retrieve_data, cleanup_data, as_binary, expected, expected_len) \
+    hREADER reader; \
+    BYTE *result; \
+    ION_READER_OPTIONS reader_options; \
+    retrieve_data; \
+    ion_test_initialize_reader_options(&reader_options); \
+    reader_options.pcatalog = catalog; \
+    ION_ASSERT_OK(ion_reader_open_buffer(&reader, result, bytes_flushed, &reader_options)); \
+    ION_ASSERT_OK(ion_stream_open_memory_only(&stream)); \
+    writer_options.output_as_binary = as_binary; \
+    ION_ASSERT_OK(ion_writer_open(&writer, stream, &writer_options)); \
+    ION_ASSERT_OK(ion_writer_write_all_values(writer, reader)); \
+    ION_ASSERT_OK(ion_reader_close(reader)); \
+    cleanup_data; \
+    ION_ASSERT_OK(ion_test_writer_get_bytes(writer, stream, &result, &bytes_flushed)); \
+    if (as_binary) { \
+        assertBytesEqual(expected, expected_len, result, bytes_flushed); \
+    } \
+    else { \
+        assertStringsEqual(expected, (char *)result, bytes_flushed); \
+    } \
+    free(result);
+
+#define _ION_SYMBOL_TEST_REWRITE_AND_ASSERT(retrieve_data, cleanup_data, as_binary, expected, expected_len) \
+    ION_WRITER_OPTIONS writer_options; \
+    ion_test_initialize_writer_options(&writer_options); \
+    ION_CATALOG *catalog = NULL; \
+    _ION_SYMBOL_TEST_REWRITE_AND_ASSERT_WITH_CATALOG(retrieve_data, cleanup_data, as_binary, expected, expected_len);
+
+#define _ION_SYMBOL_TEST_REWRITE_FROM_BUFFER_AND_ASSERT_TEXT(base_macro, data, data_len, expected) \
+    ION_SYMBOL_TEST_DECLARE_WRITER; \
+    bytes_flushed = data_len; \
+    base_macro(result = data, /*do nothing*/, FALSE, expected, strlen(expected));
+
+#define ION_SYMBOL_TEST_REWRITE_WITH_CATALOG_FROM_BUFFER_AND_ASSERT_TEXT(data, data_len, expected) \
+    _ION_SYMBOL_TEST_REWRITE_FROM_BUFFER_AND_ASSERT_TEXT(_ION_SYMBOL_TEST_REWRITE_AND_ASSERT_WITH_CATALOG, data, data_len, expected);
+
+#define ION_SYMBOL_TEST_REWRITE_FROM_BUFFER_AND_ASSERT_TEXT(data, data_len, expected) \
+    _ION_SYMBOL_TEST_REWRITE_FROM_BUFFER_AND_ASSERT_TEXT(_ION_SYMBOL_TEST_REWRITE_AND_ASSERT, data, data_len, expected);
+
+#define _ION_SYMBOL_TEST_REWRITE_FROM_WRITER_AND_ASSERT_TEXT(base_macro, expected) \
+    base_macro( \
+        ION_ASSERT_OK(ion_test_writer_get_bytes(writer, stream, &result, &bytes_flushed)), \
+        free(result), FALSE, expected, strlen(expected) \
+    );
+
+#define ION_SYMBOL_TEST_REWRITE_WITH_CATALOG_FROM_WRITER_AND_ASSERT_TEXT(expected) \
+    _ION_SYMBOL_TEST_REWRITE_FROM_WRITER_AND_ASSERT_TEXT(_ION_SYMBOL_TEST_REWRITE_AND_ASSERT_WITH_CATALOG, expected);
+
+#define ION_SYMBOL_TEST_REWRITE_FROM_WRITER_AND_ASSERT_TEXT(expected) \
+    _ION_SYMBOL_TEST_REWRITE_FROM_WRITER_AND_ASSERT_TEXT(_ION_SYMBOL_TEST_REWRITE_AND_ASSERT, expected);
+
+#define ION_SYMBOL_TEST_POPULATE_CATALOG \
+    ION_SYMBOL_TABLE writer_imports[2]; \
+    hSYMTAB import1 = &writer_imports[0], import2 = &writer_imports[1]; \
+    ION_STRING import1_name, import2_name, sym1, sym2, sym3; \
+    SID sid; \
+    hCATALOG catalog; \
+    ION_ASSERT_OK(ion_string_from_cstr("import1", &import1_name)); \
+    ION_ASSERT_OK(ion_string_from_cstr("import2", &import2_name)); \
+    ION_ASSERT_OK(ion_string_from_cstr("sym1", &sym1)); \
+    ION_ASSERT_OK(ion_string_from_cstr("sym2", &sym2)); \
+    ION_ASSERT_OK(ion_string_from_cstr("sym3", &sym3)); \
+    ION_ASSERT_OK(ion_catalog_open(&catalog)); \
+    ION_ASSERT_OK(ion_symbol_table_open_with_type(&import1, catalog, ist_SHARED)); \
+    ION_ASSERT_OK(ion_symbol_table_open_with_type(&import2, catalog, ist_SHARED)); \
+    ION_ASSERT_OK(ion_symbol_table_set_name(import1, &import1_name)); \
+    ION_ASSERT_OK(ion_symbol_table_set_name(import2, &import2_name)); \
+    ION_ASSERT_OK(ion_symbol_table_set_version(import1, 1)); \
+    ION_ASSERT_OK(ion_symbol_table_set_version(import2, 1)); \
+    ION_ASSERT_OK(ion_symbol_table_add_symbol(import1, &sym1, &sid)); \
+    ION_ASSERT_OK(ion_symbol_table_add_symbol(import2, &sym2, &sid)); \
+    ION_ASSERT_OK(ion_symbol_table_add_symbol(import2, &sym3, &sid)); \
+    ION_ASSERT_OK(ion_catalog_add_symbol_table(catalog, import1)); \
+    ION_ASSERT_OK(ion_catalog_add_symbol_table(catalog, import2));
+
+#define ION_SYMBOL_TEST_OPEN_WRITER_WITH_IMPORTS(is_binary, imports, import_count) \
+    ION_SYMBOL_TEST_DECLARE_WRITER; \
+    ION_WRITER_OPTIONS writer_options; \
+    ion_test_initialize_writer_options(&writer_options); \
+    writer_options.encoding_psymbol_table_count = import_count; \
+    writer_options.encoding_psymbol_table = imports; \
+    writer_options.output_as_binary = is_binary; \
+    writer_options.pcatalog = catalog; \
+    ION_ASSERT_OK(ion_stream_open_memory_only(&stream)); \
+    ION_ASSERT_OK(ion_writer_open(&writer, stream, &writer_options));
+
+TEST(IonSymbolTable, WriterAppendsLocalSymbolsOnFlush) {
+    ION_SYMBOL_TEST_DECLARE_WRITER;
+    ION_STRING sym1, sym2, sym3, sym4;
 
     ION_ASSERT_OK(ion_string_from_cstr("sym1", &sym1));
     ION_ASSERT_OK(ion_string_from_cstr("sym2", &sym2));
@@ -53,72 +140,17 @@ TEST(IonSymbolTable, WriterAppendsLocalSymbolsOnFlush) {
     ION_ASSERT_OK(ion_writer_write_symbol(writer, &sym4));
     ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 10)); // sym1 is no longer in scope. This refers to sym4.
 
-    ION_ASSERT_OK(ion_test_writer_get_bytes(writer, stream, &result, &bytes_flushed));
-
-    //ion_test_print_bytes(result, bytes_flushed);
-
-    ION_ASSERT_OK(ion_test_new_reader(result, bytes_flushed, &reader));
-    ION_ASSERT_OK(ion_test_new_writer(&writer, &stream, FALSE));
-    ION_ASSERT_OK(ion_writer_write_all_values(writer, reader));
-    ION_ASSERT_OK(ion_reader_close(reader));
-
-    free(result);
-    ION_ASSERT_OK(ion_test_writer_get_bytes(writer, stream, &result, &bytes_flushed));
-
-    assertStringsEqual("sym1\nsym2\nsym3\nsym1\nsym3\nsym4\nsym4", (char *)result, bytes_flushed);
-    //std::cout << std::string((char *)result, (unsigned long)bytes_flushed) << std::endl;
-    free(result);
-
+    ION_SYMBOL_TEST_REWRITE_FROM_WRITER_AND_ASSERT_TEXT("sym1\nsym2\nsym3\nsym1\nsym3\nsym4\nsym4");
 }
 
 TEST(IonSymbolTable, WriterAppendsLocalSymbolsWithImportsOnFlush) {
     // Add imports to the initial table, then append
-    hWRITER writer;
-    ION_STREAM *stream;
-    SIZE bytes_flushed;
-    ION_WRITER_OPTIONS writer_options;
-    ION_SYMBOL_TABLE writer_imports[2];
-    hSYMTAB import1 = &writer_imports[0], import2 = &writer_imports[1];
-    ION_STRING import1_name, import2_name, sym1, sym2, sym3, sym4;
-    SID sid;
-    hCATALOG catalog;
+    ION_STRING sym4;
 
-    hREADER reader;
-    ION_READER_OPTIONS reader_options;
-    BYTE *result;
-
-    ION_ASSERT_OK(ion_string_from_cstr("import1", &import1_name));
-    ION_ASSERT_OK(ion_string_from_cstr("import2", &import2_name));
-    ION_ASSERT_OK(ion_string_from_cstr("sym1", &sym1));
-    ION_ASSERT_OK(ion_string_from_cstr("sym2", &sym2));
-    ION_ASSERT_OK(ion_string_from_cstr("sym3", &sym3));
     ION_ASSERT_OK(ion_string_from_cstr("sym4", &sym4));
 
-
-    ION_ASSERT_OK(ion_catalog_open(&catalog));
-    ION_ASSERT_OK(ion_symbol_table_open_with_type(&import1, catalog, ist_SHARED));
-    ION_ASSERT_OK(ion_symbol_table_open_with_type(&import2, catalog, ist_SHARED));
-
-    ION_ASSERT_OK(ion_symbol_table_set_name(import1, &import1_name));
-    ION_ASSERT_OK(ion_symbol_table_set_name(import2, &import2_name));
-
-    ION_ASSERT_OK(ion_symbol_table_set_version(import1, 1));
-    ION_ASSERT_OK(ion_symbol_table_set_version(import2, 1));
-
-    ION_ASSERT_OK(ion_symbol_table_add_symbol(import1, &sym1, &sid));
-    ION_ASSERT_OK(ion_symbol_table_add_symbol(import2, &sym2, &sid));
-    ION_ASSERT_OK(ion_symbol_table_add_symbol(import2, &sym3, &sid));
-
-    ION_ASSERT_OK(ion_catalog_add_symbol_table(catalog, import1));
-    ION_ASSERT_OK(ion_catalog_add_symbol_table(catalog, import2));
-
-    ion_test_initialize_writer_options(&writer_options);
-    writer_options.encoding_psymbol_table_count = 2;
-    writer_options.encoding_psymbol_table = import1;
-    writer_options.output_as_binary = TRUE;
-    writer_options.pcatalog = catalog;
-    ION_ASSERT_OK(ion_stream_open_memory_only(&stream));
-    ION_ASSERT_OK(ion_writer_open(&writer, stream, &writer_options));
+    ION_SYMBOL_TEST_POPULATE_CATALOG;
+    ION_SYMBOL_TEST_OPEN_WRITER_WITH_IMPORTS(TRUE, import1, 2);
 
     ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 10));
     ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 11));
@@ -132,61 +164,24 @@ TEST(IonSymbolTable, WriterAppendsLocalSymbolsWithImportsOnFlush) {
     ION_ASSERT_OK(ion_writer_write_symbol(writer, &sym4));
     ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 13)); // Corresponds to sym4.
 
-    ION_ASSERT_OK(ion_test_writer_get_bytes(writer, stream, &result, &bytes_flushed));
-
-    //ion_test_print_bytes(result, bytes_flushed);
-
-    ion_test_initialize_reader_options(&reader_options);
-    reader_options.pcatalog = catalog;
-    ION_ASSERT_OK(ion_reader_open_buffer(&reader, result, bytes_flushed, &reader_options));
-    ION_ASSERT_OK(ion_stream_open_memory_only(&stream));
-    writer_options.output_as_binary = FALSE;
-    ION_ASSERT_OK(ion_writer_open(&writer, stream, &writer_options));
-    ION_ASSERT_OK(ion_writer_write_all_values(writer, reader));
-    ION_ASSERT_OK(ion_reader_close(reader));
-
-    free(result);
-    ION_ASSERT_OK(ion_test_writer_get_bytes(writer, stream, &result, &bytes_flushed));
-
-    assertStringsEqual("sym1\nsym2\nsym3\nsym1\nsym3\nsym4\nsym4", (char *)result, bytes_flushed);
-    //std::cout << std::string((char *)result, (unsigned long)bytes_flushed) << std::endl;
-    free(result);
-    ION_ASSERT_OK(ion_symbol_table_close(import1));
-    ION_ASSERT_OK(ion_symbol_table_close(import2));
-    ION_ASSERT_OK(ion_catalog_close(catalog));
+    ION_SYMBOL_TEST_REWRITE_WITH_CATALOG_FROM_WRITER_AND_ASSERT_TEXT("sym1\nsym2\nsym3\nsym1\nsym3\nsym4\nsym4");
+    ION_ASSERT_OK(ion_catalog_close(catalog)); // Closes the catalog and releases its tables.
 }
 
 TEST(IonSymbolTable, AppendingAfterIVMDoesNothing) {
     // LST-append syntax when the current symbol table is the system symbol table does nothing; the imports field is
     // treated as if it doesn't exist.
     // $4 $ion_symbol_table::{symbols:["sym"], imports:$ion_symbol_table} $10
-    BYTE *ion_data = (BYTE *)"\xE0\x01\x00\xEA\x71\x04\xEC\x81\x83\xD9\x87\xB4\x83sym\x86\x71\x03\x71\x0A"; // len: 21
-    hREADER reader;
-    BYTE *result;
-    SIZE result_len;
-
-    hWRITER writer;
-    ION_STREAM *stream;
-
-    ION_ASSERT_OK(ion_test_new_reader(ion_data, 21, &reader));
-    ION_ASSERT_OK(ion_test_new_writer(&writer, &stream, FALSE));
-    ION_ASSERT_OK(ion_writer_write_all_values(writer, reader));
-    ION_ASSERT_OK(ion_reader_close(reader));
-    ION_ASSERT_OK(ion_test_writer_get_bytes(writer, stream, &result, &result_len));
-
-    assertStringsEqual("name\nsym", (char *)result, result_len);
-    free(result);
+    ION_SYMBOL_TEST_REWRITE_FROM_BUFFER_AND_ASSERT_TEXT(
+        (BYTE *)"\xE0\x01\x00\xEA\x71\x04\xEC\x81\x83\xD9\x87\xB4\x83sym\x86\x71\x03\x71\x0A", 21,
+        "name\nsym"
+    );
 }
 
 TEST(IonSymbolTable, AppendingNoSymbolsDoesNotWriteSymbolTable) {
     // If, after flush, there are no additional local symbols, there is no need to write another LST.
-    hWRITER writer;
-    ION_STREAM *stream;
+    ION_SYMBOL_TEST_DECLARE_WRITER;
     ION_STRING sym1, sym2;
-    SIZE bytes_flushed;
-
-    hREADER reader;
-    BYTE *result;
 
     ION_ASSERT_OK(ion_string_from_cstr("sym1", &sym1));
     ION_ASSERT_OK(ion_string_from_cstr("sym2", &sym2));
@@ -203,19 +198,151 @@ TEST(IonSymbolTable, AppendingNoSymbolsDoesNotWriteSymbolTable) {
     ION_ASSERT_OK(ion_writer_flush(writer, &bytes_flushed));
     ASSERT_EQ(1, bytes_flushed); // int 0 occupies a single byte. An LST would require more.
 
-    ION_ASSERT_OK(ion_test_writer_get_bytes(writer, stream, &result, &bytes_flushed));
+    ION_SYMBOL_TEST_REWRITE_FROM_WRITER_AND_ASSERT_TEXT("sym1\nsym2\n0");
+}
 
-    //ion_test_print_bytes(result, bytes_flushed);
+TEST(IonSymbolTable, SharedSymbolTableCanBelongToMultipleCatalogs) {
+    const char *ion_text_1 = "$ion_symbol_table::{imports:[{name:'''foo''', version: 1, max_id: 2}]} $10 $11";
+    const char *ion_text_2 = "$ion_symbol_table::{imports:[{name:'''bar''', version: 1, max_id: 10}, {name:'''foo''', version: 1, max_id: 2}]} $20 $21";
 
-    ION_ASSERT_OK(ion_test_new_reader(result, bytes_flushed, &reader));
-    ION_ASSERT_OK(ion_test_new_writer(&writer, &stream, FALSE));
-    ION_ASSERT_OK(ion_writer_write_all_values(writer, reader));
-    ION_ASSERT_OK(ion_reader_close(reader));
+    const char *foo_table = "$ion_shared_symbol_table::{name:'''foo''', version: 1, symbols:['''abc''', '''def''']}";
 
-    free(result);
-    ION_ASSERT_OK(ion_test_writer_get_bytes(writer, stream, &result, &bytes_flushed));
+    hCATALOG catalog_1, catalog_2;
+    hREADER reader_1, reader_2, shared_symtab_reader;
+    ION_READER_OPTIONS reader_options_1, reader_options_2;
+    hSYMTAB foo_table_shared;
+    ION_STRING abc, def, sid_10, sid_11, sid_20, sid_21;
+    ION_TYPE type;
 
-    assertStringsEqual("sym1\nsym2\n0", (char *)result, bytes_flushed);
-    //std::cout << std::string((char *)result, (unsigned long)bytes_flushed) << std::endl;
-    free(result);
+    ION_ASSERT_OK(ion_string_from_cstr("abc", &abc));
+    ION_ASSERT_OK(ion_string_from_cstr("def", &def));
+
+    ION_ASSERT_OK(ion_test_new_text_reader(foo_table, &shared_symtab_reader));
+    ION_ASSERT_OK(ion_reader_next(shared_symtab_reader, &type));
+    ION_ASSERT_OK(ion_symbol_table_load(shared_symtab_reader, NULL, &foo_table_shared));
+    ION_ASSERT_OK(ion_reader_close(shared_symtab_reader));
+
+    ION_ASSERT_OK(ion_catalog_open(&catalog_1));
+    ION_ASSERT_OK(ion_catalog_open(&catalog_2));
+
+    ION_ASSERT_OK(ion_catalog_add_symbol_table(catalog_1, foo_table_shared));
+    ION_ASSERT_OK(ion_catalog_add_symbol_table(catalog_2, foo_table_shared));
+
+    ion_test_initialize_reader_options(&reader_options_1);
+    reader_options_1.pcatalog = catalog_1;
+    ion_test_initialize_reader_options(&reader_options_2);
+    reader_options_2.pcatalog = catalog_2;
+
+    ION_ASSERT_OK(ion_reader_open_buffer(&reader_1, (BYTE *)ion_text_1, (SIZE)strlen(ion_text_1), &reader_options_1));
+    ION_ASSERT_OK(ion_reader_open_buffer(&reader_2, (BYTE *)ion_text_2, (SIZE)strlen(ion_text_2), &reader_options_2));
+
+    ION_ASSERT_OK(ion_reader_next(reader_1, &type));
+    ION_ASSERT_OK(ion_reader_next(reader_2, &type));
+
+    ION_ASSERT_OK(ion_reader_read_string(reader_1, &sid_10));
+    ION_ASSERT_OK(ion_reader_read_string(reader_2, &sid_20));
+
+    ION_ASSERT_OK(ion_reader_next(reader_1, &type));
+    ION_ASSERT_OK(ion_reader_next(reader_2, &type));
+
+    ION_ASSERT_OK(ion_reader_read_string(reader_1, &sid_11));
+    ION_ASSERT_OK(ion_reader_read_string(reader_2, &sid_21));
+
+    ASSERT_TRUE(assertIonStringEq(&sid_10, &sid_20));
+    ASSERT_TRUE(assertIonStringEq(&sid_10, &abc));
+
+    ASSERT_TRUE(assertIonStringEq(&sid_11, &sid_21));
+    ASSERT_TRUE(assertIonStringEq(&sid_11, &def));
+
+    ION_ASSERT_OK(ion_reader_close(reader_1));
+    ION_ASSERT_OK(ion_reader_close(reader_2));
+
+    ION_ASSERT_OK(ion_catalog_close(catalog_1));
+    ION_ASSERT_OK(ion_catalog_close(catalog_2));
+    ION_ASSERT_OK(ion_symbol_table_close(foo_table_shared));
+
+}
+
+TEST(IonSymbolTable, ManuallyWritingSymbolTableStructIsRecognizedAsSymbolTable) {
+    // If the user manually writes a struct that is a local symbol table, it should become the active LST, and it
+    // should be possible for the user to subsequently write any SID within the new table's max_id.
+    // It should also be possible for the user to subsequently write additional symbols within the same context and
+    // have them added to the symbol table. This means that instead of actually writing out the manually-written
+    // symbol table up front, it must be intercepted, turned into a mutable ION_SYMBOL_TABLE, and written out at
+    // flush as usual. Before the new context is started, the system should flush the previous one.
+    ION_SYMBOL_TEST_DECLARE_WRITER;
+
+    ION_STRING sym1, sym2;
+    ION_ASSERT_OK(ion_string_from_cstr("sym1", &sym1));
+    ION_ASSERT_OK(ion_string_from_cstr("sym2", &sym2));
+
+    ION_ASSERT_OK(ion_test_new_writer(&writer, &stream, TRUE));
+    ION_ASSERT_OK(ion_writer_add_annotation_sid(writer, ION_SYS_SID_SYMBOL_TABLE)); // $ion_symbol_table
+    ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
+    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_SYMBOLS));
+    ION_ASSERT_OK(ion_writer_start_container(writer, tid_LIST));
+    ION_ASSERT_OK(ion_writer_write_string(writer, &sym1));
+    ION_ASSERT_OK(ion_writer_write_string(writer, &sym2));
+    ION_ASSERT_OK(ion_writer_finish_container(writer)); // end symbols list
+    ION_ASSERT_OK(ion_writer_finish_container(writer)); // end LST struct
+
+    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 10)); // This maps to sym1.
+    // TODO implement this functionality
+}
+
+TEST(IonSymbolTable, ManuallyWriteSymbolTableAppendSucceeds) {
+    // Like the previous test, but the manually written symbol table contains appended symbols.
+}
+
+TEST(IonSymbolTable, TextWritingKnownSymbolFromSIDResolvesText) {
+    // If the user writes a SID in the import range and that import is found in the catalog, that SID should be resolved
+    // to its text representation. There is no need to include the local symbol table in the stream.
+}
+
+TEST(IonSymbolTable, TextWritingSymbolFromNotFoundImportWritesIdentifierAndForcesSymbolTable) {
+    // If the user writes a SID in the import range and that import is not found in the catalog, the SID must be
+    // written as $<int> and the symbol table must be included in the stream. Future consumers may have access to
+    // that import and be able to resolve the identifier.
+}
+
+TEST(IonSymbolTable, WritingOutOfRangeSIDFails) {
+    // For both text and binary, manually writing a SID (from a pure SID or ION_SYMBOL with NULL text) that is out of
+    // range of the current symbol table context should raise an error, since this condition must also raise an error
+    // on read.
+}
+
+TEST(IonSymbolTable, SettingSharedSymbolTableMaxIdLargerThanLengthOfSymbolsExtendsWithUnknownSymbols) {
+    // If the user adds N symbols to a shared symbol table and sets that symbol table's maxId to N + M, there should
+    // be M SIDs with unknown text.
+}
+
+TEST(IonSymbolTable, NullSlotsInSharedSymbolTableAreSIDsWithUnknownText) {
+    // A shared symbol table with NULL elements within its symbols list are valid SID mappings with unknown text.
+}
+
+TEST(IonSymbolTable, WriterWithImportsListIncludesThoseImportsWithEveryNewLSTContext) {
+    // A writer that was constructed with a list of shared imports to use must include those imports in each new local
+    // symbol table context.
+    ION_STRING sym4;
+
+    ION_ASSERT_OK(ion_string_from_cstr("sym4", &sym4));
+
+    ION_SYMBOL_TEST_POPULATE_CATALOG;
+    ION_SYMBOL_TEST_OPEN_WRITER_WITH_IMPORTS(TRUE, import1, 2);
+
+    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 10));
+    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 11));
+    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 12));
+
+    ION_ASSERT_OK(ion_writer_finish(writer, &bytes_flushed));
+    ASSERT_NE(0, bytes_flushed);
+
+    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 10));
+    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 11));
+    ION_ASSERT_OK(ion_writer_write_symbol(writer, &sym3)); // sym3 is already in the symbol table, with SID 12
+    ION_ASSERT_OK(ion_writer_write_symbol(writer, &sym4));
+    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 13)); // Corresponds to sym4.
+
+    ION_SYMBOL_TEST_REWRITE_WITH_CATALOG_FROM_WRITER_AND_ASSERT_TEXT("sym1\nsym2\nsym3\nsym1\nsym2\nsym3\nsym4\nsym4");
+    ION_ASSERT_OK(ion_catalog_close(catalog)); // Closes the catalog and releases its tables.
 }

--- a/tools/ionizer/ionizer.c
+++ b/tools/ionizer/ionizer.c
@@ -130,8 +130,6 @@ fail:// this is iRETURN expanded so I can set a break point on it
         ionizer_stop_timing();
     }
 
-    ion_symbol_table_free_system_table();
-
     if (non_argv) free(non_argv);
     return err;
 }
@@ -499,7 +497,6 @@ iERR ionizer_load_catalog_list(hCATALOG *p_catalog)
     hREADER               hreader;
     ION_TYPE              t;
     BOOL                  is_symtab;
-    BOOL                  saved_flag_return_shared_symbol_tables;
     hSYMTAB               hsymtab;
     ION_STRING            annotion_name;
 
@@ -507,11 +504,6 @@ iERR ionizer_load_catalog_list(hCATALOG *p_catalog)
     ion_string_assign_cstr(&annotion_name, ION_SYS_SYMBOL_SHARED_SYMBOL_TABLE, ION_SYS_STRLEN_SHARED_SYMBOL_TABLE);
 
     CHECK(ion_catalog_open(&catalog), "create empty catalog");
-
-    // since we (Ionize) want to handle the symbol table management we need to
-    // tell the reader no to bother (we'll go back to what others wanted later)
-    saved_flag_return_shared_symbol_tables = g_reader_options.return_shared_symbol_tables;
-    g_reader_options.return_shared_symbol_tables = TRUE;
 
     for (str_node=g_ionizer_catalogs; str_node; str_node = str_node->next) 
     {
@@ -521,9 +513,7 @@ iERR ionizer_load_catalog_list(hCATALOG *p_catalog)
             fprintf(stderr, "ERROR: can't open the catalog file: %s\n", str_node->str);
             FAILWITH(IERR_CANT_FIND_FILE);
         }
-// XXX        g_reader_options.return_shared_symbol_tables = TRUE;
         CHECK(ionizer_reader_open_fstream(&reader, f_catalog, &g_reader_options), "catalog reader open failed");
-// XXX        g_reader_options.return_shared_symbol_tables = FALSE;
 
         // read the file and load all structs with the ion_shared_symbol_table
         // annotation into the hcatalog
@@ -541,9 +531,6 @@ iERR ionizer_load_catalog_list(hCATALOG *p_catalog)
         CHECK(ionizer_reader_close_fstream(reader), "closing a catalog reader");
         // ion_reader_close_fstream closes this already: fclose(f_catalog);
     }
-
-    // now return to our regularly scheduled behavior ...
-    g_reader_options.return_shared_symbol_tables = saved_flag_return_shared_symbol_tables;
 
     *p_catalog = catalog;
     iRETURN;


### PR DESCRIPTION
Also removes some dead code, adds documentation, and adds some testing TODOs.