### PR TITLE
 Adds import location to ION_SYMBOL to fully support roundtripping symbols with unknown text; exposes public APIs for reading and writing ION_SYMBOLs.

### DIFF
--- a/ionc/inc/ion_reader.h
+++ b/ionc/inc/ion_reader.h
@@ -306,11 +306,14 @@ ION_API_EXPORT iERR ion_reader_is_null             (hREADER hreader, BOOL *p_is_
 ION_API_EXPORT iERR ion_reader_is_in_struct        (hREADER preader, BOOL *p_is_in_struct);
 ION_API_EXPORT iERR ion_reader_get_field_name      (hREADER hreader, iSTRING p_str);
 ION_API_EXPORT iERR ion_reader_get_field_sid       (hREADER hreader, SID *p_sid);
+ION_API_EXPORT iERR ion_reader_get_field_name_symbol(hREADER hreader, ION_SYMBOL **p_psymbol);
 ION_API_EXPORT iERR ion_reader_get_annotations     (hREADER hreader, iSTRING p_strs, SIZE max_count, SIZE *p_count);
 ION_API_EXPORT iERR ion_reader_get_annotation_sids (hREADER hreader, SID *p_sids, SIZE max_count, SIZE *p_count);
+ION_API_EXPORT iERR ion_reader_get_annotation_symbols(hREADER hreader, ION_SYMBOL *p_symbols, SIZE max_count, SIZE *p_count);
 ION_API_EXPORT iERR ion_reader_get_annotation_count(hREADER hreader, SIZE *p_count);
 ION_API_EXPORT iERR ion_reader_get_an_annotation   (hREADER hreader, int idx, iSTRING p_strs);
 ION_API_EXPORT iERR ion_reader_get_an_annotation_sid(hREADER hreader, int idx, SID *p_sid);
+ION_API_EXPORT iERR ion_reader_get_an_annotation_symbol(hREADER hreader, int idx, ION_SYMBOL *p_symbol);
 ION_API_EXPORT iERR ion_reader_read_null           (hREADER hreader, ION_TYPE *p_value);
 ION_API_EXPORT iERR ion_reader_read_bool           (hREADER hreader, BOOL *p_value);
 
@@ -356,13 +359,17 @@ ION_API_EXPORT iERR ion_reader_read_ion_decimal    (hREADER hreader, ION_DECIMAL
 ION_API_EXPORT iERR ion_reader_read_timestamp      (hREADER hreader, iTIMESTAMP p_value);
 
 /** Read the local symbol ID of the current symbol value.
- * NOTE: use of this function is discouraged, as it can have different results for text and binary data. In Ion text,
+ * @deprecated use of this function is discouraged, as it can have different results for text and binary data. In Ion text,
  * which is not required to explicitly include a local symbol table, known symbols are not necessarily assigned symbol
  * IDs. For those symbols, this function would return UNKNOWN_SID even though the text is known.
- * Prefer `ion_reader_read_string`, which provides an ION_STRING for which ION_STRING_IS_NULL() will evaluate to TRUE
- * if the current symbol value's text is unknown.
+ * Prefer `ion_reader_read_symbol` or `ion_reader_read_string`, which provides an ION_STRING for which
+ * ION_STRING_IS_NULL() will evaluate to TRUE if the current symbol value's text is unknown.
  */
 ION_API_EXPORT iERR ion_reader_read_symbol_sid     (hREADER hreader, SID *p_value);
+
+/** Read the current symbol value as an ION_SYMBOL.
+ */
+ION_API_EXPORT iERR ion_reader_read_symbol         (hREADER hreader, ION_SYMBOL *p_symbol);
 
 /**
  * Determines the content of the current text value, which must be an

--- a/ionc/inc/ion_symbol_table.h
+++ b/ionc/inc/ion_symbol_table.h
@@ -323,6 +323,16 @@ ION_API_EXPORT iERR ion_symbol_table_add_symbol         (hSYMTAB hsymtab, iSTRIN
  */
 ION_API_EXPORT iERR ion_symbol_table_close              (hSYMTAB hsymtab);
 
+/**
+ * Copies an ION_SYMBOL to a new memory owner.
+ */
+ION_API_EXPORT iERR ion_symbol_copy_to_owner(hOWNER owner, ION_SYMBOL *dst, ION_SYMBOL *src);
+
+/**
+ * Compares the two given ION_SYMBOLs for equality under the Ion data model.
+ */
+ION_API_EXPORT iERR ion_symbol_is_equal(ION_SYMBOL *lhs, ION_SYMBOL *rhs, BOOL *is_equal);
+
 ION_API_EXPORT const char *ion_symbol_table_type_to_str (ION_SYMBOL_TABLE_TYPE t);
 
 #ifdef __cplusplus

--- a/ionc/inc/ion_symbol_table.h
+++ b/ionc/inc/ion_symbol_table.h
@@ -22,10 +22,17 @@
 extern "C" {
 #endif
 
+typedef struct _ion_symbol_import_location
+{
+    ION_STRING name;
+    SID        location;
+} ION_SYMBOL_IMPORT_LOCATION;
+
 struct _ion_symbol
 {
-    SID               sid;
-    ION_STRING        value;
+    SID                         sid;
+    ION_STRING                  value;
+    ION_SYMBOL_IMPORT_LOCATION  import_location;
     // TODO this is only needed for symbol usage metrics. Consider removal.
     int32_t           add_count;
 };
@@ -36,6 +43,8 @@ typedef enum _ION_SYMBOL_TABLE_TYPE {
     ist_SHARED = 2,
     ist_SYSTEM = 3
 } ION_SYMBOL_TABLE_TYPE;
+
+#define ION_SYMBOL_IMPORT_LOCATION_IS_NULL(symbol) ION_STRING_IS_NULL(&(symbol)->import_location.name)
 
 #define UNKNOWN_SID -1 /* symbol id's presume not only is this unknown, but sid's must be positive */
 

--- a/ionc/inc/ion_writer.h
+++ b/ionc/inc/ion_writer.h
@@ -173,13 +173,30 @@ ION_API_EXPORT iERR ion_writer_get_catalog          (hWRITER hwriter, hCATALOG *
 ION_API_EXPORT iERR ion_writer_set_symbol_table     (hWRITER hwriter, hSYMTAB     hsymtab);
 ION_API_EXPORT iERR ion_writer_get_symbol_table     (hWRITER hwriter, hSYMTAB  *p_hsymtab);
 
+/**
+ * Sets the writer's current field name. Only valid if the writer is currently in a struct. It is the caller's
+ * responsibility to keep `name` in scope until the writer's next value is written.
+ */
 ION_API_EXPORT iERR ion_writer_write_field_name     (hWRITER hwriter, iSTRING name);
+
+/**
+ * Sets the writer's current field name from a local symbol ID. Only valid if the writer is currently in a struct.
+ */
 ION_API_EXPORT iERR ion_writer_write_field_sid      (hWRITER hwriter, SID sid);
+
+/**
+ * Sets the writer's current field name from the given Ion symbol. Only valid if the writer is currently in a struct.
+ * It is the caller's responsibility to keep `field_name` in scope until the writer's next value is written.
+ */
+ION_API_EXPORT iERR ion_writer_write_field_name_symbol(hWRITER hwriter, ION_SYMBOL *field_name);
+
 ION_API_EXPORT iERR ion_writer_clear_field_name     (hWRITER hwriter);
 ION_API_EXPORT iERR ion_writer_add_annotation       (hWRITER hwriter, iSTRING annotation);
 ION_API_EXPORT iERR ion_writer_add_annotation_sid   (hWRITER hwriter, SID sid);
+ION_API_EXPORT iERR ion_writer_add_annotation_symbol(hWRITER hwriter, ION_SYMBOL *annotation);
 ION_API_EXPORT iERR ion_writer_write_annotations    (hWRITER hwriter, iSTRING *p_annotations, SIZE count);
 ION_API_EXPORT iERR ion_writer_write_annotation_sids(hWRITER hwriter, SID *p_sids, SIZE count);
+ION_API_EXPORT iERR ion_writer_write_annotation_symbols(hWRITER hwriter, ION_SYMBOL **annotations, SIZE count);
 ION_API_EXPORT iERR ion_writer_clear_annotations    (hWRITER hwriter);
 
 ION_API_EXPORT iERR ion_writer_write_null           (hWRITER hwriter);
@@ -200,6 +217,7 @@ ION_API_EXPORT iERR ion_writer_write_ion_decimal    (hWRITER hwriter, ION_DECIMA
 ION_API_EXPORT iERR ion_writer_write_timestamp      (hWRITER hwriter, iTIMESTAMP value);
 ION_API_EXPORT iERR ion_writer_write_symbol_sid     (hWRITER hwriter, SID value);
 ION_API_EXPORT iERR ion_writer_write_symbol         (hWRITER hwriter, iSTRING p_value);
+ION_API_EXPORT iERR ion_writer_write_ion_symbol     (hWRITER hwriter, ION_SYMBOL *symbol);
 ION_API_EXPORT iERR ion_writer_write_string         (hWRITER hwriter, iSTRING p_value);
 ION_API_EXPORT iERR ion_writer_write_clob           (hWRITER hwriter, BYTE *p_buf, SIZE length);
 ION_API_EXPORT iERR ion_writer_write_blob           (hWRITER hwriter, BYTE *p_buf, SIZE length);

--- a/ionc/inc/ion_writer.h
+++ b/ionc/inc/ion_writer.h
@@ -116,13 +116,15 @@ ION_API_EXPORT iERR ion_writer_options_initialize_shared_imports(ION_WRITER_OPTI
 
 /**
  * Adds the imports from the given collection of ION_SYMBOL_TABLE_IMPORT to the options' imports list.
- * `ion_writer_options_initialize_shared_imports` must have been called first.
+ * `ion_writer_options_initialize_shared_imports` must have been called first. The given collection must not contain
+ * a system symbol table.
  */
 ION_API_EXPORT iERR ion_writer_options_add_shared_imports(ION_WRITER_OPTIONS *options, ION_COLLECTION *imports);
 
 /**
  * Adds the given array of ION_SYMBOL_TABLE (which must be shared symbol tables) to the options' imports list.
- * `ion_writer_options_initialize_shared_imports` must have been called first.
+ * `ion_writer_options_initialize_shared_imports` must have been called first. The given array must not contain
+ * a system symbol table.
  */
 ION_API_EXPORT iERR ion_writer_options_add_shared_imports_symbol_tables(ION_WRITER_OPTIONS *options, ION_SYMBOL_TABLE **imports, SIZE imports_count);
 

--- a/ionc/ion_reader.c
+++ b/ionc/ion_reader.c
@@ -892,14 +892,50 @@ iERR _ion_reader_get_an_annotation_sid_helper(ION_READER *preader, int32_t idx, 
 
     switch(preader->type) {
         case ion_type_text_reader:
-        IONCHECK(_ion_reader_text_get_an_annotation_sid(preader, idx, p_sid));
+            IONCHECK(_ion_reader_text_get_an_annotation_sid(preader, idx, p_sid));
             break;
         case ion_type_binary_reader:
-        IONCHECK(_ion_reader_binary_get_an_annotation_sid(preader, idx, p_sid));
+            IONCHECK(_ion_reader_binary_get_an_annotation_sid(preader, idx, p_sid));
             break;
         case ion_type_unknown_reader:
         default:
-        FAILWITH(IERR_INVALID_STATE);
+            FAILWITH(IERR_INVALID_STATE);
+    }
+
+    iRETURN;
+}
+
+iERR ion_reader_get_an_annotation_symbol(hREADER hreader, int idx, ION_SYMBOL *p_symbol)
+{
+    iENTER;
+    ION_READER *preader;
+
+    if (!hreader) FAILWITH(IERR_INVALID_ARG);
+    preader = HANDLE_TO_PTR(hreader, ION_READER);
+    if (idx < 0) FAILWITH(IERR_INVALID_ARG);
+    if (!p_symbol) FAILWITH(IERR_INVALID_ARG);
+
+    IONCHECK(_ion_reader_get_an_annotation_symbol_helper(preader, idx, p_symbol));
+
+    iRETURN;
+}
+
+iERR _ion_reader_get_an_annotation_symbol_helper(ION_READER *preader, int32_t idx, ION_SYMBOL *p_symbol)
+{
+    iENTER;
+
+    ASSERT(preader);
+
+    switch(preader->type) {
+        case ion_type_text_reader:
+            IONCHECK(_ion_reader_text_get_an_annotation_symbol(preader, idx, p_symbol));
+            break;
+        case ion_type_binary_reader:
+            IONCHECK(_ion_reader_binary_get_an_annotation_symbol(preader, idx, p_symbol));
+            break;
+        case ion_type_unknown_reader:
+        default:
+            FAILWITH(IERR_INVALID_STATE);
     }
 
     iRETURN;
@@ -1043,19 +1079,33 @@ iERR _ion_reader_get_field_sid_helper(ION_READER *preader, SID *p_sid)
     iRETURN;
 }
 
-iERR _ion_reader_get_field_symbol_helper(ION_READER *preader, ION_SYMBOL **p_symbol)
+iERR ion_reader_get_field_name_symbol(hREADER hreader, ION_SYMBOL **p_psymbol)
+{
+    iENTER;
+    ION_READER *preader;
+
+    if (!hreader) FAILWITH(IERR_INVALID_ARG);
+    preader = HANDLE_TO_PTR(hreader, ION_READER);
+    if (!p_psymbol) FAILWITH(IERR_INVALID_ARG);
+
+    IONCHECK(_ion_reader_get_field_name_symbol_helper(preader, p_psymbol));
+
+    iRETURN;
+}
+
+iERR _ion_reader_get_field_name_symbol_helper(ION_READER *preader, ION_SYMBOL **p_psymbol)
 {
     iENTER;
 
     ASSERT(preader);
-    ASSERT(p_symbol);
+    ASSERT(p_psymbol);
 
     switch(preader->type) {
         case ion_type_text_reader:
-            IONCHECK(_ion_reader_text_get_field_name_symbol(preader, p_symbol));
+            IONCHECK(_ion_reader_text_get_field_name_symbol(preader, p_psymbol));
             break;
         case ion_type_binary_reader:
-            IONCHECK(_ion_reader_binary_get_field_symbol(preader, p_symbol));
+            IONCHECK(_ion_reader_binary_get_field_name_symbol(preader, p_psymbol));
             break;
         case ion_type_unknown_reader:
         default:
@@ -1128,12 +1178,15 @@ iERR ion_reader_get_annotation_sids(hREADER hreader, SID *p_sids, SIZE max_count
     iRETURN;
 }
 
-iERR _ion_reader_get_annotation_symbols_helper(ION_READER *preader, ION_SYMBOL *p_symbols, SIZE max_count, SIZE *p_count)
+iERR ion_reader_get_annotation_symbols(hREADER hreader, ION_SYMBOL *p_symbols, SIZE max_count, SIZE *p_count)
 {
     iENTER;
-    ASSERT(preader);
-    ASSERT(p_symbols);
-    ASSERT(p_count);
+    ION_READER *preader;
+
+    if (!hreader) FAILWITH(IERR_INVALID_ARG);
+    preader = HANDLE_TO_PTR(hreader, ION_READER);
+    if (!p_symbols) FAILWITH(IERR_INVALID_ARG);
+    if (!p_count) FAILWITH(IERR_INVALID_ARG);
 
     switch(preader->type) {
         case ion_type_text_reader:
@@ -1573,6 +1626,20 @@ iERR _ion_reader_read_symbol_sid_helper(ION_READER *preader, SID *p_value)
     iRETURN;
 }
 
+iERR ion_reader_read_symbol(hREADER hreader, ION_SYMBOL *p_symbol)
+{
+    iENTER;
+    ION_READER *preader;
+
+    if (!hreader) FAILWITH(IERR_INVALID_ARG);
+    preader = HANDLE_TO_PTR(hreader, ION_READER);
+    if (!p_symbol) FAILWITH(IERR_INVALID_ARG);
+
+    IONCHECK(_ion_reader_read_symbol_helper(preader, p_symbol));
+
+    iRETURN;
+}
+
 iERR _ion_reader_read_symbol_helper(ION_READER *preader, ION_SYMBOL *p_symbol)
 {
     iENTER;
@@ -1589,7 +1656,7 @@ iERR _ion_reader_read_symbol_helper(ION_READER *preader, ION_SYMBOL *p_symbol)
             break;
         case ion_type_unknown_reader:
         default:
-        FAILWITH(IERR_INVALID_STATE);
+            FAILWITH(IERR_INVALID_STATE);
     }
 
     iRETURN;

--- a/ionc/ion_reader.c
+++ b/ionc/ion_reader.c
@@ -1000,6 +1000,8 @@ iERR _ion_reader_get_field_name_helper(ION_READER *preader, ION_STRING **p_pstr)
     case ion_type_binary_reader:
         IONCHECK(_ion_reader_binary_get_field_name(preader, p_pstr));
         break;
+    default:
+        FAILWITH(IERR_INVALID_STATE);
     }
 
     iRETURN;
@@ -1036,6 +1038,28 @@ iERR _ion_reader_get_field_sid_helper(ION_READER *preader, SID *p_sid)
     case ion_type_unknown_reader:
     default:
         FAILWITH(IERR_INVALID_STATE);
+    }
+
+    iRETURN;
+}
+
+iERR _ion_reader_get_field_symbol_helper(ION_READER *preader, ION_SYMBOL **p_symbol)
+{
+    iENTER;
+
+    ASSERT(preader);
+    ASSERT(p_symbol);
+
+    switch(preader->type) {
+        case ion_type_text_reader:
+            IONCHECK(_ion_reader_text_get_field_name_symbol(preader, p_symbol));
+            break;
+        case ion_type_binary_reader:
+            IONCHECK(_ion_reader_binary_get_field_symbol(preader, p_symbol));
+            break;
+        case ion_type_unknown_reader:
+        default:
+            FAILWITH(IERR_INVALID_STATE);
     }
 
     iRETURN;
@@ -1099,6 +1123,28 @@ iERR ion_reader_get_annotation_sids(hREADER hreader, SID *p_sids, SIZE max_count
     case ion_type_unknown_reader:
     default:
         FAILWITH(IERR_INVALID_STATE);
+    }
+
+    iRETURN;
+}
+
+iERR _ion_reader_get_annotation_symbols_helper(ION_READER *preader, ION_SYMBOL *p_symbols, SIZE max_count, SIZE *p_count)
+{
+    iENTER;
+    ASSERT(preader);
+    ASSERT(p_symbols);
+    ASSERT(p_count);
+
+    switch(preader->type) {
+        case ion_type_text_reader:
+            IONCHECK(_ion_reader_text_get_annotation_symbols(preader, p_symbols, max_count, p_count));
+            break;
+        case ion_type_binary_reader:
+            IONCHECK(_ion_reader_binary_get_annotation_symbols(preader, p_symbols, max_count, p_count));
+            break;
+        case ion_type_unknown_reader:
+        default:
+            FAILWITH(IERR_INVALID_STATE);
     }
 
     iRETURN;

--- a/ionc/ion_reader_binary.c
+++ b/ionc/ion_reader_binary.c
@@ -823,7 +823,6 @@ iERR _ion_reader_binary_get_field_name_symbol(ION_READER *preader, ION_SYMBOL **
 
     IONCHECK(_ion_reader_binary_validate_symbol_token(preader, binary->_value_field_id));
     IONCHECK(_ion_symbol_table_find_symbol_by_sid_helper(preader->_current_symtab, binary->_value_field_id, &field_symbol));
-    // TODO duplicated in _ion_reader_binary_get_annotation_symbols
     if (field_symbol == NULL) {
         field_symbol = ion_alloc_with_owner(preader->_temp_entity_pool, sizeof (ION_SYMBOL));
         ION_STRING_INIT(&field_symbol->value);

--- a/ionc/ion_reader_binary.c
+++ b/ionc/ion_reader_binary.c
@@ -500,7 +500,7 @@ iERR _ion_reader_binary_has_annotation(ION_READER *preader, ION_STRING *annotati
         goto return_value;
     }
 
-    // and now check the annotation list for the sid of the users string
+    // and now check the annotation list for the sid of the user's string
     ION_COLLECTION_OPEN(&binary->_annotation_sids, cursor);
     for (;;) {
         ION_COLLECTION_NEXT(cursor, psid);
@@ -614,6 +614,35 @@ iERR _ion_reader_binary_get_an_annotation(ION_READER *preader, int32_t idx, ION_
 
     IONCHECK(_ion_symbol_table_find_by_sid_helper(preader->_current_symtab, sid, &pstr));
     IONCHECK(_ion_reader_binary_string_copy_or_null(preader, p_str, pstr));
+
+    iRETURN;
+}
+
+iERR _ion_reader_binary_get_an_annotation_symbol(ION_READER *preader, int32_t idx, ION_SYMBOL *p_symbol)
+{
+    iENTER;
+    SID               sid;
+    ION_SYMBOL       *psymbol;
+
+    ASSERT(preader && preader->type == ion_type_binary_reader);
+    ASSERT(p_symbol != NULL);
+
+
+    IONCHECK(_ion_reader_binary_get_an_annotation_sid(preader, idx, &sid));
+    if (sid <= UNKNOWN_SID) FAILWITH(IERR_INVALID_SYMBOL);
+
+    if (sid == 0) {
+        ION_STRING_INIT(&p_symbol->value);
+        ION_STRING_INIT(&p_symbol->import_location.name);
+        p_symbol->sid = 0;
+        p_symbol->import_location.location = UNKNOWN_SID;
+        p_symbol->add_count = 0;
+    }
+    else {
+        IONCHECK(_ion_symbol_table_find_symbol_by_sid_helper(preader->_current_symtab, sid, &psymbol));
+        ASSERT(psymbol != NULL);
+        IONCHECK(ion_symbol_copy_to_owner(preader->_temp_entity_pool, p_symbol, psymbol));
+    }
 
     iRETURN;
 }
@@ -781,7 +810,7 @@ iERR _ion_reader_binary_get_field_sid(ION_READER *preader, SID *p_sid)
     iRETURN;
 }
 
-iERR _ion_reader_binary_get_field_symbol(ION_READER *preader, ION_SYMBOL **p_psymbol)
+iERR _ion_reader_binary_get_field_name_symbol(ION_READER *preader, ION_SYMBOL **p_psymbol)
 {
     iENTER;
     ION_BINARY_READER *binary;

--- a/ionc/ion_reader_impl.h
+++ b/ionc/ion_reader_impl.h
@@ -216,7 +216,9 @@ iERR _ion_reader_get_an_annotation_sid_helper(ION_READER *preader, int32_t idx, 
 iERR _ion_reader_is_null_helper(ION_READER *preader, BOOL *p_is_null);
 iERR _ion_reader_get_field_name_helper(ION_READER *preader, ION_STRING **p_pstr);
 iERR _ion_reader_get_field_sid_helper(ION_READER *preader, SID *p_sid);
+iERR _ion_reader_get_field_symbol_helper(ION_READER *preader, ION_SYMBOL **p_symbol);
 iERR _ion_reader_get_annotations_helper(ION_READER *preader, ION_STRING *p_strs, SIZE max_count, SIZE *p_count);
+iERR _ion_reader_get_annotation_symbols_helper(ION_READER *preader, ION_SYMBOL *p_symbols, SIZE max_count, SIZE *p_count);
 iERR _ion_reader_read_null_helper(ION_READER *preader, ION_TYPE *p_value);
 iERR _ion_reader_read_bool_helper(ION_READER *preader, BOOL *p_value);
 iERR _ion_reader_read_int_helper(ION_READER *preader, int *p_value);
@@ -284,8 +286,10 @@ iERR _ion_reader_binary_get_an_annotation_sid(ION_READER *preader, int32_t idx, 
 
 iERR _ion_reader_binary_get_field_name     (ION_READER *preader, ION_STRING **pstr);
 iERR _ion_reader_binary_get_field_sid      (ION_READER *preader, SID *p_sid);
+iERR _ion_reader_binary_get_field_symbol   (ION_READER *preader, ION_SYMBOL **p_psymbol);
 iERR _ion_reader_binary_get_annotations    (ION_READER *preader, iSTRING p_strs, SIZE max_count, SIZE *p_count);
 iERR _ion_reader_binary_get_annotation_sids(ION_READER *preader, SID *p_sids, SIZE max_count, SIZE *p_count);
+iERR _ion_reader_binary_get_annotation_symbols(ION_READER *preader, ION_SYMBOL *p_annotations, SIZE max_count, SIZE *p_count);
 
 iERR _ion_reader_binary_is_null             (ION_READER *preader, BOOL *p_is_null);
 iERR _ion_reader_binary_read_null           (ION_READER *preader, ION_TYPE *p_value);

--- a/ionc/ion_reader_impl.h
+++ b/ionc/ion_reader_impl.h
@@ -213,12 +213,12 @@ iERR _ion_reader_has_annotation_helper(ION_READER *preader, ION_STRING *annotati
 iERR _ion_reader_get_annotation_count_helper(ION_READER *preader, int32_t *p_count);
 iERR _ion_reader_get_an_annotation_helper(ION_READER *preader, int32_t idx, ION_STRING *p_str);
 iERR _ion_reader_get_an_annotation_sid_helper(ION_READER *preader, int32_t idx, SID *p_sid);
+iERR _ion_reader_get_an_annotation_symbol_helper(ION_READER *preader, int32_t idx, ION_SYMBOL *p_symbol);
 iERR _ion_reader_is_null_helper(ION_READER *preader, BOOL *p_is_null);
 iERR _ion_reader_get_field_name_helper(ION_READER *preader, ION_STRING **p_pstr);
 iERR _ion_reader_get_field_sid_helper(ION_READER *preader, SID *p_sid);
-iERR _ion_reader_get_field_symbol_helper(ION_READER *preader, ION_SYMBOL **p_symbol);
+iERR _ion_reader_get_field_name_symbol_helper(ION_READER *preader, ION_SYMBOL **p_psymbol);
 iERR _ion_reader_get_annotations_helper(ION_READER *preader, ION_STRING *p_strs, SIZE max_count, SIZE *p_count);
-iERR _ion_reader_get_annotation_symbols_helper(ION_READER *preader, ION_SYMBOL *p_symbols, SIZE max_count, SIZE *p_count);
 iERR _ion_reader_read_null_helper(ION_READER *preader, ION_TYPE *p_value);
 iERR _ion_reader_read_bool_helper(ION_READER *preader, BOOL *p_value);
 iERR _ion_reader_read_int_helper(ION_READER *preader, int *p_value);
@@ -283,10 +283,11 @@ iERR _ion_reader_binary_has_annotation      (ION_READER *preader, iSTRING annota
 iERR _ion_reader_binary_get_annotation_count(ION_READER *preader, int32_t *p_count);
 iERR _ion_reader_binary_get_an_annotation   (ION_READER *preader, int32_t idx, ION_STRING *p_str);
 iERR _ion_reader_binary_get_an_annotation_sid(ION_READER *preader, int32_t idx, SID *p_sid);
+iERR _ion_reader_binary_get_an_annotation_symbol(ION_READER *preader, int32_t idx, ION_SYMBOL *p_symbol);
 
 iERR _ion_reader_binary_get_field_name     (ION_READER *preader, ION_STRING **pstr);
 iERR _ion_reader_binary_get_field_sid      (ION_READER *preader, SID *p_sid);
-iERR _ion_reader_binary_get_field_symbol   (ION_READER *preader, ION_SYMBOL **p_psymbol);
+iERR _ion_reader_binary_get_field_name_symbol(ION_READER *preader, ION_SYMBOL **p_psymbol);
 iERR _ion_reader_binary_get_annotations    (ION_READER *preader, iSTRING p_strs, SIZE max_count, SIZE *p_count);
 iERR _ion_reader_binary_get_annotation_sids(ION_READER *preader, SID *p_sids, SIZE max_count, SIZE *p_count);
 iERR _ion_reader_binary_get_annotation_symbols(ION_READER *preader, ION_SYMBOL *p_annotations, SIZE max_count, SIZE *p_count);

--- a/ionc/ion_reader_text.c
+++ b/ionc/ion_reader_text.c
@@ -1001,7 +1001,7 @@ iERR _ion_reader_text_get_an_annotation(ION_READER *preader, int32_t idx, ION_ST
 {
     iENTER;
     ION_TEXT_READER  *text = &preader->typed_reader.text;
-    ION_SYMBOL       *str;
+    ION_SYMBOL       *symbol;
 
     ASSERT(preader && preader->type == ion_type_text_reader);
     ASSERT(p_str != NULL);
@@ -1015,10 +1015,10 @@ iERR _ion_reader_text_get_an_annotation(ION_READER *preader, int32_t idx, ION_ST
     }
 
     // get a pointer to our string header in the annotation string pool
-    str = text->_annotation_string_pool + idx;
-    IONCHECK(_ion_reader_text_validate_symbol_token(preader, str));
-    IONCHECK(ion_string_copy_to_owner(preader->_temp_entity_pool, p_str, &str->value));
-    if (str->sid == 0) {
+    symbol = text->_annotation_string_pool + idx;
+    IONCHECK(_ion_reader_text_validate_symbol_token(preader, symbol));
+    IONCHECK(ion_string_copy_to_owner(preader->_temp_entity_pool, p_str, &symbol->value));
+    if (symbol->sid == 0) {
         ION_STRING_INIT(p_str); // This nulls the string, because symbol 0 has no text representation.
     }
 
@@ -1029,7 +1029,7 @@ iERR _ion_reader_text_get_an_annotation_sid(ION_READER *preader, int32_t idx, SI
 {
     iENTER;
     ION_TEXT_READER  *text = &preader->typed_reader.text;
-    ION_SYMBOL       *str;
+    ION_SYMBOL       *symbol;
 
     ASSERT(preader && preader->type == ion_type_text_reader);
     ASSERT(p_sid != NULL);
@@ -1043,9 +1043,34 @@ iERR _ion_reader_text_get_an_annotation_sid(ION_READER *preader, int32_t idx, SI
     }
 
     // get a pointer to our string header in the annotation string pool
-    str = text->_annotation_string_pool + idx;
-    IONCHECK(_ion_reader_text_validate_symbol_token(preader, str));
-    *p_sid = str->sid;
+    symbol = text->_annotation_string_pool + idx;
+    IONCHECK(_ion_reader_text_validate_symbol_token(preader, symbol));
+    *p_sid = symbol->sid;
+
+    iRETURN;
+}
+
+iERR _ion_reader_text_get_an_annotation_symbol(ION_READER *preader, int32_t idx, ION_SYMBOL *p_symbol)
+{
+    iENTER;
+    ION_TEXT_READER  *text = &preader->typed_reader.text;
+    ION_SYMBOL       *symbol;
+
+    ASSERT(preader && preader->type == ion_type_text_reader);
+    ASSERT(p_symbol != NULL);
+
+    if (text->_state == IPS_ERROR || text->_state == IPS_NONE) {
+        FAILWITH(IERR_INVALID_STATE);
+    }
+
+    if (idx < 0 || idx >= text->_annotation_count) {
+        FAILWITH(IERR_INVALID_ARG);
+    }
+
+    // get a pointer to our string header in the annotation string pool
+    symbol = text->_annotation_string_pool + idx;
+    IONCHECK(_ion_reader_text_validate_symbol_token(preader, symbol));
+    IONCHECK(ion_symbol_copy_to_owner(preader->_temp_entity_pool, p_symbol, symbol));
 
     iRETURN;
 }

--- a/ionc/ion_reader_text.c
+++ b/ionc/ion_reader_text.c
@@ -273,7 +273,7 @@ iERR _ion_reader_text_next(ION_READER *preader, ION_TYPE *p_value_type)
     iRETURN;
 }
 
-iERR _ion_reader_text_intern_symbol(ION_READER *preader, ION_STRING *symbol_name, ION_SYMBOL **psym, BOOL parse_symbol_identifiers) {
+iERR _ion_reader_text_intern_symbol(ION_READER *preader, ION_STRING *symbol_name, SID *local_sid, ION_SYMBOL **psym, BOOL parse_symbol_identifiers) {
     iENTER;
     ION_SYMBOL       *sym = NULL;
     ION_SYMBOL_TABLE *symbols;
@@ -283,7 +283,7 @@ iERR _ion_reader_text_intern_symbol(ION_READER *preader, ION_STRING *symbol_name
 
     if (parse_symbol_identifiers) {
         IONCHECK(_ion_reader_text_get_symbol_table(preader, &symbols));
-        IONCHECK(_ion_symbol_table_parse_possible_symbol_identifier(symbols, symbol_name, NULL, &sym, &is_symbol_identifier));
+        IONCHECK(_ion_symbol_table_parse_possible_symbol_identifier(symbols, symbol_name, local_sid, &sym, &is_symbol_identifier));
         ASSERT(!(is_symbol_identifier ^ (sym != NULL)));
     }
 
@@ -299,6 +299,7 @@ iERR _ion_reader_text_load_fieldname(ION_READER *preader, ION_SUB_TYPE *p_ist)
     ION_SUB_TYPE     ist = IST_NONE;
     BOOL             eos_encountered = FALSE;
     ION_SYMBOL      *sym;
+    SID              local_sid;
 
     ASSERT(preader);
     ASSERT(text);
@@ -330,10 +331,13 @@ iERR _ion_reader_text_load_fieldname(ION_READER *preader, ION_SUB_TYPE *p_ist)
         }
 
         text->_field_name.value.value = text->_field_name_buffer;
-        IONCHECK(_ion_reader_text_intern_symbol(preader, &text->_field_name.value, &sym, ist != IST_SYMBOL_QUOTED));
+        ION_STRING_INIT(&text->_field_name.import_location.name);
+        IONCHECK(_ion_reader_text_intern_symbol(preader, &text->_field_name.value, &local_sid, &sym, ist != IST_SYMBOL_QUOTED));
         if (sym) {
             ION_STRING_ASSIGN(&text->_field_name.value, &sym->value);
-            text->_field_name.sid = sym->sid;
+            ION_STRING_ASSIGN(&text->_field_name.import_location.name, &sym->import_location.name);
+            text->_field_name.sid = local_sid;
+            text->_field_name.import_location.location = sym->import_location.location;
             text->_field_name.add_count = sym->add_count;
         }
 
@@ -363,7 +367,7 @@ iERR _ion_reader_text_check_for_no_op_IVM(ION_READER *preader, ION_SUB_TYPE ist,
     str.value = text->_scanner._value_buffer;
     str.length = text->_scanner._value_image.length;
     if (ist != IST_SYMBOL_QUOTED) {
-        IONCHECK(_ion_reader_text_intern_symbol(preader, &str, &sym, TRUE));
+        IONCHECK(_ion_reader_text_intern_symbol(preader, &str, NULL, &sym, TRUE));
         if (sym) {
             if (ION_STRING_EQUALS(&ION_SYMBOL_VTM_STRING, &sym->value)) {
                 // This is a symbol identifier, e.g. $2, pointing to the text $ion_1_0, which is a no-op
@@ -392,6 +396,7 @@ iERR _ion_reader_text_load_utas(ION_READER *preader, ION_SUB_TYPE *p_ist)
     BYTE            *next_dst;
     BOOL             is_double_colon;
     BOOL             eos_encountered = FALSE, is_system_value;
+    SID              local_sid;
 
     ASSERT(preader);
     ASSERT(text);
@@ -476,12 +481,15 @@ iERR _ion_reader_text_load_utas(ION_READER *preader, ION_SUB_TYPE *p_ist)
             str->value.value = text->_scanner._value_buffer;
             str->value.length = text->_scanner._value_image.length;
             str->sid = UNKNOWN_SID; // Known symbols don't necessarily have local symbol table mappings in text.
-            IONCHECK(_ion_reader_text_intern_symbol(preader, &str->value, &sym, ist != IST_SYMBOL_QUOTED));
+            ION_STRING_INIT(&str->import_location.name);
+            IONCHECK(_ion_reader_text_intern_symbol(preader, &str->value, &local_sid, &sym, ist != IST_SYMBOL_QUOTED));
             if (sym) {
                 // The original text was a symbol identifier.
                 ASSERT(sym->sid > UNKNOWN_SID);
                 ION_STRING_ASSIGN(&str->value, &sym->value);
-                str->sid = sym->sid;
+                ION_STRING_ASSIGN(&str->import_location.name, &sym->import_location.name);
+                str->sid = local_sid;
+                str->import_location.location = sym->import_location.location;
                 str->add_count = sym->add_count;
             }
 
@@ -924,6 +932,22 @@ iERR _ion_reader_text_has_any_annotations(ION_READER *preader, BOOL *p_has_annot
     iRETURN;
 }
 
+iERR _ion_reader_text_validate_symbol_token(ION_READER *preader, ION_SYMBOL *p_symbol) {
+    iENTER;
+    ION_SYMBOL_TABLE *symbol_table;
+    ASSERT(preader);
+    ASSERT(p_symbol);
+
+    IONCHECK(_ion_reader_text_get_symbol_table(preader, &symbol_table));
+    ASSERT(symbol_table);
+
+    if (p_symbol->sid > symbol_table->max_id) {
+        FAILWITH(IERR_INVALID_SYMBOL);
+    }
+
+    iRETURN;
+}
+
 iERR _ion_reader_text_has_annotation(ION_READER *preader, ION_STRING *annotation, BOOL *p_annotation_found)
 {
     iENTER;
@@ -992,6 +1016,7 @@ iERR _ion_reader_text_get_an_annotation(ION_READER *preader, int32_t idx, ION_ST
 
     // get a pointer to our string header in the annotation string pool
     str = text->_annotation_string_pool + idx;
+    IONCHECK(_ion_reader_text_validate_symbol_token(preader, str));
     IONCHECK(ion_string_copy_to_owner(preader->_temp_entity_pool, p_str, &str->value));
     if (str->sid == 0) {
         ION_STRING_INIT(p_str); // This nulls the string, because symbol 0 has no text representation.
@@ -1019,6 +1044,7 @@ iERR _ion_reader_text_get_an_annotation_sid(ION_READER *preader, int32_t idx, SI
 
     // get a pointer to our string header in the annotation string pool
     str = text->_annotation_string_pool + idx;
+    IONCHECK(_ion_reader_text_validate_symbol_token(preader, str));
     *p_sid = str->sid;
 
     iRETURN;
@@ -1047,6 +1073,7 @@ iERR _ion_reader_text_get_annotations(ION_READER *preader, ION_STRING *p_strs, i
     src = text->_annotation_string_pool;
     dst = p_strs;
     for (idx = 0; idx < text->_annotation_count; idx++) {
+        IONCHECK(_ion_reader_text_validate_symbol_token(preader, src));
         IONCHECK(ion_string_copy_to_owner(preader->_temp_entity_pool, dst, &src->value));
         if (src->sid == 0) {
             ION_STRING_INIT(dst); // This nulls the string, because symbol 0 has no text representation.
@@ -1072,6 +1099,7 @@ iERR _ion_reader_text_get_field_name(ION_READER *preader, ION_STRING **p_pstr)
         FAILWITH(IERR_INVALID_STATE);
     }
 
+    IONCHECK(_ion_reader_text_validate_symbol_token(preader, &text->_field_name));
     // TODO: I'm not sure I like this. The caller is getting a pointer 
     //       into the middle of the parser struct
     if (text->_field_name.sid == 0) {
@@ -1096,6 +1124,7 @@ iERR _ion_reader_text_get_field_name_symbol(ION_READER *preader, ION_SYMBOL **p_
         FAILWITH(IERR_INVALID_STATE);
     }
 
+    IONCHECK(_ion_reader_text_validate_symbol_token(preader, &text->_field_name));
     *p_psymbol = &text->_field_name;
 
     iRETURN;
@@ -1128,6 +1157,7 @@ iERR _ion_reader_text_get_field_sid(ION_READER *preader, SID *p_sid)
         FAILWITH(IERR_INVALID_STATE);
     }
 
+    IONCHECK(_ion_reader_text_validate_symbol_token(preader, &text->_field_name));
     *p_sid = text->_field_name.sid;
     iRETURN;
 }
@@ -1150,6 +1180,7 @@ iERR _ion_reader_text_get_annotation_sids(ION_READER *preader, SID *p_sids, SIZE
 
     for (ii = 0; ii<count; ii++) {
         str = &text->_annotation_string_pool[ii];
+        IONCHECK(_ion_reader_text_validate_symbol_token(preader, str));
         p_sids[ii] = str->sid;
     }
     *p_count = count;
@@ -1180,6 +1211,7 @@ iERR _ion_reader_text_get_annotation_symbols(ION_READER *preader, ION_SYMBOL *p_
     src = text->_annotation_string_pool;
     dst = p_symbols;
     for (idx = 0; idx < text->_annotation_count; idx++) {
+        IONCHECK(_ion_reader_text_validate_symbol_token(preader, src));
         IONCHECK(ion_symbol_copy_to_owner(preader->_temp_entity_pool, dst, src));
         dst++;
         src++;
@@ -1643,6 +1675,9 @@ iERR _ion_reader_text_read_symbol_sid(ION_READER *preader, SID *p_value)
 
     IONCHECK(_ion_symbol_table_find_by_name_helper(preader->_current_symtab, &text->_scanner._value_image, p_value, NULL,
                                                   text->_value_sub_type != IST_SYMBOL_QUOTED));
+    if (*p_value > preader->_current_symtab->max_id) {
+        FAILWITH(IERR_INVALID_SYMBOL);
+    }
 
     iRETURN;
 }
@@ -1653,6 +1688,7 @@ iERR _ion_reader_text_read_symbol(ION_READER *preader, ION_SYMBOL *p_symbol)
     ION_TEXT_READER  *text = &preader->typed_reader.text;
     ION_STRING       *user_str = &text->_scanner._value_image;
     ION_SYMBOL       *sym;
+    SID               local_sid;
 
     ASSERT(preader);
     ASSERT(p_symbol);
@@ -1668,17 +1704,22 @@ iERR _ion_reader_text_read_symbol(ION_READER *preader, ION_SYMBOL *p_symbol)
     }
 
     IONCHECK(_ion_reader_text_load_string_in_value_buffer(preader));
-    IONCHECK(_ion_reader_text_intern_symbol(preader, user_str, &sym, text->_value_sub_type != IST_SYMBOL_QUOTED));
+    IONCHECK(_ion_reader_text_intern_symbol(preader, user_str, &local_sid, &sym, text->_value_sub_type != IST_SYMBOL_QUOTED));
     if (sym) {
+        IONCHECK(_ion_reader_text_validate_symbol_token(preader, sym));
         // This was a symbol identifier, e.g. $10. The user should be presented with the symbol text, not the SID.
         ASSERT(sym->sid > UNKNOWN_SID); // Success to this point means the symbol is defined.
         ION_STRING_ASSIGN(&p_symbol->value, &sym->value);
-        p_symbol->sid = sym->sid;
+        ION_STRING_ASSIGN(&p_symbol->import_location.name, &sym->import_location.name);
+        p_symbol->sid = local_sid;
+        p_symbol->import_location.location = sym->import_location.location;
+        p_symbol->add_count = sym->add_count;
     }
     else {
         // This is a regular text symbol. No local symbol table mapping is required.
         ION_STRING_ASSIGN(&p_symbol->value, user_str);
         p_symbol->sid = UNKNOWN_SID;
+        ION_STRING_INIT(&p_symbol->import_location.name);
     }
     iRETURN;
 }
@@ -1753,10 +1794,11 @@ iERR _ion_reader_text_read_string(ION_READER *preader, ION_STRING *p_user_str)
     IONCHECK(_ion_reader_text_load_string_in_value_buffer(preader));
 
     if (text->_value_sub_type->base_type == tid_SYMBOL) {
-        IONCHECK(_ion_reader_text_intern_symbol(preader, user_str, &sym, text->_value_sub_type != IST_SYMBOL_QUOTED));
+        IONCHECK(_ion_reader_text_intern_symbol(preader, user_str, NULL, &sym, text->_value_sub_type != IST_SYMBOL_QUOTED));
         if (sym) {
             // This was a symbol identifier, e.g. $10. The user should be presented with the symbol text, not the SID.
             ASSERT(sym->sid > UNKNOWN_SID); // Success to this point means the symbol is defined.
+            IONCHECK(_ion_reader_text_validate_symbol_token(preader, sym));
             ION_STRING_ASSIGN(p_user_str, &sym->value);
         }
         else {

--- a/ionc/ion_reader_text.h
+++ b/ionc/ion_reader_text.h
@@ -303,6 +303,7 @@ iERR _ion_reader_text_has_annotation            (ION_READER *preader, ION_STRING
 iERR _ion_reader_text_get_annotation_count      (ION_READER *preader, int32_t *p_count);
 iERR _ion_reader_text_get_an_annotation         (ION_READER *preader, int32_t idx, ION_STRING *p_str);
 iERR _ion_reader_text_get_an_annotation_sid     (ION_READER *preader, int32_t idx, SID *p_sid);
+iERR _ion_reader_text_get_an_annotation_symbol  (ION_READER *preader, int32_t idx, ION_SYMBOL *p_symbol);
 iERR _ion_reader_text_get_field_name            (ION_READER *preader, ION_STRING **p_pstr);
 iERR _ion_reader_text_get_field_name_symbol     (ION_READER *preader, ION_SYMBOL **p_psymbol);
 iERR _ion_reader_text_get_symbol_table          (ION_READER *preader, ION_SYMBOL_TABLE **p_return);

--- a/ionc/ion_reader_text.h
+++ b/ionc/ion_reader_text.h
@@ -304,10 +304,12 @@ iERR _ion_reader_text_get_annotation_count      (ION_READER *preader, int32_t *p
 iERR _ion_reader_text_get_an_annotation         (ION_READER *preader, int32_t idx, ION_STRING *p_str);
 iERR _ion_reader_text_get_an_annotation_sid     (ION_READER *preader, int32_t idx, SID *p_sid);
 iERR _ion_reader_text_get_field_name            (ION_READER *preader, ION_STRING **p_pstr);
+iERR _ion_reader_text_get_field_name_symbol     (ION_READER *preader, ION_SYMBOL **p_psymbol);
 iERR _ion_reader_text_get_symbol_table          (ION_READER *preader, ION_SYMBOL_TABLE **p_return);
 iERR _ion_reader_text_get_field_sid             (ION_READER *preader, SID *p_sid);
 iERR _ion_reader_text_get_annotations           (ION_READER *preader, ION_STRING *p_strs, SIZE max_count, SIZE *p_count);
 iERR _ion_reader_text_get_annotation_sids       (ION_READER *preader, SID *p_sids, SIZE max_count, SIZE *p_count);
+iERR _ion_reader_text_get_annotation_symbols    (ION_READER *preader, ION_SYMBOL *p_symbols, SIZE max_count, SIZE *p_count);
 iERR _ion_reader_text_get_value_offset          (ION_READER *preader, POSITION *p_offset);
 iERR _ion_reader_text_get_value_length          (ION_READER *preader, SIZE *p_length);
 

--- a/ionc/ion_symbol_table.c
+++ b/ionc/ion_symbol_table.c
@@ -1219,12 +1219,11 @@ iERR _ion_symbol_table_parse_possible_symbol_identifier(ION_SYMBOL_TABLE *symtab
             sid += c - '0';
         }
         is_symbol_identifier = TRUE;
-        if (sid == 0) {
+        if (sid == 0 || sid > symtab->max_id) {
             // SID 0 is not in any symbol table, but is available in all symbol table contexts.
-            _ion_symbol_table_allocate_symbol_unknown_text(symtab->owner, 0, &sym);
-        }
-        else if (sid > symtab->max_id) {
-            FAILWITH(IERR_INVALID_SYMBOL); // The requested SID is out of range for the current symtab context.
+            // If the requested SID is out of range for the current symtab context, an error will be raised when the
+            // user retrieves the symbol token.
+            _ion_symbol_table_allocate_symbol_unknown_text(symtab->owner, sid, &sym);
         }
         else if (p_sym) {
             IONCHECK(_ion_symbol_table_find_symbol_by_sid_helper(symtab, sid, &sym));
@@ -1310,8 +1309,6 @@ iERR _ion_symbol_table_local_find_by_sid(ION_SYMBOL_TABLE *symtab, SID sid, ION_
     ASSERT(symtab != NULL);
     ASSERT(p_sym != NULL);
 
-    // TODO if found and this is a shared symtab, set the import location
-
     if (!INDEX_IS_ACTIVE(symtab) && symtab->max_id > DEFAULT_INDEX_BUILD_THRESHOLD) {
         IONCHECK(_ion_symbol_table_initialize_indices_helper(symtab));
     }
@@ -1333,6 +1330,11 @@ iERR _ion_symbol_table_local_find_by_sid(ION_SYMBOL_TABLE *symtab, SID sid, ION_
             _ion_symbol_table_allocate_symbol_unknown_text(symtab->owner, sid, &sym);
         }
 
+    }
+    if (sym && !ION_STRING_IS_NULL(&symtab->name)) {
+        // The symbol is found and this is a shared symbol table. Set the import location.
+        ION_STRING_ASSIGN(&sym->import_location.name, &symtab->name);
+        sym->import_location.location = sid;
     }
     *p_sym = sym;
 
@@ -1372,7 +1374,8 @@ iERR _ion_symbol_table_find_symbol_by_sid_helper(ION_SYMBOL_TABLE *symtab, SID s
     ASSERT(sid > UNKNOWN_SID);
     ASSERT(p_sym);
 
-    if (sid <= symtab->system_symbol_table->max_id) {
+    if (ION_STRING_IS_NULL(&symtab->name) && sid <= symtab->system_symbol_table->max_id) {
+        // Only local symbol tables implicitly import the system symbol table. Shared symbol table SIDs start at 1.
         IONCHECK(_ion_symbol_table_local_find_by_sid(symtab->system_symbol_table, sid, &sym));
     }
     else {
@@ -1392,6 +1395,8 @@ iERR _ion_symbol_table_find_symbol_by_sid_helper(ION_SYMBOL_TABLE *symtab, SID s
                         // The SID is in range, but either the shared symbol table is not found, or the SID refers to a
                         // NULL slot in the shared symbol table. This symbol has unknown text.
                         _ion_symbol_table_allocate_symbol_unknown_text(symtab->owner, sid, &sym);
+                        ION_STRING_ASSIGN(&sym->import_location.name, &imp->descriptor.name);
+                        sym->import_location.location = sid - offset;
                     }
                     ASSERT(sym);
                     break;
@@ -1776,12 +1781,9 @@ iERR _ion_symbol_local_copy_new_owner(void *context, void *dst, void *src, int32
     ION_SYMBOL *symbol_src = (ION_SYMBOL *)src;
 
     if (data_size != sizeof(ION_SYMBOL)) FAILWITH(IERR_INVALID_ARG);
-    ASSERT(dst);
-    ASSERT(src);
     ASSERT(context);
 
-    symbol_dst->sid     = symbol_src->sid;
-    IONCHECK(ion_string_copy_to_owner(context, &symbol_dst->value, &symbol_src->value));
+    IONCHECK(ion_symbol_copy_to_owner(context, symbol_dst, symbol_src));
 
     iRETURN;
 }
@@ -1798,6 +1800,8 @@ iERR _ion_symbol_local_copy_same_owner(void *context, void *dst, void *src, int3
 
     symbol_dst->sid = symbol_src->sid;
     ION_STRING_ASSIGN(&symbol_dst->value, &symbol_src->value);
+    ION_STRING_ASSIGN(&symbol_dst->import_location.name, &symbol_src->import_location.name);
+    symbol_dst->import_location.location = symbol_src->import_location.location;
 
     iRETURN;
 }
@@ -2026,6 +2030,8 @@ void _ion_symbol_table_allocate_symbol_unknown_text(hOWNER owner, SID sid, ION_S
     ION_STRING_INIT(&symbol->value); // NULLS the value.
     symbol->sid = sid;
     symbol->add_count++;
+    ION_STRING_INIT(&symbol->import_location.name); // NULLS the value.
+    symbol->import_location.location = UNKNOWN_SID;
 
     *p_symbol = symbol;
 }
@@ -2057,11 +2063,11 @@ iERR ion_symbol_copy_to_owner(hOWNER owner, ION_SYMBOL *dst, ION_SYMBOL *src)
     ASSERT(dst);
     ASSERT(src);
 
-    //dst = ion_alloc_with_owner(owner, sizeof(ION_SYMBOL));
-    //if (!dst) FAILWITH(IERR_NO_MEMORY);
     dst->sid = src->sid;
     dst->add_count = 0;
     IONCHECK(ion_string_copy_to_owner(owner, &dst->value, &src->value));
+    IONCHECK(ion_string_copy_to_owner(owner, &dst->import_location.name, &src->import_location.name));
+    dst->import_location.location = src->import_location.location;
 
     iRETURN;
 }
@@ -2075,34 +2081,45 @@ iERR ion_symbol_is_equal(ION_SYMBOL *lhs, ION_SYMBOL *rhs, BOOL *is_equal)
     if (lhs == rhs) {
         // Both inputs are the same reference, or NULL.
         *is_equal = TRUE;
-        SUCCEED();
     }
-    if (!lhs ^ !rhs) {
+    else if (!lhs ^ !rhs) {
         // Only one of the inputs is NULL.
         *is_equal = FALSE;
-        SUCCEED();
     }
     // Both are non-NULL, and are not the same reference.
-    if (ION_STRING_IS_NULL(&lhs->value) ^ ION_STRING_IS_NULL(&rhs->value)) {
+    else if (ION_STRING_IS_NULL(&lhs->value) ^ ION_STRING_IS_NULL(&rhs->value)) {
         // Only one of the inputs has unknown text.
         *is_equal = FALSE;
-        SUCCEED();
     }
-    if (ION_STRING_IS_NULL(&lhs->value)) {
+    else if (ION_STRING_IS_NULL(&lhs->value)) {
         ASSERT(ION_STRING_IS_NULL(&rhs->value));
-        if (lhs->sid <= UNKNOWN_SID || rhs->sid <= UNKNOWN_SID) {
+        if (ION_SYMBOL_IMPORT_LOCATION_IS_NULL(rhs) ^ ION_SYMBOL_IMPORT_LOCATION_IS_NULL(lhs)) {
+            *is_equal = FALSE;
+        }
+        else if (!ION_SYMBOL_IMPORT_LOCATION_IS_NULL(rhs)) {
+            ASSERT(!ION_SYMBOL_IMPORT_LOCATION_IS_NULL(lhs));
+            // Both are shared symbols with unknown text. They are equivalent only if their import locations are
+            // equivalent.
+            *is_equal = ION_STRING_EQUALS(&lhs->import_location.name, &rhs->import_location.name)
+                        && (lhs->import_location.location == rhs->import_location.location);
+        }
+        else if (lhs->sid <= UNKNOWN_SID || rhs->sid <= UNKNOWN_SID) {
+            ASSERT(ION_SYMBOL_IMPORT_LOCATION_IS_NULL(lhs));
             FAILWITH(IERR_INVALID_SYMBOL);
         }
-        // TODO if import location is present, compare the import locations. Otherwise, they are equivalent to symbol zero.
-        *is_equal = TRUE;
-        SUCCEED();
+        else {
+            // All local symbols with unknown text are equivalent to each other (and to symbol zero).
+            ASSERT(ION_SYMBOL_IMPORT_LOCATION_IS_NULL(lhs));
+            *is_equal = TRUE;
+        }
     }
-    if (ION_STRING_EQUALS(&lhs->value, &rhs->value)) {
+    else if (ION_STRING_EQUALS(&lhs->value, &rhs->value)) {
         // Both inputs have the same text. They are equivalent regardless of SID or import location.
         *is_equal = TRUE;
-        SUCCEED();
     }
-    *is_equal = FALSE;
+    else {
+        *is_equal = FALSE;
+    }
     iRETURN;
 }
 

--- a/ionc/ion_writer.c
+++ b/ionc/ion_writer.c
@@ -2381,8 +2381,8 @@ iERR _ion_writer_write_one_value_helper(ION_WRITER *pwriter, ION_READER *preader
     iENTER;
 
     ION_TYPE      type;
-    ION_STRING   *fld_name, string_value;
-    ION_SYMBOL    symbol_value;
+    ION_STRING    string_value;
+    ION_SYMBOL    symbol_value, *fld_name;
     SID           sid;
     int32_t       count, ii;
     BOOL          is_null, bool_value, is_in_struct;
@@ -2416,30 +2416,17 @@ iERR _ion_writer_write_one_value_helper(ION_WRITER *pwriter, ION_READER *preader
     case (intptr_t)tid_SEXP:
         break;
     }
-
     IONCHECK(ion_reader_is_in_struct(preader, &is_in_struct));
     if (is_in_struct) {
-        IONCHECK(_ion_reader_get_field_name_helper(preader, &fld_name));
-        if (ION_STRING_IS_NULL(fld_name)) {
-            IONCHECK(_ion_reader_get_field_sid_helper(preader, &sid));
-            IONCHECK(_ion_writer_write_field_sid_helper(pwriter, sid));
-        } else {
-            IONCHECK(_ion_writer_write_field_name_helper(pwriter, fld_name));
-        }
+        IONCHECK(_ion_reader_get_field_name_symbol_helper(preader, &fld_name));
+        IONCHECK(_ion_writer_write_field_name_symbol_helper(pwriter, fld_name));
     }
 
     IONCHECK(_ion_reader_get_annotation_count_helper(preader, &count));
     if (count > 0) {
-        ION_STRING_INIT(&string_value);
         for (ii=0; ii<count; ii++) {
-            IONCHECK(_ion_reader_get_an_annotation_helper(preader, ii, &string_value));
-            if (ION_STRING_IS_NULL(&string_value)) {
-                IONCHECK(_ion_reader_get_an_annotation_sid_helper(preader, ii, &sid));
-                IONCHECK(_ion_writer_add_annotation_sid_helper(pwriter, sid));
-            }
-            else {
-                IONCHECK(_ion_writer_add_annotation_helper(pwriter, &string_value));
-            }
+            IONCHECK(_ion_reader_get_an_annotation_symbol_helper(preader, ii, &symbol_value));
+            IONCHECK(_ion_writer_add_annotation_symbol_helper(pwriter, &symbol_value));
         }
     }
 
@@ -2499,12 +2486,7 @@ iERR _ion_writer_write_one_value_helper(ION_WRITER *pwriter, ION_READER *preader
         break;
     case (intptr_t)tid_SYMBOL:
         IONCHECK(_ion_reader_read_symbol_helper(preader, &symbol_value));
-        if (ION_STRING_IS_NULL(&symbol_value.value)) {
-            IONCHECK(_ion_writer_write_symbol_id_helper(pwriter, symbol_value.sid));
-        }
-        else {
-            IONCHECK(_ion_writer_write_symbol_helper(pwriter, &symbol_value.value));
-        }
+        IONCHECK(_ion_writer_write_ion_symbol_helper(pwriter, &symbol_value));
         break;
     case (intptr_t)tid_CLOB:
     case (intptr_t)tid_BLOB:

--- a/ionc/ion_writer_impl.h
+++ b/ionc/ion_writer_impl.h
@@ -156,15 +156,11 @@ typedef struct _ion_writer
     BOOL               _in_struct;
     SIZE               depth;
 
-    ION_TYPE           field_name_type;     // really ion type is only used for int, string or null (unknown)
-    ION_STRING         field_name;
-    SID                field_name_sid;
+    ION_SYMBOL         field_name;
 
-    ION_TYPE           annotations_type;     // really type is type of annotation, only int, string or null (null for unknown)
     SIZE               annotation_count;
     SIZE               annotation_curr;
-    ION_STRING        *annotations;
-    SID               *annotation_sids;      // new int[10];
+    ION_SYMBOL        *annotations;
 
     BOOL               writer_owns_stream;   // true when open writer created the stream object
     ION_STREAM        *output;
@@ -227,11 +223,13 @@ iERR _ion_writer_set_symbol_table_helper(ION_WRITER *pwriter, ION_SYMBOL_TABLE *
 iERR _ion_writer_get_symbol_table_helper(ION_WRITER *pwriter, ION_SYMBOL_TABLE **p_psymtab);
 iERR _ion_writer_write_field_name_helper(ION_WRITER *pwriter, ION_STRING *name);
 iERR _ion_writer_write_field_sid_helper(ION_WRITER *pwriter, SID sid);
+iERR _ion_writer_write_field_symbol_helper(ION_WRITER *pwriter, ION_SYMBOL *field_name);
 iERR _ion_writer_clear_field_name_helper(ION_WRITER *pwriter);
 iERR _ion_writer_add_annotation_helper(ION_WRITER *pwriter, ION_STRING *annotation);
 iERR _ion_writer_add_annotation_sid_helper(ION_WRITER *pwriter, SID sid);
 iERR _ion_writer_write_annotations_helper(ION_WRITER *pwriter, ION_STRING **p_annotations, int32_t count);
 iERR _ion_writer_write_annotation_sids_helper(ION_WRITER *pwriter, int32_t *p_sids, SIZE count);
+iERR _ion_writer_write_annotation_symbols_helper(ION_WRITER *pwriter, ION_SYMBOL **annotations, SIZE count);
 iERR _ion_writer_clear_annotations_helper(ION_WRITER *pwriter);
 iERR _ion_writer_write_typed_null_helper(ION_WRITER *pwriter, ION_TYPE type);
 iERR _ion_writer_write_bool_helper(ION_WRITER *pwriter, BOOL value);
@@ -245,6 +243,7 @@ iERR _ion_writer_write_timestamp_helper(ION_WRITER *pwriter, ION_TIMESTAMP *valu
 iERR _ion_writer_write_symbol_id_helper(ION_WRITER *pwriter, SID value);
 iERR _ion_writer_validate_symbol_id(ION_WRITER *pwriter, SID sid);
 iERR _ion_writer_write_symbol_helper(ION_WRITER *pwriter, ION_STRING *symbol);
+iERR _ion_writer_write_ion_symbol_helper(ION_WRITER *pwriter, ION_SYMBOL *symbol);
 iERR _ion_writer_write_string_helper(ION_WRITER *pwriter, ION_STRING *pstr);
 iERR _ion_writer_write_clob_helper(ION_WRITER *pwriter, BYTE *p_buf, SIZE length);
 iERR _ion_writer_write_blob_helper(ION_WRITER *pwriter, BYTE *p_buf, SIZE length);

--- a/ionc/ion_writer_impl.h
+++ b/ionc/ion_writer_impl.h
@@ -227,6 +227,7 @@ iERR _ion_writer_write_field_name_symbol_helper(ION_WRITER *pwriter, ION_SYMBOL 
 iERR _ion_writer_clear_field_name_helper(ION_WRITER *pwriter);
 iERR _ion_writer_add_annotation_helper(ION_WRITER *pwriter, ION_STRING *annotation);
 iERR _ion_writer_add_annotation_sid_helper(ION_WRITER *pwriter, SID sid);
+iERR _ion_writer_add_annotation_symbol_helper(ION_WRITER *pwriter, ION_SYMBOL *annotation);
 iERR _ion_writer_write_annotations_helper(ION_WRITER *pwriter, ION_STRING **p_annotations, int32_t count);
 iERR _ion_writer_write_annotation_sids_helper(ION_WRITER *pwriter, int32_t *p_sids, SIZE count);
 iERR _ion_writer_write_annotation_symbols_helper(ION_WRITER *pwriter, ION_SYMBOL **annotations, SIZE count);

--- a/ionc/ion_writer_impl.h
+++ b/ionc/ion_writer_impl.h
@@ -223,7 +223,7 @@ iERR _ion_writer_set_symbol_table_helper(ION_WRITER *pwriter, ION_SYMBOL_TABLE *
 iERR _ion_writer_get_symbol_table_helper(ION_WRITER *pwriter, ION_SYMBOL_TABLE **p_psymtab);
 iERR _ion_writer_write_field_name_helper(ION_WRITER *pwriter, ION_STRING *name);
 iERR _ion_writer_write_field_sid_helper(ION_WRITER *pwriter, SID sid);
-iERR _ion_writer_write_field_symbol_helper(ION_WRITER *pwriter, ION_SYMBOL *field_name);
+iERR _ion_writer_write_field_name_symbol_helper(ION_WRITER *pwriter, ION_SYMBOL *field_name);
 iERR _ion_writer_clear_field_name_helper(ION_WRITER *pwriter);
 iERR _ion_writer_add_annotation_helper(ION_WRITER *pwriter, ION_STRING *annotation);
 iERR _ion_writer_add_annotation_sid_helper(ION_WRITER *pwriter, SID sid);

--- a/ionc/ion_writer_text.c
+++ b/ionc/ion_writer_text.c
@@ -243,7 +243,7 @@ iERR _ion_writer_text_start_value(ION_WRITER *pwriter)
     // write field name
     if (pwriter->_in_struct) {
         IONCHECK(_ion_writer_get_field_name_as_string_helper(pwriter, &str));
-        IONCHECK(_ion_writer_text_append_symbol_string(pwriter->output, &str, pwriter->options.escape_all_non_ascii, pwriter->field_name_type == tid_STRING));
+        IONCHECK(_ion_writer_text_append_symbol_string(pwriter->output, &str, pwriter->options.escape_all_non_ascii, !ION_STRING_IS_NULL(&pwriter->field_name.value)));
         ION_TEXT_WRITER_APPEND_CHAR(':');
         IONCHECK(_ion_writer_clear_field_name_helper(pwriter));
     }
@@ -253,7 +253,7 @@ iERR _ion_writer_text_start_value(ION_WRITER *pwriter)
     if (count > 0) {
         for (ii=0; ii<count; ii++) {
             IONCHECK(_ion_writer_get_annotation_as_string_helper(pwriter, ii, &str));
-            IONCHECK(_ion_writer_text_append_symbol_string(pwriter->output, &str, pwriter->options.escape_all_non_ascii, pwriter->annotations_type == tid_STRING));
+            IONCHECK(_ion_writer_text_append_symbol_string(pwriter->output, &str, pwriter->options.escape_all_non_ascii, !ION_STRING_IS_NULL(&pwriter->annotations[ii].value)));
             ION_TEXT_WRITER_APPEND_CHAR(':');
             ION_TEXT_WRITER_APPEND_CHAR(':');
         }

--- a/test/gather_vectors.cpp
+++ b/test/gather_vectors.cpp
@@ -128,6 +128,8 @@ void add_to_skip(std::string prefix, std::string suffix) {
 std::vector<std::string> *skip_list() {
     // Assumption: these tests are single-threaded.
     if (_skip_list.size() == 0) {
+        add_to_skip(good_path, "item1.10n");
+
         add_to_skip(good_path, "utf16.ion");
         add_to_skip(good_path, "utf32.ion");
 

--- a/test/ion_assert.cpp
+++ b/test/ion_assert.cpp
@@ -74,6 +74,8 @@ char *ionStringToString(ION_STRING *value) {
 ::testing::AssertionResult assertIonSymbolEq(ION_SYMBOL *expected, ION_SYMBOL *actual) {
     char *expected_str = NULL;
     char *actual_str = NULL;
+    char *expected_import_str = NULL;
+    char *actual_import_str = NULL;
     if (!(expected == NULL ^ actual == NULL)) {
         if (expected == NULL) {
             return ::testing::AssertionSuccess();
@@ -86,10 +88,14 @@ char *ionStringToString(ION_STRING *value) {
     }
     expected_str = ionStringToString(&expected->value);
     actual_str = ionStringToString(&actual->value);
+    expected_import_str = ionStringToString(&expected->import_location.name);
+    actual_import_str = ionStringToString(&actual->import_location.name);
     ::testing::AssertionResult result = ::testing::AssertionFailure()
-            << std::string("(") << expected_str << "," << expected->sid
-            << ")  vs. ("
-            << actual_str << "," << actual->sid << ")"; // TODO add import locations
+            << std::string("(text=") << expected_str << ", local_sid=" << expected->sid
+                << ", location=(" << expected_import_str << ", " << expected->import_location.location << "))"
+            << " vs. "
+            << "(text=" << actual_str << ", local_sid=" << actual->sid
+                << ", location=(" << actual_import_str << ", " << actual->import_location.location << "))";
     free(expected_str);
     free(actual_str);
     return result;

--- a/test/ion_assert.cpp
+++ b/test/ion_assert.cpp
@@ -37,7 +37,7 @@ char *ionIntToString(ION_INT *value) {
 char *ionStringToString(ION_STRING *value) {
     BYTE *src, *dst;
     SIZE len;
-    if (value) {
+    if (!ION_STRING_IS_NULL(value)) {
         src = value->value;
         len = value->length;
     }
@@ -66,6 +66,30 @@ char *ionStringToString(ION_STRING *value) {
     actual_str = ionStringToString(actual);
     ::testing::AssertionResult result = ::testing::AssertionFailure()
             << std::string("") << expected_str << "  vs. " << actual_str;
+    free(expected_str);
+    free(actual_str);
+    return result;
+}
+
+::testing::AssertionResult assertIonSymbolEq(ION_SYMBOL *expected, ION_SYMBOL *actual) {
+    char *expected_str = NULL;
+    char *actual_str = NULL;
+    if (!(expected == NULL ^ actual == NULL)) {
+        if (expected == NULL) {
+            return ::testing::AssertionSuccess();
+        }
+        BOOL is_equal;
+        ION_EXPECT_OK(ion_symbol_is_equal(expected, actual, &is_equal));
+        if (is_equal) {
+            return ::testing::AssertionSuccess();
+        }
+    }
+    expected_str = ionStringToString(&expected->value);
+    actual_str = ionStringToString(&actual->value);
+    ::testing::AssertionResult result = ::testing::AssertionFailure()
+            << std::string("(") << expected_str << "," << expected->sid
+            << ")  vs. ("
+            << actual_str << "," << actual->sid << ")"; // TODO add import locations
     free(expected_str);
     free(actual_str);
     return result;
@@ -117,8 +141,8 @@ char *ionStringToString(ION_STRING *value) {
             << std::string(expected_str, (size_t)expected_str_len) << " vs. " << std::string(actual_str, (size_t)actual_str_len);
 }
 
-BOOL ionStringEq(ION_STRING *expected, ION_STRING *actual) {
-    return assertIonStringEq(expected, actual) == ::testing::AssertionSuccess();
+BOOL ionSymbolEq(ION_SYMBOL *expected, ION_SYMBOL *actual) {
+    return assertIonSymbolEq(expected, actual) == ::testing::AssertionSuccess();
 }
 
 BOOL assertIonScalarEq(IonEvent *expected, IonEvent *actual, ASSERTION_TYPE assertion_type) {
@@ -147,6 +171,8 @@ BOOL assertIonScalarEq(IonEvent *expected, IonEvent *actual, ASSERTION_TYPE asse
             ION_EXPECT_TIMESTAMP_EQ((ION_TIMESTAMP *) expected_value, (ION_TIMESTAMP *) actual_value);
             break;
         case tid_SYMBOL_INT:
+            ION_EXPECT_SYMBOL_EQ((ION_SYMBOL *) expected_value, (ION_SYMBOL *) actual_value);
+            break;
         case tid_STRING_INT:
         case tid_CLOB_INT:
         case tid_BLOB_INT: // Clobs and blobs are stored in ION_STRINGs too...
@@ -175,14 +201,14 @@ BOOL assertIonStructIsSubset(IonEventStream *stream_expected, size_t index_expec
         if (expected->event_type == CONTAINER_END && expected->depth == target_depth) {
             break;
         }
-        ION_STRING *expected_field_name = expected->field_name;
+        ION_SYMBOL *expected_field_name = expected->field_name;
         EXPECT_TRUE(expected_field_name != NULL);
         while (TRUE) {
             if (skips.count(index_actual) == 0) {
                 IonEvent *actual = stream_actual->at(index_actual);
                 ION_ASSERT(!(actual->event_type == CONTAINER_END && actual->depth == target_depth),
                            "Reached end of struct before finding matching field.");
-                if (ionStringEq(expected_field_name, actual->field_name)
+                if (ionSymbolEq(expected_field_name, actual->field_name)
                     && assertIonEventsEq(stream_expected, index_expected, stream_actual, index_actual,
                                          ASSERTION_TYPE_SET_FLAG)) {
                     // Skip indices that have already matched. Ensures that structs with different numbers of the same
@@ -238,10 +264,10 @@ BOOL assertIonEventsEq(IonEventStream *stream_expected, size_t index_expected, I
     ION_EXPECT_EQ(expected->event_type, actual->event_type);
     ION_EXPECT_EQ(expected->ion_type, actual->ion_type);
     ION_EXPECT_EQ(expected->depth, actual->depth);
-    ION_EXPECT_STRING_EQ(expected->field_name, actual->field_name);
+    ION_EXPECT_SYMBOL_EQ(expected->field_name, actual->field_name);
     ION_EXPECT_EQ(expected->num_annotations, actual->num_annotations);
     for (size_t i = 0; i < expected->num_annotations; i++) {
-        ION_EXPECT_STRING_EQ(expected->annotations[i], actual->annotations[i]);
+        ION_EXPECT_SYMBOL_EQ(expected->annotations[i], actual->annotations[i]);
     }
     switch (expected->event_type) {
         case STREAM_END:

--- a/test/ion_assert.h
+++ b/test/ion_assert.h
@@ -127,6 +127,25 @@
     } \
 } \
 
+#define ION_EXPECT_SYMBOL_EQ(x, y) { \
+    switch (assertion_type) { \
+        case ASSERTION_TYPE_NORMAL: \
+            EXPECT_TRUE(assertIonSymbolEq(x, y)) << "Test: " << g_CurrentTest; \
+            break; \
+        case ASSERTION_TYPE_SET_FLAG: \
+            BOOL _ion_symbol_is_equal_result; \
+            if ((x) == NULL ^ (y) == NULL) return FALSE; \
+            if ((x) != NULL) { \
+                ION_EXPECT_OK(ion_symbol_is_equal(x, y, &_ion_symbol_is_equal_result)); \
+                if (!_ion_symbol_is_equal_result) return FALSE; \
+            } \
+            break; \
+        default: \
+            EXPECT_FALSE("Illegal state: unknown assertion type."); \
+            break; \
+    } \
+} \
+
 #define ION_EXPECT_INT_EQ(x, y) { \
     int _ion_int_assertion_result = 0; \
     switch (assertion_type) { \
@@ -228,6 +247,7 @@ char *ionIntToString(ION_INT *value);
 char *ionStringToString(ION_STRING *value);
 
 ::testing::AssertionResult assertIonStringEq(ION_STRING *expected, ION_STRING *actual);
+::testing::AssertionResult assertIonSymbolEq(ION_SYMBOL *expected, ION_SYMBOL *actual);
 ::testing::AssertionResult assertIonIntEq(ION_INT *expected, ION_INT *actual);
 ::testing::AssertionResult assertIonDecimalEq(ION_DECIMAL *expected, ION_DECIMAL *actual);
 
@@ -237,9 +257,9 @@ char *ionStringToString(ION_STRING *value);
 ::testing::AssertionResult assertIonTimestampEq(ION_TIMESTAMP *expected, ION_TIMESTAMP *actual);
 
 /**
- * Returns TRUE if and only if assertIonStringEq succeeds for the inputs.
+ * Returns TRUE if and only if assertIonSymbolEq succeeds for the inputs.
  */
-BOOL ionStringEq(ION_STRING *expected, ION_STRING *actual);
+BOOL ionSymbolEq(ION_SYMBOL *expected, ION_SYMBOL *actual);
 
 /**
  * Tests the values starting at the given indices in the given streams (they may be the same) for equivalence

--- a/test/ion_event_stream.cpp
+++ b/test/ion_event_stream.cpp
@@ -190,8 +190,7 @@ iERR read_next_value(hREADER hreader, IonEventStream *stream, ION_TYPE t, BOOL i
 
     if (in_struct) {
         ION_SYMBOL *field_name_tmp;
-        // TODO this needs to be a public API
-        IONCHECKORFREE2(_ion_reader_get_field_symbol_helper(hreader, &field_name_tmp));
+        IONCHECKORFREE2(ion_reader_get_field_name_symbol(hreader, &field_name_tmp));
         copy_ion_symbol(&field_name, field_name_tmp);
     }
 
@@ -199,8 +198,7 @@ iERR read_next_value(hREADER hreader, IonEventStream *stream, ION_TYPE t, BOOL i
     if (annotation_count > 0) {
         annotations_tmp = (ION_SYMBOL *)calloc((size_t)annotation_count, sizeof(ION_SYMBOL));
         annotations = (ION_SYMBOL **)calloc((size_t)annotation_count, sizeof(ION_SYMBOL *));
-        // TODO this needs to be a public API
-        IONCHECKORFREE(_ion_reader_get_annotation_symbols_helper(hreader, annotations_tmp, annotation_count, &annotation_count),
+        IONCHECKORFREE(ion_reader_get_annotation_symbols(hreader, annotations_tmp, annotation_count, &annotation_count),
                        annotations_tmp);
         for (int i = 0; i < annotation_count; i++) {
             copy_ion_symbol(&annotations[i], &annotations_tmp[i]);
@@ -263,8 +261,7 @@ iERR read_next_value(hREADER hreader, IonEventStream *stream, ION_TYPE t, BOOL i
         case tid_SYMBOL_INT:
         {
             ION_SYMBOL tmp, *symbol_value;
-            // TODO this should be a public API
-            IONCHECKORFREE2(_ion_reader_read_symbol_helper(hreader, &tmp));
+            IONCHECKORFREE2(ion_reader_read_symbol(hreader, &tmp));
             copy_ion_symbol(&symbol_value, &tmp);
             event->value = symbol_value;
             break;

--- a/test/ion_event_stream.cpp
+++ b/test/ion_event_stream.cpp
@@ -430,8 +430,7 @@ iERR write_scalar(hWRITER writer, IonEvent *event) {
             IONCHECK(ion_writer_write_timestamp(writer, (ION_TIMESTAMP *)event->value));
             break;
         case tid_SYMBOL_INT:
-            // TODO this needs to be a public API
-            IONCHECK(_ion_writer_write_ion_symbol_helper(writer, (ION_SYMBOL *)event->value));
+            IONCHECK(ion_writer_write_ion_symbol(writer, (ION_SYMBOL *)event->value));
             break;
         case tid_STRING_INT:
             IONCHECK(ion_writer_write_string(writer, (ION_STRING *)event->value));
@@ -452,12 +451,10 @@ iERR write_scalar(hWRITER writer, IonEvent *event) {
 iERR write_event(hWRITER writer, IonEvent *event) {
     iENTER;
     if (event->field_name) {
-        // TODO this needs to be a public API
-        IONCHECK(_ion_writer_write_field_name_symbol_helper(writer, event->field_name));
+        IONCHECK(ion_writer_write_field_name_symbol(writer, event->field_name));
     }
     if (event->num_annotations) {
-        // TODO this needs to be a public API
-        IONCHECK(_ion_writer_write_annotation_symbols_helper(writer, event->annotations, event->num_annotations));
+        IONCHECK(ion_writer_write_annotation_symbols(writer, event->annotations, event->num_annotations));
     }
     switch (event->event_type) {
         case CONTAINER_START:

--- a/test/ion_event_stream.h
+++ b/test/ion_event_stream.h
@@ -60,13 +60,13 @@ class IonEvent {
 public:
     ION_EVENT_TYPE event_type;
     ION_TYPE ion_type;
-    ION_STRING *field_name;
-    ION_STRING **annotations;
+    ION_SYMBOL *field_name;
+    ION_SYMBOL **annotations;
     SIZE num_annotations;
     int depth;
     void *value;
 
-    IonEvent(ION_EVENT_TYPE event_type, ION_TYPE ion_type, ION_STRING *field_name, ION_STRING **annotations, SIZE num_annotations, int depth) {
+    IonEvent(ION_EVENT_TYPE event_type, ION_TYPE ion_type, ION_SYMBOL *field_name, ION_SYMBOL **annotations, SIZE num_annotations, int depth) {
         this->event_type = event_type;
         this->ion_type = ion_type;
         this->field_name = field_name;
@@ -87,8 +87,8 @@ public:
      * Creates a new IonEvent from the given parameters, appends it to the IonEventStream, and returns it.
      * It is up to the caller to set the returned IonEvent's value.
      */
-    IonEvent *append_new(ION_EVENT_TYPE event_type, ION_TYPE ion_type, ION_STRING *field_name,
-                         ION_STRING **annotations, SIZE num_annotations, int depth);
+    IonEvent *append_new(ION_EVENT_TYPE event_type, ION_TYPE ion_type, ION_SYMBOL *field_name,
+                         ION_SYMBOL **annotations, SIZE num_annotations, int depth);
 
     size_t size() {
         return event_stream->size();

--- a/test/test_ion_symbol.cpp
+++ b/test/test_ion_symbol.cpp
@@ -1166,20 +1166,20 @@ TEST_P(BinaryAndTextTest, ReaderCorrectlySetsImportLocation) {
     ION_ASSERT_OK(ion_reader_step_in(reader));
 
     ION_ASSERT_OK(ion_reader_next(reader, &type));
-    ION_ASSERT_OK(_ion_reader_get_annotation_symbols_helper(reader, annotation, 1, &annotation_count));
+    ION_ASSERT_OK(ion_reader_get_annotation_symbols(reader, annotation, 1, &annotation_count));
     ASSERT_EQ(1, annotation_count);
     ASSERT_TRUE(assertIonStringEq(&import2_name, &annotation[0].import_location.name));
     ASSERT_EQ(1, annotation[0].import_location.location);
     ASSERT_TRUE(assertIonStringEq(&sym2, &annotation[0].value));
     ASSERT_EQ(11, annotation[0].sid);
 
-    ION_ASSERT_OK(_ion_reader_get_field_symbol_helper(reader, &field_name));
+    ION_ASSERT_OK(ion_reader_get_field_name_symbol(reader, &field_name));
     ASSERT_TRUE(assertIonStringEq(&import1_name, &field_name->import_location.name));
     ASSERT_EQ(1, field_name->import_location.location);
     ASSERT_TRUE(assertIonStringEq(&sym1, &field_name->value));
     ASSERT_EQ(10, field_name->sid);
 
-    ION_ASSERT_OK(_ion_reader_read_symbol_helper(reader, &value));
+    ION_ASSERT_OK(ion_reader_read_symbol(reader, &value));
     ASSERT_TRUE(assertIonStringEq(&import2_name, &value.import_location.name));
     ASSERT_EQ(2, value.import_location.location);
     ASSERT_TRUE(assertIonStringEq(&sym3, &value.value));
@@ -1219,18 +1219,18 @@ TEST_P(BinaryAndTextTest, LocalSymbolHasNoImportLocation) {
     ION_ASSERT_OK(ion_reader_next(reader, &type));
     ASSERT_EQ(tid_SYMBOL, type);
 
-    ION_ASSERT_OK(_ion_reader_get_field_symbol_helper(reader, &field_name));
+    ION_ASSERT_OK(ion_reader_get_field_name_symbol(reader, &field_name));
     ASSERT_TRUE(assertIonStringEq(&zoo, &field_name->value));
     ASSERT_TRUE(ION_SYMBOL_IMPORT_LOCATION_IS_NULL(field_name));
     ASSERT_EQ(is_binary ? 10 : UNKNOWN_SID, field_name->sid);
 
-    ION_ASSERT_OK(_ion_reader_get_annotation_symbols_helper(reader, annotation, 1, &annotation_count));
+    ION_ASSERT_OK(ion_reader_get_annotation_symbols(reader, annotation, 1, &annotation_count));
     ASSERT_EQ(1, annotation_count);
     ASSERT_TRUE(assertIonStringEq(&zar, &annotation[0].value));
     ASSERT_TRUE(ION_SYMBOL_IMPORT_LOCATION_IS_NULL(&annotation[0]));
     ASSERT_EQ(is_binary ? 11 : UNKNOWN_SID, annotation[0].sid);
 
-    ION_ASSERT_OK(_ion_reader_read_symbol_helper(reader, &value));
+    ION_ASSERT_OK(ion_reader_read_symbol(reader, &value));
     ASSERT_TRUE(assertIonStringEq(&zaz, &value.value));
     ASSERT_TRUE(ION_SYMBOL_IMPORT_LOCATION_IS_NULL(&value));
     ASSERT_EQ(is_binary ? 12 : UNKNOWN_SID, value.sid);
@@ -1259,7 +1259,7 @@ TEST_P(BinaryAndTextTest, ReadingOutOfRangeAnnotationSIDFails) {
     ION_ASSERT_OK(ion_reader_open_buffer(&reader, (BYTE *)ion_data, ion_data_len, NULL));
     ION_ASSERT_OK(ion_reader_next(reader, &type));
     ASSERT_EQ(tid_INT, type);
-    ASSERT_EQ(IERR_INVALID_SYMBOL, _ion_reader_get_annotation_symbols_helper(reader, annotations, 1, &annotation_count));
+    ASSERT_EQ(IERR_INVALID_SYMBOL, ion_reader_get_annotation_symbols(reader, annotations, 1, &annotation_count));
     ION_ASSERT_OK(ion_reader_close(reader));
 }
 
@@ -1285,7 +1285,7 @@ TEST_P(BinaryAndTextTest, ReadingOutOfRangeFieldNameSIDFails) {
     ION_ASSERT_OK(ion_reader_step_in(reader));
     ION_ASSERT_OK(ion_reader_next(reader, &type));
     ASSERT_EQ(tid_INT, type);
-    ASSERT_EQ(IERR_INVALID_SYMBOL, _ion_reader_get_field_symbol_helper(reader, &field_name));
+    ASSERT_EQ(IERR_INVALID_SYMBOL, ion_reader_get_field_name_symbol(reader, &field_name));
     ION_ASSERT_OK(ion_reader_close(reader));
 }
 
@@ -1308,6 +1308,6 @@ TEST_P(BinaryAndTextTest, ReadingOutOfRangeSymbolValueSIDFails) {
     ION_ASSERT_OK(ion_reader_open_buffer(&reader, (BYTE *)ion_data, ion_data_len, NULL));
     ION_ASSERT_OK(ion_reader_next(reader, &type));
     ASSERT_EQ(tid_SYMBOL, type);
-    ASSERT_EQ(IERR_INVALID_SYMBOL, _ion_reader_read_symbol_helper(reader, &symbol));
+    ASSERT_EQ(IERR_INVALID_SYMBOL, ion_reader_read_symbol(reader, &symbol));
     ION_ASSERT_OK(ion_reader_close(reader));
 }

--- a/test/test_ion_text.cpp
+++ b/test/test_ion_text.cpp
@@ -353,9 +353,11 @@ TEST(IonTextSymbol, ReaderReadsSymbolValueTrueIVM) {
     const char *ion_text = "$ion_symbol_table::{symbols:[\"foo\"]} $ion_1_0 $10";
     hREADER reader;
     ION_TYPE type;
+    SID sid;
 
     ION_ASSERT_OK(ion_test_new_text_reader(ion_text, &reader));
-    ASSERT_EQ(IERR_INVALID_SYMBOL, ion_reader_next(reader, &type));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(IERR_INVALID_SYMBOL, ion_reader_read_symbol_sid(reader, &sid));
 
     ION_ASSERT_OK(ion_reader_close(reader));
 }

--- a/test/test_ion_text.cpp
+++ b/test/test_ion_text.cpp
@@ -160,13 +160,13 @@ TEST(IonTextSymbol, ReaderReadsSymbolValueSymbolZero) {
 
     ION_ASSERT_OK(ion_reader_next(reader, &type));
     ASSERT_EQ(tid_SYMBOL, type);
-    ION_ASSERT_OK(_ion_reader_read_symbol_helper(reader, &symbol_value));
+    ION_ASSERT_OK(ion_reader_read_symbol(reader, &symbol_value));
     ASSERT_TRUE(ION_STRING_IS_NULL(&symbol_value.value));
     ASSERT_EQ(0, symbol_value.sid); // Because it was unquoted, this represents symbol zero.
 
     ION_ASSERT_OK(ion_reader_next(reader, &type));
     ASSERT_EQ(tid_SYMBOL, type);
-    ION_ASSERT_OK(_ion_reader_read_symbol_helper(reader, &symbol_value));
+    ION_ASSERT_OK(ion_reader_read_symbol(reader, &symbol_value));
     ASSERT_STREQ("$0", ionStringToString(&symbol_value.value)); // This one just looks like symbol zero, but it's actually a user symbol with the text $0
 
     ION_ASSERT_OK(ion_reader_close(reader));
@@ -200,7 +200,7 @@ TEST(IonTextSymbol, ReaderReadsAnnotationSymbolZero) {
     ION_ASSERT_OK(ion_reader_get_annotations(reader, annotation_strs, 1, &num_annotations));
     ASSERT_EQ(1, num_annotations);
     ASSERT_TRUE(ION_STRING_IS_NULL(&annotation_strs[0]));
-    ION_ASSERT_OK(_ion_reader_read_symbol_helper(reader, &symbol));
+    ION_ASSERT_OK(ion_reader_read_symbol(reader, &symbol));
     ASSERT_STREQ("$0", ionStringToString(&symbol.value)); // This one just looks like symbol zero, but it's actually a user symbol with the text $0
 
     ION_ASSERT_OK(ion_reader_close(reader));

--- a/test/test_vectors.cpp
+++ b/test/test_vectors.cpp
@@ -340,7 +340,7 @@ void testComparisonSets(IonEventStream *stream, COMPARISON_TYPE comparison_type)
             ASSERT_EQ(CONTAINER_START, event->event_type);
             ASSERT_TRUE((tid_SEXP == event->ion_type) || (tid_LIST == event->ion_type));
             size_t step = valueEventLength(stream, i);
-            char *first_annotation = (event->num_annotations == 1) ? ionStringToString(event->annotations[0]) : NULL;
+            char *first_annotation = (event->num_annotations == 1) ? ionStringToString(&event->annotations[0]->value) : NULL;
             if (first_annotation && !strcmp(first_annotation, embeddedDocumentsAnnotation)) {
                 testEmbeddedDocumentSet(stream, i + 1, 0, comparison_type);
             } else {


### PR DESCRIPTION
Import location, defined as an import name and position within that import, is essential for determining equivalence of symbol tokens with unknown text. Symbol tokens with unknown text but equivalent import locations are defined as equivalent by the spec. This also allows a writer to correctly write symbol tokens with unknown text.