### PR TITLE
Writes a text LST when the writer has imports; ensures the import declaration's max_id is authoritative; prohibits writer flush/finish/close when a value is in progress.

### DIFF
--- a/ionc/inc/ion_writer.h
+++ b/ionc/inc/ion_writer.h
@@ -191,8 +191,8 @@ ION_API_EXPORT iERR ion_writer_write_all_values     (hWRITER hwriter, hREADER hr
 
 /**
  * Flushes pending bytes without forcing an Ion Version Marker or ending the current symbol table context.
- * If writer was created using open_stream, also flushes write buffer to stream. If not at the top level, flushing a
- * binary writer will do nothing.
+ * If writer was created using open_stream, also flushes write buffer to stream. If any value is in-progress, flushing
+ * any writer is an error.
  * @param   p_bytes_flushed - the number of bytes written into the buffer/stream.
  */
 ION_API_EXPORT iERR ion_writer_flush                (hWRITER hwriter, SIZE *p_bytes_flushed);
@@ -200,15 +200,15 @@ ION_API_EXPORT iERR ion_writer_flush                (hWRITER hwriter, SIZE *p_by
 /**
  * Flushes pending bytes, ending the current symbol table context and forcing an Ion Version Marker if the writer
  * continues writing to the stream. If writer was created using open_stream, also flushes write buffer to stream.
- * If not at the top level, finishing any writer is an error.
+ * If any value is in-progress, finishing any writer is an error.
  * @param   p_bytes_flushed - the number of bytes written into the buffer/stream.
  */
 ION_API_EXPORT iERR ion_writer_finish               (hWRITER hwriter, SIZE *p_bytes_flushed);
 
 /**
  * Finishes the writer, frees the writer's associated resources, and finally frees the writer itself. The writer may
- * not continue writing to the stream after this function is called. If not at the top level, closing any writer is an
- * error.
+ * not continue writing to the stream after this function is called. If any value is in-progress, closing any writer is
+ * an error.
  */
 ION_API_EXPORT iERR ion_writer_close                (hWRITER hwriter);
 

--- a/ionc/ion_reader.c
+++ b/ionc/ion_reader.c
@@ -1857,7 +1857,7 @@ iERR _ion_reader_process_possible_symbol_table(ION_READER *preader, BOOL *is_sym
      * readers must throw if the annotation wrapper is malformed (e.g. has no annotation SIDs).
      */
     iENTER;
-    BOOL              is_local_symbol_table, has_previous_local_symbol_table = TRUE;
+    BOOL              has_previous_local_symbol_table = TRUE;
     ION_SYMBOL_TABLE *system, *local = NULL;
     void             *owner = NULL;
     ION_STRING        annotation;
@@ -1868,9 +1868,9 @@ iERR _ion_reader_process_possible_symbol_table(ION_READER *preader, BOOL *is_sym
     // TODO - this should be done with flags set while we're
     // recognizing the annotations below (in the fullness of time)
     IONCHECK(_ion_reader_get_an_annotation_helper(preader, 0, &annotation));
-    is_local_symbol_table = ION_STRING_EQUALS(&ION_SYMBOL_SYMBOL_TABLE_STRING, &annotation);
+    *is_symbol_table = ION_STRING_EQUALS(&ION_SYMBOL_SYMBOL_TABLE_STRING, &annotation);
     // if we return system values we don't process them
-    if (is_local_symbol_table && preader->options.return_system_values != TRUE) {
+    if (*is_symbol_table && preader->options.return_system_values != TRUE) {
         // this is a local symbol table and the user has not *insisted* we return system values, so we process it
         IONCHECK(_ion_symbol_table_get_system_symbol_helper(&system, ION_SYSTEM_VERSION));
         IONCHECK(_ion_reader_allocate_pool_owner(&owner));
@@ -1892,7 +1892,6 @@ iERR _ion_reader_process_possible_symbol_table(ION_READER *preader, BOOL *is_sym
         preader->_local_symtab_pool = owner;
         preader->_current_symtab = local;
     }
-    *is_symbol_table = is_local_symbol_table;
     iRETURN;
 }
 

--- a/ionc/ion_reader_text.c
+++ b/ionc/ion_reader_text.c
@@ -187,18 +187,7 @@ iERR _ion_reader_text_next(ION_READER *preader, ION_TYPE *p_value_type)
 {
     iENTER;
     ION_TEXT_READER *text = &preader->typed_reader.text;
-    ION_TYPE         t   = tid_none;
     ION_SUB_TYPE     ist = IST_NONE;
-
-#ifdef DEBUG
-    static long _value_counter = 0;
-
-    _value_counter++;
-    if (_value_counter == 99999912) { // 7238 || scanner->_has_marked_value) {
-        ion_helper_breakpoint();
-        _value_counter = _value_counter + 0;;
-    }
-#endif
 
     ASSERT(preader);
 

--- a/ionc/ion_string.c
+++ b/ionc/ion_string.c
@@ -61,12 +61,14 @@ ION_STRING *ion_string_assign_cstr(ION_STRING *str, char *val, SIZE len)
 }
 
 // assignment with ownership move
-// was" iERR ion_string_copy_to_owner(hOWNER owner, ION_STRING *dst, ION_STRING *src)
 iERR  ion_string_copy_to_owner(hOWNER owner, ION_STRING *dst, ION_STRING *src)
 {
     iENTER;
 
-    dst->length = 0;
+    ASSERT(dst != NULL);
+
+    ION_STRING_INIT(dst);
+    if (ION_STRING_IS_NULL(src)) SUCCEED();
     dst->value = ion_alloc_with_owner(owner, src->length);
     if (dst->value == NULL) FAILWITH(IERR_NO_MEMORY);
     memcpy(dst->value, src->value, src->length);

--- a/ionc/ion_symbol_table_impl.h
+++ b/ionc/ion_symbol_table_impl.h
@@ -87,7 +87,7 @@ iERR _ion_symbol_table_find_by_sid_helper(ION_SYMBOL_TABLE *symtab, SID sid, ION
 iERR _ion_symbol_table_find_symbol_by_sid_helper(ION_SYMBOL_TABLE *symtab, SID sid, ION_SYMBOL **p_sym);
 iERR _ion_symbol_table_get_unknown_symbol_name(ION_SYMBOL_TABLE *symtab, SID sid, ION_STRING **p_name);
 iERR _ion_symbol_table_find_by_sid_force(ION_SYMBOL_TABLE *symtab, SID sid, ION_STRING **p_name);
-void _ion_symbol_table_allocate_symbol_unknown_text(ION_SYMBOL_TABLE *symtab, SID sid, ION_SYMBOL **p_symbol);
+void _ion_symbol_table_allocate_symbol_unknown_text(hOWNER owner, SID sid, ION_SYMBOL **p_symbol);
 iERR _ion_symbol_table_is_symbol_known_helper(ION_SYMBOL_TABLE *symtab, SID sid, BOOL *p_is_known);
 iERR _ion_symbol_table_add_symbol_helper(ION_SYMBOL_TABLE *symtab, ION_STRING *name, SID *p_sid);
 iERR _ion_symbol_table_close_helper(ION_SYMBOL_TABLE *symtab);

--- a/test/test_ion_decimal.cpp
+++ b/test/test_ion_decimal.cpp
@@ -207,7 +207,7 @@ TEST(IonTextDecimal, ReaderAlwaysPreservesUpTo34Digits) {
     // Because decQuads are statically sized, decimals with <= DECQUAD_Pmax digits of precision never need to overflow;
     // they can always be accommodated in a decQuad. This test asserts that precision is preserved even when the context
     // is configured with fewer digits than DECQUAD_Pmax.
-    const char *text_decimal = "1.234\n5.678";
+    const char *text_decimal = "1.234 5.678";
     ION_DECIMAL ion_decimal;
     decQuad quad;
 
@@ -231,7 +231,7 @@ TEST(IonBinaryDecimal, ReaderAlwaysPreservesUpTo34Digits) {
     // Because decQuads are statically sized, decimals with <= DECQUAD_Pmax digits of precision never need to overflow;
     // they ca always be accommodated in a decQuad. This test asserts that precision is preserved even when the context
     // is configured with fewer digits than DECQUAD_Pmax.
-    const char *text_decimal = "1.234\n5.678";
+    const char *text_decimal = "1.234 5.678";
     ION_DECIMAL ion_decimal_before, ion_decimal_after;
     decQuad quad_before, quad_after;
     BOOL decimal_equals, quad_equals;
@@ -269,7 +269,7 @@ TEST(IonBinaryDecimal, ReaderAlwaysPreservesUpTo34Digits) {
 }
 
 TEST(IonDecimal, WriteAllValues) {
-    const char *text_decimal = "1.1999999999999999555910790149937383830547332763671875\n-1d+123";
+    const char *text_decimal = "1.1999999999999999555910790149937383830547332763671875 -1d+123";
     ION_DECIMAL ion_decimal;
 
     ION_DECIMAL_READER_INIT;

--- a/test/test_ion_text.cpp
+++ b/test/test_ion_text.cpp
@@ -90,7 +90,7 @@ TEST(IonTextSymbol, WriterWritesSymbolValueZero) {
     ION_ASSERT_OK(ion_writer_write_symbol(writer, &symbol_zero));
     ION_ASSERT_OK(ion_test_writer_get_bytes(writer, ion_stream, &result, &result_len));
 
-    assertStringsEqual("$0\n'$0'", (char *)result, result_len);
+    assertStringsEqual("$0 '$0'", (char *)result, result_len);
 }
 
 TEST(IonTextSymbol, WriterWritesSymbolAnnotationZero) {
@@ -113,7 +113,7 @@ TEST(IonTextSymbol, WriterWritesSymbolAnnotationZero) {
 
     ION_ASSERT_OK(ion_test_writer_get_bytes(writer, ion_stream, &result, &result_len));
 
-    assertStringsEqual("'$0'::$0\n$0::$0::'$0'", (char *)result, result_len);
+    assertStringsEqual("'$0'::$0 $0::$0::'$0'", (char *)result, result_len);
 }
 
 TEST(IonTextSymbol, WriterWritesSymbolFieldNameZero) {
@@ -326,7 +326,7 @@ TEST(IonTextSymbol, WriterWritesSymbolValueIVMTextAsNoOp) {
 
     ION_ASSERT_OK(ion_test_writer_get_bytes(writer, ion_stream, &result, &result_len));
 
-    assertStringsEqual("123\n456\n789", (char *)result, result_len);
+    assertStringsEqual("123 456 789", (char *)result, result_len);
 }
 
 TEST(IonTextSymbol, ReaderReadsSymbolValueIVM) {
@@ -423,7 +423,7 @@ TEST(IonTextSymbol, WriterWritesKeywordsAsQuotedSymbols) {
 
     ION_ASSERT_OK(ion_test_writer_get_bytes(writer, ion_stream, &result, &result_len));
 
-    assertStringsEqual("'false'\n'true'\n'nan'", (char *)result, result_len);
+    assertStringsEqual("'false' 'true' 'nan'", (char *)result, result_len);
 }
 
 TEST(IonTextSymbol, ReaderChoosesLowestSIDForDuplicateSymbol) {


### PR DESCRIPTION
In order to avoid having to buffer text streams, when text writers are provided shared symbol tables, a local symbol table that declares those imports will always be written (before the first value is written).

The max_id of the import declaration must be authoritative; this helps allow forward-compatibility when symbols are appended to a given shared symbol table.

Flush/finish must happen between top-level values because changes to the local symbol table context can only occur at the top level.