### PR TITLE
Makes writer options' imports list an ION_COLLECTION of ION_SYMBOL_TABLE_IMPORT to support writing with not-found imports.

### DIFF
--- a/ionc/inc/ion_writer.h
+++ b/ionc/inc/ion_writer.h
@@ -85,17 +85,14 @@ typedef struct _ion_writer_options
      */
     ION_CATALOG *pcatalog;
 
-    /** Pointer to the first element of an array of shared symbol tables that the writer will import into each new local
-     *  symbol table context. The size of the array is specified by `encoding_psymbol_table_count`. The user owns the
-     *  associated memory, and must ensure it stays in scope for the lifetime of the writer.
+    /** An ordered list of ION_SYMBOL_TABLE_IMPORT that the writer will import into each new local
+     *  symbol table context. Should be initialized by calling `ion_writer_options_initialize_shared_imports`,
+     *  populated by calling `ion_writer_options_add_shared_imports` and/or
+     *  `ion_writer_options_add_shared_imports_symbol_tables`, and freed by calling
+     *  `ion_writer_options_close_shared_imports`.
      *  NOTE: the system symbol table is always used as the first import; it need not be provided here.
      */
-    ION_SYMBOL_TABLE *encoding_psymbol_table;
-
-    /** Number of symbol tables in the `encoding_psymbol_table` array.
-     *
-     */
-    SIZE encoding_psymbol_table_count;
+    ION_COLLECTION encoding_psymbol_table;
 
     /** Handle to the decNumber context for the writer to use. This allows configuration of the maximum number of
      * decimal digits, decimal exponent range, etc. See decContextDefault in decContext.h for simple initialization.
@@ -109,6 +106,31 @@ typedef struct _ion_writer_options
 
 } ION_WRITER_OPTIONS;
 
+
+/**
+ * Initializes the options' imports list. This must be done before calling `ion_writer_options_add_*`.
+ * NOTE: This does NOT need to be called if the writer does not need to use shared imports.
+ * @param options - The writer options containing the imports list to initialize.
+ */
+ION_API_EXPORT iERR ion_writer_options_initialize_shared_imports(ION_WRITER_OPTIONS *options);
+
+/**
+ * Adds the imports from the given collection of ION_SYMBOL_TABLE_IMPORT to the options' imports list.
+ * `ion_writer_options_initialize_shared_imports` must have been called first.
+ */
+ION_API_EXPORT iERR ion_writer_options_add_shared_imports(ION_WRITER_OPTIONS *options, ION_COLLECTION *imports);
+
+/**
+ * Adds the given array of ION_SYMBOL_TABLE (which must be shared symbol tables) to the options' imports list.
+ * `ion_writer_options_initialize_shared_imports` must have been called first.
+ */
+ION_API_EXPORT iERR ion_writer_options_add_shared_imports_symbol_tables(ION_WRITER_OPTIONS *options, ION_SYMBOL_TABLE **imports, SIZE imports_count);
+
+/**
+ * Frees the options' imports list. This must be done once the options are no longer needed, and only if
+ * `ion_writer_options_initialize_shared_imports` was called.
+ */
+ION_API_EXPORT iERR ion_writer_options_close_shared_imports(ION_WRITER_OPTIONS *options);
 
 /** Ion Writer interfaces. Takes a byte buffer and length which
  *  will contain the text or binary content, returns handle to a writer.

--- a/ionc/ion_symbol_table_impl.h
+++ b/ionc/ion_symbol_table_impl.h
@@ -107,7 +107,7 @@ iERR _ion_symbol_table_local_load_import_list   (ION_READER *preader, hOWNER own
 iERR _ion_symbol_table_local_load_symbol_struct (ION_READER *preader, hOWNER owner, ION_COLLECTION *psymbol_list);
 iERR _ion_symbol_table_local_load_symbol_list   (ION_READER *preader, hOWNER owner, ION_COLLECTION *psymbol_list);
 
-iERR _ion_symbol_table_import_symbol_table_helper(ION_SYMBOL_TABLE *symtab, ION_SYMBOL_TABLE *import_symtab);
+iERR _ion_symbol_table_import_symbol_table_helper(ION_SYMBOL_TABLE *symtab, ION_SYMBOL_TABLE *import_symtab, ION_STRING *import_name, int32_t import_version, int32_t import_max_id);
 iERR _ion_symbol_table_local_incorporate_symbols(ION_SYMBOL_TABLE *symtab, ION_SYMBOL_TABLE *shared, int32_t import_max_id);
 iERR _ion_symbol_table_local_add_symbol_helper(ION_SYMBOL_TABLE *symtab, ION_STRING *name, SID sid, ION_SYMBOL **p_psym);
 

--- a/ionc/ion_writer_impl.h
+++ b/ionc/ion_writer_impl.h
@@ -107,7 +107,7 @@ typedef struct _ion_writer
     decContext         deccontext;                  // working context
 
     ION_CATALOG       *pcatalog;
-    ION_COLLECTION     _imported_symbol_tables; // Collection of ION_SYMBOL_TABLE*
+    ION_COLLECTION     _imported_symbol_tables; // Collection of ION_SYMBOL_TABLE_IMPORT
     ION_SYMBOL_TABLE  *symbol_table;        // if there are local symbols defined this will be a seperately allocated table, and should be freed as we close the top level value
     BOOL               _local_symbol_table; // identifies the current symbol table as a symbol table that we'll have to free
     BOOL               _has_local_symbols;

--- a/test/ion_assert.cpp
+++ b/test/ion_assert.cpp
@@ -306,7 +306,7 @@ void assertBytesEqual(const char *expected, SIZE expected_len, const BYTE *actua
 }
 
 void assertStringsEqual(const char *expected, const char *actual, SIZE actual_len) {
-    BOOL strings_not_equal = strncmp(expected, actual, (size_t)actual_len);
+    BOOL strings_not_equal = strlen(expected) != actual_len || strncmp(expected, actual, (size_t)actual_len);
     if (strings_not_equal) {
         ASSERT_FALSE(strings_not_equal) << std::string(expected) << " vs. " << std::endl
                                         << std::string(actual, (unsigned long)actual_len);

--- a/tools/ionizer/ionizer.c
+++ b/tools/ionizer/ionizer.c
@@ -130,6 +130,7 @@ fail:// this is iRETURN expanded so I can set a break point on it
         ionizer_stop_timing();
     }
 
+    ion_writer_options_close_shared_imports(&g_writer_options);
     if (non_argv) free(non_argv);
     return err;
 }
@@ -602,8 +603,8 @@ iERR ionizer_load_symbol_table(void)
         fprintf(stderr, "ERROR - couldn't find the symbol table \"%s\" in the catalog or as a file\n", g_ionizer_writer_symtab);
         FAILWITH(IERR_CANT_FIND_FILE);
     }
-    g_writer_options.encoding_psymbol_table = (ION_SYMBOL_TABLE *)g_writer_hsymtab;  // HACK - TODO - do the same that that we do for catalog
-    g_writer_options.encoding_psymbol_table_count = 1;
+    IONCHECK(ion_writer_options_initialize_shared_imports(&g_writer_options));
+    IONCHECK(ion_writer_options_add_shared_imports_symbol_tables(&g_writer_options, &g_writer_hsymtab, 1));
 
     iRETURN;
 }


### PR DESCRIPTION
The writer should be able to write symbol tokens that map to shared symbol table imports even when those shared symbol table imports can't be resolved. A reader that later consumes the data will be able to resolve the symbol tables to known text if it can resolve the import declarations.