### PR TITLE
Forces the writer to raise an error if the user attempts to write an out-of-range symbol ID.

### DIFF
--- a/ionc/ion_writer_impl.h
+++ b/ionc/ion_writer_impl.h
@@ -206,6 +206,7 @@ iERR _ion_writer_write_decimal_helper(ION_WRITER *pwriter, decQuad *value);
 iERR _ion_writer_write_ion_decimal_helper(ION_WRITER *pwriter, ION_DECIMAL *value);
 iERR _ion_writer_write_timestamp_helper(ION_WRITER *pwriter, ION_TIMESTAMP *value);
 iERR _ion_writer_write_symbol_id_helper(ION_WRITER *pwriter, SID value);
+iERR _ion_writer_validate_symbol_id(ION_WRITER *pwriter, SID sid);
 iERR _ion_writer_write_symbol_helper(ION_WRITER *pwriter, ION_STRING *symbol);
 iERR _ion_writer_write_string_helper(ION_WRITER *pwriter, ION_STRING *pstr);
 iERR _ion_writer_write_clob_helper(ION_WRITER *pwriter, BYTE *p_buf, SIZE length);

--- a/ionc/ion_writer_text.c
+++ b/ionc/ion_writer_text.c
@@ -650,13 +650,8 @@ iERR _ion_writer_text_write_symbol_id(ION_WRITER *pwriter, SID sid)
     ASSERT(pwriter);
 
     // if they passed us a reasonable sid we'll look it up (otherwise str will still be null)
-    if (sid != UNKNOWN_SID) {
-        IONCHECK(_ion_writer_get_symbol_table_helper(pwriter, &symtab));
-        if (sid > symtab->max_id) {
-            FAILWITHMSG(IERR_INVALID_SYMBOL, "Attempted to write out-of-range symbol ID.");
-        }
-        IONCHECK(_ion_symbol_table_find_by_sid_force(symtab, sid, &pstr));
-    }
+    IONCHECK(_ion_writer_get_symbol_table_helper(pwriter, &symtab));
+    IONCHECK(_ion_symbol_table_find_by_sid_force(symtab, sid, &pstr));
 
     // Even symbols with unknown text will now have a string value (e.g. $10). Out-of-range (illegal) symbols have
     // already raised an error.


### PR DESCRIPTION
This prevents the writer from writing Ion data that can never successfully be read; data with symbol IDs out of range of the current local symbol table context MUST raise an error on read.