### PR TITLE
Adds ability to register a callback with the reader to be notified upon change of local symbol table context.

### DIFF
--- a/ionc/inc/ion_reader.h
+++ b/ionc/inc/ion_reader.h
@@ -22,6 +22,34 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * A function that may be called by the reader upon a change to the stream's symbol table context.
+ *
+ * For example, an ION_READER_CONTEXT_CALLBACK function may be used to wrap `ion_writer_add_imported_tables`, with the
+ * user context pointing to a writer instance, in order to update the writer's symbol table context in lockstep with
+ * the reader.
+ *
+ * @param context - User-provided context, e.g., a hWRITER.
+ * @param imports - A collection of ION_SYMBOL_TABLE_IMPORT, representing the shared symbol tables in the new symbol
+ *  table context.
+ */
+typedef iERR (*ION_READER_CONTEXT_CALLBACK)(void *context, ION_COLLECTION *imports);
+
+typedef struct _ion_reader_context_change_notifier {
+    /**
+     * The function to call upon a change to the reader's symbol table context.
+     */
+    ION_READER_CONTEXT_CALLBACK notify;
+
+    /**
+     * The user context to provide as the first argument to `notify`. May be NULL.
+     */
+    void *context;
+
+} ION_READER_CONTEXT_CHANGE_NOTIFIER;
+
+
 /** Reader configuration data, could be supplied by user during reader creation time.
  * All fields in the structure are defaulted to 0, except for the following:
  *
@@ -113,6 +141,11 @@ typedef struct _ion_reader_options
      * Note that up to 34 digits of precision will always be supported, even if configured to be less than 34.
      */
     decContext *decimal_context;
+
+    /** Notification callback data to be used upon symbol table context change. Ignored if
+     * `context_change_notifier.notify` is NULL.
+     */
+    ION_READER_CONTEXT_CHANGE_NOTIFIER context_change_notifier;
 
 } ION_READER_OPTIONS;
 

--- a/ionc/inc/ion_writer.h
+++ b/ionc/inc/ion_writer.h
@@ -170,8 +170,34 @@ ION_API_EXPORT iERR ion_writer_get_depth            (hWRITER hwriter, SIZE *p_de
 
 ION_API_EXPORT iERR ion_writer_set_catalog          (hWRITER hwriter, hCATALOG    hcatalog);
 ION_API_EXPORT iERR ion_writer_get_catalog          (hWRITER hwriter, hCATALOG *p_hcatalog);
+
+/**
+ * Sets the writer's symbol table.
+ *
+ * If the writer's current symbol table context must be serialized, forces the writer to finish and flush its current
+ * symbol table context (with the same side-effects as `ion_writer_finish`) first. If the given symbol table is a shared
+ * symbol table, a new local symbol table that imports that shared symbol table is created. Raises an error if a
+ * manually-written symbol table is in progress or if the writer is not at the top level.
+ */
 ION_API_EXPORT iERR ion_writer_set_symbol_table     (hWRITER hwriter, hSYMTAB     hsymtab);
 ION_API_EXPORT iERR ion_writer_get_symbol_table     (hWRITER hwriter, hSYMTAB  *p_hsymtab);
+
+/**
+ * Adds the given list of imports to the writer's list of imports. These imports will only be used in the writer's
+ * current symbol table context. To configure the writer to use the same list of imports for each new symbol table
+ * context, convey that list of imports through ION_WRITER_OPTIONS.
+ *
+ * If the writer's current symbol table context must be serialized, forces the writer to finish and flush its current
+ * symbol table context (with the same side-effects as `ion_writer_finish`) first. A new symbol table context is then
+ * created, starting with any imports specified in ION_WRITER_OPTIONS, and followed by the list of imports given to this
+ * function.
+ *
+ * This function may be called multiple times in succession without changing the current symbol table context as long as
+ * no values have been written in between calls; in this case, this function appends to the writer's list of imports.
+ *
+ * Raises an error if a manually-written symbol table is in progress or if the writer is not at the top level.
+ */
+ION_API_EXPORT iERR ion_writer_add_imported_tables  (hWRITER hwriter, ION_COLLECTION *imports);
 
 /**
  * Sets the writer's current field name. Only valid if the writer is currently in a struct. It is the caller's

--- a/ionc/ion_collection.c
+++ b/ionc/ion_collection.c
@@ -216,6 +216,79 @@ iERR _ion_collection_copy( ION_COLLECTION *dst, ION_COLLECTION *src, ION_COPY_FN
     iRETURN;
 }
 
+iERR _ion_collection_compare(ION_COLLECTION *lhs, ION_COLLECTION *rhs, ION_COMPARE_FN compare_contents_fn, BOOL *is_equal)
+{
+    iENTER;
+    ION_COLLECTION_NODE *lhs_node, *rhs_node;
+
+    ASSERT(is_equal != NULL);
+    ASSERT(compare_contents_fn != NULL);
+
+    if (lhs == NULL ^ rhs == NULL) {
+        *is_equal = FALSE;
+        SUCCEED();
+    }
+    if (lhs == NULL) {
+        ASSERT(rhs == NULL);
+        *is_equal = TRUE;
+        SUCCEED();
+    }
+    if (lhs->_count != rhs->_count) {
+        *is_equal = FALSE;
+        SUCCEED();
+    }
+    if (lhs->_node_size != rhs->_node_size) {
+        *is_equal = FALSE;
+        SUCCEED();
+    }
+
+    lhs_node = lhs->_head;
+    rhs_node = rhs->_head;
+
+    while (lhs_node != NULL) {
+        ASSERT(rhs_node != NULL);
+        IONCHECK(compare_contents_fn(IPCN_pNODE_TO_pDATA(lhs_node), IPCN_pNODE_TO_pDATA(rhs_node), is_equal));
+        if (!(*is_equal)) {
+            SUCCEED();
+        }
+        lhs_node = lhs_node->_next;
+        rhs_node = rhs_node->_next;
+    }
+
+    *is_equal = TRUE;
+
+    iRETURN;
+}
+
+iERR _ion_collection_contains(ION_COLLECTION *collection, void *element, ION_COMPARE_FN compare_contents_fn, BOOL *contains)
+{
+    iENTER;
+    ION_COLLECTION_NODE *node;
+    BOOL is_equal;
+
+    ASSERT(contains);
+    ASSERT(compare_contents_fn != NULL);
+    ASSERT(collection);
+
+    if (!element || collection->_count == 0) {
+        *contains = FALSE;
+        SUCCEED();
+    }
+
+    node = collection->_head;
+    while (node != NULL) {
+        IONCHECK(compare_contents_fn(IPCN_pNODE_TO_pDATA(node), element, &is_equal));
+        if (is_equal) {
+            *contains = TRUE;
+            SUCCEED();
+        }
+        node = node->_next;
+    }
+    *contains = FALSE;
+
+    iRETURN;
+}
+
 
 // internal routines
 

--- a/ionc/ion_collection_impl.h
+++ b/ionc/ion_collection_impl.h
@@ -25,6 +25,7 @@ extern "C" {
 #define IPCN_pDATA_TO_pNODE(x) ((ION_COLLECTION_NODE *)(((uint8_t *)(x)) - IPCN_OVERHEAD_SIZE))
 
 typedef iERR (*ION_COPY_FN)(void *context, void *dst, void *src, int32_t data_size);
+typedef iERR (*ION_COMPARE_FN)(void *lhs, void *rhs, BOOL *is_equal);
 
 void  _ion_collection_initialize(void *allocation_parent, ION_COLLECTION *collection, int32_t data_length);
 void *_ion_collection_push      (ION_COLLECTION *collection);
@@ -37,6 +38,8 @@ void *_ion_collection_tail      (ION_COLLECTION *collection);
 void  _ion_collection_reset     (ION_COLLECTION *collection);  // resets the collection contents, preserves the freelist
 void  _ion_collection_release   (ION_COLLECTION *collection);  // frees the pages back to the owner, back to new state - valid only on empty collections
 iERR  _ion_collection_copy      (ION_COLLECTION *dst, ION_COLLECTION *src, ION_COPY_FN copy_contents_fn, void *copy_fn_context);
+iERR  _ion_collection_compare   (ION_COLLECTION *lhs, ION_COLLECTION *rhs, ION_COMPARE_FN compare_contents_fn, BOOL *is_equal);
+iERR  _ion_collection_contains  (ION_COLLECTION *collection, void *element, ION_COMPARE_FN compare_contents_fn, BOOL *contains);
 
 #ifdef __cplusplus
 }

--- a/ionc/ion_reader_impl.h
+++ b/ionc/ion_reader_impl.h
@@ -175,6 +175,8 @@ struct _ion_reader
     ION_SYMBOL_TABLE   *_current_symtab;
     ION_SYMBOL_TABLE   *_local_symtab_pool;         // memory pool for local symbol table we recycle
     void               *_temp_entity_pool;          // memory pool for top level objects that we'll throw away
+
+    ION_READER_CONTEXT_CHANGE_NOTIFIER context_change_notifier;
     
     struct {
         BOOL            _is_ion_int;

--- a/ionc/ion_symbol_table.c
+++ b/ionc/ion_symbol_table.c
@@ -1104,6 +1104,43 @@ iERR ion_symbol_table_add_import(hSYMTAB hsymtab, ION_SYMBOL_TABLE_IMPORT_DESCRI
     iRETURN;
 }
 
+iERR _ion_symbol_table_import_compare(ION_SYMBOL_TABLE_IMPORT *lhs, ION_SYMBOL_TABLE_IMPORT *rhs, BOOL *is_equal)
+{
+    iENTER;
+    ASSERT(is_equal);
+    if (lhs == NULL ^ rhs == NULL) {
+        *is_equal = FALSE;
+        SUCCEED();
+    }
+    if (lhs == NULL) {
+        ASSERT(rhs == NULL);
+        *is_equal = TRUE;
+        SUCCEED();
+    }
+    if (!ION_STRING_EQUALS(&lhs->descriptor.name, &rhs->descriptor.name)) {
+        *is_equal = FALSE;
+        SUCCEED();
+    }
+    if (lhs->descriptor.version != rhs->descriptor.version || lhs->descriptor.max_id != rhs->descriptor.max_id) {
+        *is_equal = FALSE;
+        SUCCEED();
+    }
+
+    *is_equal = TRUE;
+
+    iRETURN;
+}
+
+iERR _ion_symbol_table_import_compare_fn(void *lhs, void *rhs, BOOL *is_equal)
+{
+    iENTER;
+    ION_SYMBOL_TABLE_IMPORT *lhs_import, *rhs_import;
+    lhs_import = (ION_SYMBOL_TABLE_IMPORT *)lhs;
+    rhs_import = (ION_SYMBOL_TABLE_IMPORT *)rhs;
+    IONCHECK(_ion_symbol_table_import_compare(lhs_import, rhs_import, is_equal));
+    iRETURN;
+}
+
 iERR _ion_symbol_table_local_incorporate_symbols(ION_SYMBOL_TABLE *symtab, ION_SYMBOL_TABLE *shared, int32_t import_max_id)
 {
     iENTER;
@@ -1465,16 +1502,18 @@ iERR _ion_symbol_table_get_unknown_symbol_name(ION_SYMBOL_TABLE *symtab, SID sid
 /**
  * Retrieve the text for the given SID. If the text is unknown, return a symbol identifier in the form $<int>.
  */
-iERR _ion_symbol_table_find_by_sid_force(ION_SYMBOL_TABLE *symtab, SID sid, ION_STRING **p_name)
+iERR _ion_symbol_table_find_by_sid_force(ION_SYMBOL_TABLE *symtab, SID sid, ION_STRING **p_name, BOOL *p_is_symbol_identifier)
 {
     iENTER;
-
+    BOOL is_symbol_identifier = FALSE;
     ASSERT(p_name != NULL);
 
     IONCHECK(_ion_symbol_table_find_by_sid_helper(symtab, sid, p_name));
     if (ION_STRING_IS_NULL(*p_name)) {
         IONCHECK(_ion_symbol_table_get_unknown_symbol_name(symtab, sid, p_name));
+        is_symbol_identifier = TRUE;
     }
+    if (p_is_symbol_identifier) *p_is_symbol_identifier = is_symbol_identifier;
     iRETURN;
 }
 

--- a/ionc/ion_symbol_table_impl.h
+++ b/ionc/ion_symbol_table_impl.h
@@ -86,7 +86,7 @@ iERR _ion_symbol_table_find_by_name_helper(ION_SYMBOL_TABLE *symtab, ION_STRING 
 iERR _ion_symbol_table_find_by_sid_helper(ION_SYMBOL_TABLE *symtab, SID sid, ION_STRING **p_name);
 iERR _ion_symbol_table_find_symbol_by_sid_helper(ION_SYMBOL_TABLE *symtab, SID sid, ION_SYMBOL **p_sym);
 iERR _ion_symbol_table_get_unknown_symbol_name(ION_SYMBOL_TABLE *symtab, SID sid, ION_STRING **p_name);
-iERR _ion_symbol_table_find_by_sid_force(ION_SYMBOL_TABLE *symtab, SID sid, ION_STRING **p_name);
+iERR _ion_symbol_table_find_by_sid_force(ION_SYMBOL_TABLE *symtab, SID sid, ION_STRING **p_name, BOOL *p_is_symbol_identifier);
 void _ion_symbol_table_allocate_symbol_unknown_text(hOWNER owner, SID sid, ION_SYMBOL **p_symbol);
 iERR _ion_symbol_table_is_symbol_known_helper(ION_SYMBOL_TABLE *symtab, SID sid, BOOL *p_is_known);
 iERR _ion_symbol_table_add_symbol_helper(ION_SYMBOL_TABLE *symtab, ION_STRING *name, SID *p_sid);
@@ -107,6 +107,8 @@ iERR _ion_symbol_table_local_load_import_list   (ION_READER *preader, hOWNER own
 iERR _ion_symbol_table_local_load_symbol_struct (ION_READER *preader, hOWNER owner, ION_COLLECTION *psymbol_list);
 iERR _ion_symbol_table_local_load_symbol_list   (ION_READER *preader, hOWNER owner, ION_COLLECTION *psymbol_list);
 
+iERR _ion_symbol_table_import_compare(ION_SYMBOL_TABLE_IMPORT *lhs, ION_SYMBOL_TABLE_IMPORT *rhs, BOOL *is_equal);
+iERR _ion_symbol_table_import_compare_fn(void *lhs, void *rhs, BOOL *is_equal);
 iERR _ion_symbol_table_import_symbol_table_helper(ION_SYMBOL_TABLE *symtab, ION_SYMBOL_TABLE *import_symtab, ION_STRING *import_name, int32_t import_version, int32_t import_max_id);
 iERR _ion_symbol_table_local_incorporate_symbols(ION_SYMBOL_TABLE *symtab, ION_SYMBOL_TABLE *shared, int32_t import_max_id);
 iERR _ion_symbol_table_local_add_symbol_helper(ION_SYMBOL_TABLE *symtab, ION_STRING *name, SID sid, ION_SYMBOL **p_psym);

--- a/ionc/ion_writer_binary.c
+++ b/ionc/ion_writer_binary.c
@@ -1075,7 +1075,7 @@ iERR _ion_writer_binary_write_symbol_id(ION_WRITER *pwriter, SID sid)
     }
     IONCHECK( _ion_writer_binary_patch_lengths( pwriter, len + ION_BINARY_TYPE_DESC_LENGTH ));
 
-    if (pwriter->symbol_table && sid >= pwriter->symbol_table->min_local_id) {
+    if (pwriter->symbol_table && sid > pwriter->symbol_table->system_symbol_table->max_id) {
         pwriter->_has_local_symbols = TRUE;
     }
 
@@ -1212,15 +1212,11 @@ iERR _ion_writer_binary_flush_to_output(ION_WRITER *pwriter)
     int                patch_pos;
     int                len;
     SIZE               written;
-    BOOL               has_imports, needs_local_symbol_table;
 
     ION_BINARY_PATCH  *ppatch;
     ION_STREAM        *out = pwriter->output;
     ION_STREAM        *values_in;
     ION_BINARY_WRITER *bwriter = &pwriter->_typed_writer.binary;
-
-    has_imports = (pwriter->symbol_table && !ION_COLLECTION_IS_EMPTY(&pwriter->symbol_table->import_list));
-    needs_local_symbol_table = (pwriter->_has_local_symbols || has_imports);
 
     if (pwriter->_needs_version_marker) {
         IONCHECK( ion_stream_write( out, ION_VERSION_MARKER, ION_VERSION_MARKER_LENGTH, &written ));
@@ -1228,7 +1224,7 @@ iERR _ion_writer_binary_flush_to_output(ION_WRITER *pwriter)
         pwriter->_needs_version_marker = FALSE;
     }
     
-    if (needs_local_symbol_table) {
+    if (pwriter->_has_local_symbols) {
 
         // we have (we could have but didn't) saved the value stack before recursing 
         // into the symbol table "write" but since we want to write to the stream we're

--- a/ionc/ion_writer_impl.h
+++ b/ionc/ion_writer_impl.h
@@ -123,7 +123,6 @@ typedef struct _ion_binary_patch {
 
 typedef struct _ion_binary_writer
 {
-    BOOL                _version_marker_written;
     ION_TYPE            _lob_in_progress;
 
     ION_COLLECTION      _patch_stack;  // stack of patch pointers
@@ -164,6 +163,8 @@ typedef struct _ion_writer
 
     BOOL               writer_owns_stream;   // true when open writer created the stream object
     ION_STREAM        *output;
+
+    BOOL                _needs_version_marker;
 
     union {
         struct _ion_text_writer   text;
@@ -221,6 +222,8 @@ iERR _ion_writer_set_catalog_helper(ION_WRITER *pwriter, ION_CATALOG *pcatalog);
 iERR _ion_writer_get_catalog_helper(ION_WRITER *pwriter, ION_CATALOG **p_pcatalog);
 iERR _ion_writer_set_symbol_table_helper(ION_WRITER *pwriter, ION_SYMBOL_TABLE *psymtab);
 iERR _ion_writer_get_symbol_table_helper(ION_WRITER *pwriter, ION_SYMBOL_TABLE **p_psymtab);
+iERR _ion_writer_add_imported_table_helper(ION_WRITER *pwriter, ION_SYMBOL_TABLE_IMPORT *import);
+iERR _ion_writer_add_imported_tables_helper(ION_WRITER *pwriter, ION_COLLECTION *imports);
 iERR _ion_writer_write_field_name_helper(ION_WRITER *pwriter, ION_STRING *name);
 iERR _ion_writer_write_field_sid_helper(ION_WRITER *pwriter, SID sid);
 iERR _ion_writer_write_field_name_symbol_helper(ION_WRITER *pwriter, ION_SYMBOL *field_name);
@@ -260,12 +263,18 @@ iERR _ion_writer_close_helper(ION_WRITER *pwriter);
 iERR _ion_writer_free_local_symbol_table( ION_WRITER *pwriter );
 iERR _ion_writer_make_symbol_helper(ION_WRITER *pwriter, ION_STRING *pstr, SID *p_sid);
 iERR _ion_writer_clear_field_name_helper(ION_WRITER *pwriter);
-iERR _ion_writer_get_field_name_as_string_helper(ION_WRITER *pwriter, ION_STRING *p_str);
+iERR _ion_writer_get_field_name_as_string_helper(ION_WRITER *pwriter, ION_STRING *p_str, BOOL *p_is_symbol_identifier);
 iERR _ion_writer_get_field_name_as_sid_helper(ION_WRITER *pwriter, SID *p_sid);
 iERR _ion_writer_clear_annotations_helper(ION_WRITER *pwriter);
 iERR _ion_writer_get_annotation_count_helper(ION_WRITER *pwriter, int32_t *p_count);
-iERR _ion_writer_get_annotation_as_string_helper(ION_WRITER *pwriter, int32_t idx, ION_STRING *p_str);
+iERR _ion_writer_get_annotation_as_string_helper(ION_WRITER *pwriter, int32_t idx, ION_STRING *p_str, BOOL *p_is_symbol_identifier);
 iERR _ion_writer_get_annotation_as_sid_helper(ION_WRITER *pwriter, int32_t idx, SID *p_sid);
+
+/**
+ * Returns TRUE only if the writer has a local symbol table that must be serialized. The conditions under which this
+ * is TRUE are different for text and binary writers.
+ */
+BOOL _ion_writer_has_symbol_table(ION_WRITER *pwriter);
 
 iERR ion_temp_buffer_init(hOWNER owner, ION_TEMP_BUFFER *temp_buffer, SIZE size_of_temp_space);
 iERR ion_temp_buffer_alloc(ION_TEMP_BUFFER *temp_buffer, SIZE needed, void **p_ptr);
@@ -306,6 +315,8 @@ iERR _ion_writer_text_write_timestamp(ION_WRITER *pwriter, iTIMESTAMP value);
 iERR _ion_writer_text_write_symbol_id(ION_WRITER *pwriter, SID value);
 iERR _ion_writer_text_write_symbol(ION_WRITER *pwriter, iSTRING symbol);
 iERR _ion_writer_text_write_string(ION_WRITER *pwriter, iSTRING str);
+
+BOOL _ion_writer_text_has_symbol_table(ION_WRITER *pwriter);
 
 iERR _ion_writer_text_write_clob(ION_WRITER *pwriter, BYTE *p_buf, SIZE length);
 iERR _ion_writer_text_append_clob_contents(ION_WRITER *pwriter, BYTE *p_buf, SIZE length);

--- a/ionc/ion_writer_impl.h
+++ b/ionc/ion_writer_impl.h
@@ -222,7 +222,7 @@ iERR _ion_writer_set_catalog_helper(ION_WRITER *pwriter, ION_CATALOG *pcatalog);
 iERR _ion_writer_get_catalog_helper(ION_WRITER *pwriter, ION_CATALOG **p_pcatalog);
 iERR _ion_writer_set_symbol_table_helper(ION_WRITER *pwriter, ION_SYMBOL_TABLE *psymtab);
 iERR _ion_writer_get_symbol_table_helper(ION_WRITER *pwriter, ION_SYMBOL_TABLE **p_psymtab);
-iERR _ion_writer_add_imported_table_helper(ION_WRITER *pwriter, ION_SYMBOL_TABLE_IMPORT *import);
+iERR _ion_writer_add_imported_table_helper(ION_WRITER *pwriter, ION_SYMBOL_TABLE_IMPORT *import, BOOL *finish_on_unique);
 iERR _ion_writer_add_imported_tables_helper(ION_WRITER *pwriter, ION_COLLECTION *imports);
 iERR _ion_writer_write_field_name_helper(ION_WRITER *pwriter, ION_STRING *name);
 iERR _ion_writer_write_field_sid_helper(ION_WRITER *pwriter, SID sid);

--- a/test/ion_event_stream.cpp
+++ b/test/ion_event_stream.cpp
@@ -310,6 +310,9 @@ iERR read_next_value(hREADER hreader, IonEventStream *stream, ION_TYPE t, BOOL i
     iRETURN;
 }
 
+// TODO create a dummy event type that indicates a symbol table context boundary and holds the new imports at that
+// boundary. When the writer encounters that boundary in the stream, it sets its imports accordingly.
+
 iERR read_all(hREADER hreader, IonEventStream *stream) {
     iENTER;
     IONCHECK(read_all(hreader, stream, /*in_struct=*/FALSE, /*depth=*/0));

--- a/test/test_ion_symbol.cpp
+++ b/test/test_ion_symbol.cpp
@@ -1387,7 +1387,7 @@ TEST_P(BinaryAndTextTest, WriterAcceptsImportsAfterConstruction) {
     ION_SYMBOL_TEST_OPEN_WRITER_WITH_IMPORTS(is_binary, writer_imports, 2);
 
     ION_STRING foo, bar;
-    ION_SYMBOL_TABLE_IMPORT *foo_import, *bar_import;
+    ION_SYMBOL_TABLE_IMPORT *foo_import, *bar_import, import1_import, import2_import;
     ION_COLLECTION new_imports_1, new_imports_2;
     ION_SYMBOL_TABLE *writer_table;
     BOOL contains_import;
@@ -1420,8 +1420,22 @@ TEST_P(BinaryAndTextTest, WriterAcceptsImportsAfterConstruction) {
     ION_ASSERT_OK(_ion_collection_contains(&writer_table->import_list, bar_import, &_ion_symbol_table_import_compare_fn, &contains_import));
     ASSERT_TRUE(contains_import);
 
-    // TODO also assert that it contains import1 and import2
+    ION_STRING_ASSIGN(&import1_import.descriptor.name, &import1_name);
+    ION_STRING_ASSIGN(&import2_import.descriptor.name, &import2_name);
+    import1_import.descriptor.max_id = import1->max_id;
+    import2_import.descriptor.max_id = import2->max_id;
+    import1_import.descriptor.version = import1->version;
+    import2_import.descriptor.version = import2->version;
 
+    ION_ASSERT_OK(_ion_collection_contains(&writer_table->import_list, &import1_import, &_ion_symbol_table_import_compare_fn, &contains_import));
+    ASSERT_TRUE(contains_import);
+
+    ION_ASSERT_OK(_ion_collection_contains(&writer_table->import_list, &import2_import, &_ion_symbol_table_import_compare_fn, &contains_import));
+    ASSERT_TRUE(contains_import);
+
+    ION_ASSERT_OK(ion_writer_close(writer));
+    ION_ASSERT_OK(ion_catalog_close(catalog));
+    ION_ASSERT_OK(ion_writer_options_close_shared_imports(&writer_options));
 }
 
 TEST_P(BinaryAndTextTest, AddImportedTablesFailsBelowTopLevel) {


### PR DESCRIPTION
It is a common pattern to read Ion data, operate on a subset of the values in the stream, and re-write it so that the next node has a full view of the data.

Because Ion streams may have multiple symbol table contexts, if the reader doesn't convey when the context has changed, the writer won't be able to synchronize its symbol table context accordingly, which can lead to errors or incorrect symbol mappings on write.

This change allows the user to be notified when a reader has encountered a change in the symbol table context that changes which shared symbol table imports are required to interpret the symbol tokens. The user may then pass these along to the writer, which will flush its previous symbol table context and create a fresh one which uses the provided shared symbol tables. This is also done automatically by `ion_writer_write_all_values`.