### PR TITLE
 Adds support for intercepting user-written local symbol tables.

### DIFF
--- a/ionc/inc/ion_writer.h
+++ b/ionc/inc/ion_writer.h
@@ -229,8 +229,8 @@ ION_API_EXPORT iERR ion_writer_finish               (hWRITER hwriter, SIZE *p_by
 
 /**
  * Finishes the writer, frees the writer's associated resources, and finally frees the writer itself. The writer may
- * not continue writing to the stream after this function is called. If any value is in-progress, closing any writer is
- * an error.
+ * not continue writing to the stream after this function is called. If any value is in-progress, closing any writer
+ * raises an error, but still frees the writer and any associated memory.
  */
 ION_API_EXPORT iERR ion_writer_close                (hWRITER hwriter);
 

--- a/ionc/ion_symbol_table.c
+++ b/ionc/ion_symbol_table.c
@@ -468,6 +468,7 @@ iERR _ion_symbol_table_append(ION_READER *preader, hOWNER owner, ION_SYMBOL_TABL
                 ION_STRING_ASSIGN(&appended_symbol->value, &symbol_to_append->value);
                 appended_symbol->sid = UNKNOWN_SID; // This is assigned correctly later.
             }
+            ION_COLLECTION_CLOSE(symbol_cursor);
         }
         // This overwrites p_symtab's reference, which will be cleaned up when its owner is freed.
         *p_symtab = cloned;

--- a/ionc/ion_writer_impl.h
+++ b/ionc/ion_writer_impl.h
@@ -64,6 +64,34 @@ typedef enum _ION_WRITER_OUTPUT_TYPE {
     iWOT_PRETTY_UTF8 = 3
 } ION_WRITER_OUTPUT_TYPE;
 
+typedef enum _ION_WRITER_SYMTAB_INTERCEPT_STATE {
+    iWSIS_NONE               = 0x00,
+    iWSIS_IN_LST_STRUCT      = 0x01,
+    iWSIS_LOCAL_SYMBOLS      = 0x02,
+    iWSIS_IMPORTS            = 0x04,
+    iWSIS_IN_IMPORTS_STRUCT  = 0x08,
+    iWSIS_IMPORT_VERSION     = 0x10,
+    iWSIS_IMPORT_MAX_ID      = 0x20,
+    iWSIS_IMPORT_NAME        = 0x40,
+} ION_WRITER_SYMTAB_INTERCEPT_STATE;
+
+#define ION_WRITER_SI_HAS_LOCAL_SYMBOLS(flags) ((flags) & iWSIS_LOCAL_SYMBOLS)
+#define ION_WRITER_SI_HAS_IMPORTS(flags) ((flags) & iWSIS_IMPORTS)
+#define ION_WRITER_SI_HAS_IMPORT_SYMBOLS(flags) ((flags) & iWSIS_IMPORT_SYMBOLS)
+#define ION_WRITER_SI_HAS_IMPORT_VERSION(flags) ((flags) & iWSIS_IMPORT_VERSION
+#define ION_WRITER_SI_HAS_IMPORT_MAX_ID(flags) ((flags) & iWSIS_IMPORT_MAX_ID)
+
+#define ION_WRITER_SI_COMPLETE_LOCAL_SYMBOLS(flags) flags |= iWSIS_LOCAL_SYMBOLS
+#define ION_WRITER_SI_COMPLETE_IMPORTS(flags) flags |= iWSIS_IMPORTS
+#define ION_WRITER_SI_COMPLETE_IMPORT_NAME(flags) flags |= iWSIS_IMPORT_NAME
+#define ION_WRITER_SI_COMPLETE_IMPORT_VERSION(flags) flags |= iWSIS_IMPORT_VERSION
+#define ION_WRITER_SI_COMPLETE_IMPORT_MAX_ID(flags) flags |= iWSIS_IMPORT_MAX_ID
+#define ION_WRITER_SI_COMPLETE_IMPORT(flags) flags &= iWSIS_LOCAL_SYMBOLS
+
+#define ION_WRITER_SI_CLEAR_STATE(writer) \
+    writer->_current_symtab_intercept_state = iWSIS_NONE; \
+    writer->_completed_symtab_intercept_states = 0;
+
 typedef struct _ion_text_writer
 {
     BOOL       _no_output;           // is true until at least 1 char is written to the stream
@@ -111,6 +139,9 @@ typedef struct _ion_writer
     ION_SYMBOL_TABLE  *symbol_table;        // if there are local symbols defined this will be a seperately allocated table, and should be freed as we close the top level value
     BOOL               _local_symbol_table; // identifies the current symbol table as a symbol table that we'll have to free
     BOOL               _has_local_symbols;
+
+    ION_WRITER_SYMTAB_INTERCEPT_STATE   _current_symtab_intercept_state;
+    int8_t                              _completed_symtab_intercept_states;
 
     ION_TEMP_BUFFER    temp_buffer;         // holds field names and annotations until the writer needs them
     void              *_temp_entity_pool;   // memory pool for top level objects that we'll throw away during flush
@@ -197,7 +228,6 @@ iERR _ion_writer_write_annotation_sids_helper(ION_WRITER *pwriter, int32_t *p_si
 iERR _ion_writer_clear_annotations_helper(ION_WRITER *pwriter);
 iERR _ion_writer_write_typed_null_helper(ION_WRITER *pwriter, ION_TYPE type);
 iERR _ion_writer_write_bool_helper(ION_WRITER *pwriter, BOOL value);
-iERR _ion_writer_write_int32_helper(ION_WRITER *pwriter, int32_t value);
 iERR _ion_writer_write_int64_helper(ION_WRITER *pwriter, int64_t value);
 iERR _ion_writer_write_ion_int_helper(ION_WRITER *pwriter, ION_INT *value);
 iERR _ion_writer_write_mixed_int_helper(ION_WRITER *pwriter, ION_READER *preader);

--- a/test/test_ion_symbol.cpp
+++ b/test/test_ion_symbol.cpp
@@ -357,7 +357,10 @@ TEST_P(BinaryAndTextTest, ManuallyWritingSymbolTableStructWithImportsAndOpenCont
     ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_NAME));
     ION_ASSERT_OK(ion_writer_write_string(writer, &import1_name));
     ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_VERSION));
+    ION_ASSERT_OK(ion_writer_add_annotation(writer, &foo_name)); // open content; ignored.
     ION_ASSERT_OK(ion_writer_write_int(writer, 1));
+    ION_ASSERT_OK(ion_writer_write_field_name(writer, &foo_name)); // open content; ignored.
+    ION_ASSERT_OK(ion_writer_write_int(writer, 123)); // open content; ignored.
     ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_MAX_ID));
     ION_ASSERT_OK(ion_writer_write_int(writer, 1)); // $10 = sym1
     ION_ASSERT_OK(ion_writer_finish_container(writer)); // end import struct
@@ -368,44 +371,156 @@ TEST_P(BinaryAndTextTest, ManuallyWritingSymbolTableStructWithImportsAndOpenCont
     ION_ASSERT_OK(ion_writer_write_int(writer, 1));
     ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_MAX_ID));
     ION_ASSERT_OK(ion_writer_write_int(writer, 2)); // $11 and $12
+    ION_ASSERT_OK(ion_writer_write_field_name(writer, &foo_name)); // open content; ignored.
+    ION_ASSERT_OK(ion_writer_start_container(writer, tid_LIST)); // open content; ignored.
+    ION_ASSERT_OK(ion_writer_write_int(writer, 456)); // open content; ignored.
+    ION_ASSERT_OK(ion_writer_finish_container(writer)); // end open content list
     ION_ASSERT_OK(ion_writer_finish_container(writer)); // end import struct
+    ION_ASSERT_OK(ion_writer_write_int(writer, 789)); // open content; ignored.
     ION_ASSERT_OK(ion_writer_finish_container(writer)); // end imports list
     ION_ASSERT_OK(ion_writer_finish_container(writer)); // end LST struct
 
     ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 10)); // This maps to sym1.
     ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 12)); // This maps to unknown text.
-    // TODO need to rewrite with a writer that has the shared symbol table from which $12 comes
-    // NOTE: the user should only have to provide "foo" to this writer; the symbol token should contain the import
+
+    // TODO if the user writes a symbol token with an import location using the writer, writing should succeed if the
+    // import is one of the shared symbol tables the writer is configured to use. Being in the catalog is not sufficient
+    // because (in the case of the text writer) the symbol table has already been written (to avoid buffering) by the
+    // time the writer reaches the value region of the stream -- UNLESS the import is found in the catalog AND the text
+    // is known. In that case, for text writers, the text can simply be written; for binary writers, the text can be
+    // interned into the LST and a local SID written.
+    // the user should only have to provide "foo" to this writer; the symbol token should contain the import
     // location, which the writer will use to serialize the symbol instead of the local symbol ID (which is currently
     // used).
 
-    // TODO there currently isn't a way to provide a writer with a not-found shared symbol table to use while writing.
-    /*
     hREADER reader;
     BYTE *result;
     ION_READER_OPTIONS reader_options;
     hWRITER roundtrip_writer;
+    ION_COLLECTION *imports;
+    ION_SYMBOL_TABLE *reader_symtab;
+    ION_TYPE type;
+
     ION_ASSERT_OK(ion_test_writer_get_bytes(writer, stream, &result, &bytes_flushed));
     ion_test_initialize_reader_options(&reader_options);
     reader_options.pcatalog = catalog;
     ION_ASSERT_OK(ion_reader_open_buffer(&reader, result, bytes_flushed, &reader_options));
     ION_ASSERT_OK(ion_stream_open_memory_only(&stream));
-    writer_options.output_as_binary = TRUE;
-    writer_options.encoding_psymbol_table_count = 2;
-    writer_options.encoding_psymbol_table = writer_imports; // TODO wrong. This needs to include import1 and foo (which has unknown symbols)
+    writer_options.output_as_binary = FALSE;
+    ION_ASSERT_OK(ion_writer_options_initialize_shared_imports(&writer_options));
+
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ION_ASSERT_OK(ion_reader_get_symbol_table(reader, &reader_symtab));
+    ION_ASSERT_OK(ion_symbol_table_get_imports(reader_symtab, &imports));
+    ION_ASSERT_OK(ion_writer_options_add_shared_imports(&writer_options, imports));
     ION_ASSERT_OK(ion_writer_open(&roundtrip_writer, stream, &writer_options));
-    ION_ASSERT_OK(ion_writer_write_all_values(roundtrip_writer, reader));
+    ION_ASSERT_OK(ion_writer_options_close_shared_imports(&writer_options));
+
+    ION_ASSERT_OK(ion_reader_read_symbol_sid(reader, &sid));
+    ION_ASSERT_OK(ion_writer_write_symbol_sid(roundtrip_writer, sid));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ION_ASSERT_OK(ion_reader_read_symbol_sid(reader, &sid));
+    ION_ASSERT_OK(ion_writer_write_symbol_sid(roundtrip_writer, sid));
     ION_ASSERT_OK(ion_reader_close(reader));
     free(result);
 
-    ION_ASSERT_OK(ion_test_writer_get_bytes(writer, stream, &result, &bytes_flushed)); \
-    assertStringsEqual("sym1 $12", (char *)result, bytes_flushed); \
+    ION_ASSERT_OK(ion_test_writer_get_bytes(roundtrip_writer, stream, &result, &bytes_flushed));
+    assertStringsEqual("$ion_symbol_table::{imports:[{name:\"import1\",version:1,max_id:1},{name:\"foo\",version:1,max_id:2}]} sym1 $12", (char *)result, bytes_flushed);
     free(result);
-     */
+}
+
+TEST_P(BinaryAndTextTest, ManuallyWritingSymbolTableWithDuplicateFieldsFails) {
+    ION_SYMBOL_TEST_DECLARE_WRITER;
+
+    ION_STRING foo;
+    ION_ASSERT_OK(ion_string_from_cstr("foo", &foo));
+
+    ION_ASSERT_OK(ion_test_new_writer(&writer, &stream, is_binary));
+    ION_ASSERT_OK(ion_writer_add_annotation_sid(writer, ION_SYS_SID_SYMBOL_TABLE)); // $ion_symbol_table
+    ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
+    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_IMPORTS));
+    ION_ASSERT_OK(ion_writer_start_container(writer, tid_LIST));
+    ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
+    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_NAME));
+    ION_ASSERT_OK(ion_writer_write_string(writer, &foo));
+    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_VERSION));
+    ION_ASSERT_OK(ion_writer_write_int(writer, 1));
+    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_MAX_ID));
+    ION_ASSERT_OK(ion_writer_write_int(writer, 1));
+    ASSERT_EQ(IERR_INVALID_SYMBOL_TABLE, ion_writer_write_field_sid(writer, ION_SYS_SID_VERSION));
+    ASSERT_EQ(IERR_INVALID_SYMBOL_TABLE, ion_writer_write_field_sid(writer, ION_SYS_SID_MAX_ID));
+    ASSERT_EQ(IERR_INVALID_SYMBOL_TABLE, ion_writer_write_field_sid(writer, ION_SYS_SID_NAME));
+    ION_ASSERT_OK(ion_writer_finish_container(writer)); // end import struct
+    ION_ASSERT_OK(ion_writer_finish_container(writer)); // end imports list
+    ASSERT_EQ(IERR_INVALID_SYMBOL_TABLE, ion_writer_write_field_sid(writer, ION_SYS_SID_IMPORTS));
+    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_SYMBOLS));
+    ION_ASSERT_OK(ion_writer_start_container(writer, tid_LIST));
+    ION_ASSERT_OK(ion_writer_write_string(writer, &foo));
+    ION_ASSERT_OK(ion_writer_finish_container(writer)); // end symbols list
+    ASSERT_EQ(IERR_INVALID_SYMBOL_TABLE, ion_writer_write_field_sid(writer, ION_SYS_SID_SYMBOLS));
+    ION_ASSERT_OK(ion_writer_finish_container(writer)); // end LST struct
+
+    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 11)); // foo
+
+    ION_SYMBOL_TEST_REWRITE_FROM_WRITER_AND_ASSERT_TEXT("foo");
+}
+
+TEST_P(BinaryAndTextTest, ManuallyWritingImportWithNoNameIsIgnored) {
+    ION_SYMBOL_TEST_DECLARE_WRITER;
+
+    ION_STRING foo;
+    ION_ASSERT_OK(ion_string_from_cstr("foo", &foo));
+
+    ION_ASSERT_OK(ion_test_new_writer(&writer, &stream, is_binary));
+    ION_ASSERT_OK(ion_writer_add_annotation_sid(writer, ION_SYS_SID_SYMBOL_TABLE)); // $ion_symbol_table
+    ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
+    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_SYMBOLS));
+    ION_ASSERT_OK(ion_writer_start_container(writer, tid_LIST));
+    ION_ASSERT_OK(ion_writer_write_string(writer, &foo));
+    ION_ASSERT_OK(ion_writer_finish_container(writer));
+    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_IMPORTS));
+    ION_ASSERT_OK(ion_writer_start_container(writer, tid_LIST));
+    ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
+    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_NAME));
+    ION_ASSERT_OK(ion_writer_write_int(writer, 123)); // This is not a string, so it's ignored.
+    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_VERSION));
+    ION_ASSERT_OK(ion_writer_write_int(writer, 1));
+    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_MAX_ID));
+    ION_ASSERT_OK(ion_writer_write_int(writer, 1));
+    ASSERT_EQ(IERR_INVALID_SYMBOL_TABLE, ion_writer_write_field_sid(writer, ION_SYS_SID_NAME));
+    ION_ASSERT_OK(ion_writer_finish_container(writer));
+    ION_ASSERT_OK(ion_writer_finish_container(writer));
+    ION_ASSERT_OK(ion_writer_finish_container(writer));
+
+    // NOTE: the ignored import had space for one symbol. If it weren't ignored, SID 10 would fall within its range.
+    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 10));
+
+    ION_SYMBOL_TEST_REWRITE_FROM_WRITER_AND_ASSERT_TEXT("foo");
+}
+
+TEST_P(BinaryAndTextTest, ManuallyWritingAmbiguousImportFails) {
+    ION_SYMBOL_TEST_DECLARE_WRITER;
+
+    ION_STRING foo;
+    ION_ASSERT_OK(ion_string_from_cstr("foo", &foo));
+
+    ION_ASSERT_OK(ion_test_new_writer(&writer, &stream, is_binary));
+    ION_ASSERT_OK(ion_writer_add_annotation_sid(writer, ION_SYS_SID_SYMBOL_TABLE)); // $ion_symbol_table
+    ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
+    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_IMPORTS));
+    ION_ASSERT_OK(ion_writer_start_container(writer, tid_LIST));
+    ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
+    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_NAME));
+    ION_ASSERT_OK(ion_writer_write_string(writer, &foo));
+    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_VERSION));
+    ION_ASSERT_OK(ion_writer_write_int(writer, 1));
+    ASSERT_EQ(IERR_INVALID_SYMBOL_TABLE, ion_writer_finish_container(writer));
+    ASSERT_EQ(IERR_UNEXPECTED_EOF, ion_writer_close(writer));
 }
 
 TEST(IonSymbolTable, ManuallyWriteSymbolTableAppendSucceeds) {
     // Like the previous test, but the manually written symbol table contains appended symbols.
+    // TODO just fail for now?
 }
 
 // TODO symbol table getters on writer while a manual LST is in progress should return the system symbol table
@@ -457,12 +572,39 @@ TEST(IonSymbolTable, TextWritingSymbolWithUnknownTextFromImportWritesIdentifierA
 
     ION_ASSERT_OK(ion_test_writer_get_bytes(writer, stream, &result, &bytes_flushed));
     assertStringsEqual("$ion_symbol_table::{imports:[{name:\"foo\",version:1,max_id:3}]} abc $11 def", (char *)result, bytes_flushed);
+    free(result);
 }
 
 TEST(IonSymbolTable, TextWritingSymbolWithUnknownTextFromManuallyWrittenSymbolTableWritesIdentifierAndForcesSymbolTable) {
     // If the user writes a SID in the import range of a manually written symbol table with import(s) and that import is
     // not found in the catalog, the SID must be written as $<int> and the symbol table must be included in the stream.
     // Future consumers may have access to that import and be able to resolve the identifier.
+    ION_SYMBOL_TEST_DECLARE_WRITER;
+    BYTE *result;
+    ION_STRING foo;
+    ION_ASSERT_OK(ion_string_from_cstr("foo", &foo));
+
+    ION_ASSERT_OK(ion_test_new_writer(&writer, &stream, FALSE));
+    ION_ASSERT_OK(ion_writer_add_annotation_sid(writer, ION_SYS_SID_SYMBOL_TABLE)); // $ion_symbol_table
+    ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
+    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_IMPORTS));
+    ION_ASSERT_OK(ion_writer_start_container(writer, tid_LIST));
+    ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
+    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_NAME));
+    ION_ASSERT_OK(ion_writer_write_string(writer, &foo));
+    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_VERSION));
+    ION_ASSERT_OK(ion_writer_write_int(writer, 1));
+    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_MAX_ID));
+    ION_ASSERT_OK(ion_writer_write_int(writer, 1));
+    ION_ASSERT_OK(ion_writer_finish_container(writer)); // end import struct
+    ION_ASSERT_OK(ion_writer_finish_container(writer)); // end imports list
+    ION_ASSERT_OK(ion_writer_finish_container(writer)); // end LST struct
+
+    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 10)); // $10 (unknown text).
+
+    ION_ASSERT_OK(ion_test_writer_get_bytes(writer, stream, &result, &bytes_flushed));
+    assertStringsEqual("$ion_symbol_table::{imports:[{name:\"foo\",version:1,max_id:1}]} $10", (char *)result, bytes_flushed);
+    free(result);
 }
 
 TEST_P(BinaryAndTextTest, WritingOutOfRangeSIDFails) {
@@ -582,50 +724,28 @@ TEST_P(BinaryAndTextTest, FlushingOrFinishingOrClosingWriterBelowTopLevelFails) 
     // potential to require a symbol table to be written immediately afterward. Therefore, these must only be done
     // at the top level.
     ION_SYMBOL_TEST_DECLARE_WRITER;
-    BYTE *result;
     bytes_flushed = 0;
 
     ION_ASSERT_OK(ion_test_new_writer(&writer, &stream, is_binary));
     ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
-    ASSERT_EQ(IERR_INVALID_STATE, ion_writer_flush(writer, &bytes_flushed));
+    ASSERT_EQ(IERR_UNEXPECTED_EOF, ion_writer_flush(writer, &bytes_flushed));
     ASSERT_EQ(0, bytes_flushed);
-    ASSERT_EQ(IERR_INVALID_STATE, ion_writer_finish(writer, &bytes_flushed));
+    ASSERT_EQ(IERR_UNEXPECTED_EOF, ion_writer_finish(writer, &bytes_flushed));
     ASSERT_EQ(0, bytes_flushed);
-    ASSERT_EQ(IERR_INVALID_STATE, ion_writer_close(writer));
-    ION_ASSERT_OK(ion_writer_finish_container(writer));
-
-    ION_ASSERT_OK(ion_test_writer_get_bytes(writer, stream, &result, &bytes_flushed));
-    if (is_binary) {
-        assertBytesEqual("\xE0\x01\x00\xEA\xD0", 5, result, bytes_flushed);
-    }
-    else {
-        assertStringsEqual("{}", (char *)result, bytes_flushed);
-    }
-    free(result);
+    ASSERT_EQ(IERR_UNEXPECTED_EOF, ion_writer_close(writer));
 }
 
 TEST_P(BinaryAndTextTest, ClosingWriterWithPendingLobFails) {
     ION_SYMBOL_TEST_DECLARE_WRITER;
-    BYTE *result;
     bytes_flushed = 0;
 
     ION_ASSERT_OK(ion_test_new_writer(&writer, &stream, is_binary));
     ION_ASSERT_OK(ion_writer_start_lob(writer, tid_CLOB));
-    ASSERT_EQ(IERR_INVALID_STATE, ion_writer_flush(writer, &bytes_flushed));
+    ASSERT_EQ(IERR_UNEXPECTED_EOF, ion_writer_flush(writer, &bytes_flushed));
     ASSERT_EQ(0, bytes_flushed);
-    ASSERT_EQ(IERR_INVALID_STATE, ion_writer_finish(writer, &bytes_flushed));
+    ASSERT_EQ(IERR_UNEXPECTED_EOF, ion_writer_finish(writer, &bytes_flushed));
     ASSERT_EQ(0, bytes_flushed);
-    ASSERT_EQ(IERR_INVALID_STATE, ion_writer_close(writer));
-    ION_ASSERT_OK(ion_writer_finish_lob(writer));
-
-    ION_ASSERT_OK(ion_test_writer_get_bytes(writer, stream, &result, &bytes_flushed));
-    if (is_binary) {
-        assertBytesEqual("\xE0\x01\x00\xEA\x90", 5, result, bytes_flushed);
-    }
-    else {
-        assertStringsEqual("{{\"\"}}", (char *)result, bytes_flushed);
-    }
-    free(result);
+    ASSERT_EQ(IERR_UNEXPECTED_EOF, ion_writer_close(writer));
 }
 
 TEST(IonSymbolTable, LoadSymbolTableWithAnnotationSecondFails) {


### PR DESCRIPTION
When a user manually writes a top-level struct with the $ion_symbol_table annotation, it must be intercepted and treated as a local symbol table. This avoids the writer blindly writing what would look to a reader like a symbol table context change, without the writer having internally changed its symbol table context.