### PR TITLE
Adds support for handing off shared symbol tables from reader to writer in roundtrip tests.

### DIFF
--- a/ionc/inc/ion_writer.h
+++ b/ionc/inc/ion_writer.h
@@ -195,7 +195,8 @@ ION_API_EXPORT iERR ion_writer_get_symbol_table     (hWRITER hwriter, hSYMTAB  *
  * This function may be called multiple times in succession without changing the current symbol table context as long as
  * no values have been written in between calls; in this case, this function appends to the writer's list of imports.
  *
- * Raises an error if a manually-written symbol table is in progress or if the writer is not at the top level.
+ * Raises an error if a manually-written symbol table is in progress, if the writer is not at the top level, or if the
+ * writer has pending annotations.
  */
 ION_API_EXPORT iERR ion_writer_add_imported_tables  (hWRITER hwriter, ION_COLLECTION *imports);
 

--- a/ionc/ion_binary.c
+++ b/ionc/ion_binary.c
@@ -558,7 +558,10 @@ iERR ion_binary_write_int32_with_field_sid( ION_STREAM *pstream, SID sid, int32_
     len = ion_binary_len_uint_64( unsignedValue );
     IONCHECK( ion_binary_write_var_uint_64( pstream, sid ));
     ION_PUT( pstream, makeTypeDescriptor( tid, len ));
-    IONCHECK( ion_binary_write_uint_64( pstream, unsignedValue ));
+    if (unsignedValue > 0) {
+        ASSERT(len > 0);
+        IONCHECK(ion_binary_write_uint_64(pstream, unsignedValue));
+    }
 
     iRETURN;
 }

--- a/ionc/ion_symbol_table.c
+++ b/ionc/ion_symbol_table.c
@@ -715,7 +715,7 @@ iERR _ion_symbol_table_unload_helper(ION_SYMBOL_TABLE *symtab, ION_WRITER *pwrit
                 IONCHECK(_ion_writer_write_field_sid_helper(pwriter, ION_SYS_SID_VERSION));
                 IONCHECK(_ion_writer_write_int64_helper(pwriter, import->descriptor.version));
             }
-            if (import->descriptor.max_id > 0) {
+            if (import->descriptor.max_id > ION_SYS_SYMBOL_MAX_ID_UNDEFINED) {
                 IONCHECK(_ion_writer_write_field_sid_helper(pwriter, ION_SYS_SID_MAX_ID));
                 IONCHECK(_ion_writer_write_int64_helper(pwriter, import->descriptor.max_id));
             }

--- a/ionc/ion_writer.c
+++ b/ionc/ion_writer.c
@@ -704,6 +704,9 @@ iERR _ion_writer_add_imported_tables_helper(ION_WRITER *pwriter, ION_COLLECTION 
     if (pwriter->_current_symtab_intercept_state != iWSIS_NONE) {
         FAILWITHMSG(IERR_INVALID_STATE, "Cannot add imports while manually writing a local symbol table.");
     }
+    if (pwriter->annotation_curr != 0) {
+        FAILWITHMSG(IERR_INVALID_STATE, "Cannot add imports while there are pending annotations.");
+    }
 
     // If the writer's current symbol table context must be serialized, then it must be done before adding imports.
     require_finish = _ion_writer_has_symbol_table(pwriter);

--- a/ionc/ion_writer_binary.c
+++ b/ionc/ion_writer_binary.c
@@ -1486,7 +1486,7 @@ iERR _ion_writer_binary_serialize_symbol_table(ION_SYMBOL_TABLE *psymtab, ION_ST
                 // now we write the name, version, and max id
                 IONCHECK(ion_binary_write_string_with_field_sid(out, ION_SYS_SID_NAME, &import->descriptor.name));
                 IONCHECK(ion_binary_write_int32_with_field_sid(out, ION_SYS_SID_VERSION, import->descriptor.version));
-                if (import->descriptor.max_id > 0) {
+                if (import->descriptor.max_id > ION_SYS_SYMBOL_MAX_ID_UNDEFINED) {
                     IONCHECK(ion_binary_write_int32_with_field_sid(out, ION_SYS_SID_MAX_ID, import->descriptor.max_id));
                 }
             }
@@ -1535,17 +1535,9 @@ int ion_writer_binary_serialize_import_struct_length(ION_SYMBOL_TABLE_IMPORT_DES
     }
     len += 1 + ION_BINARY_TYPE_DESC_LENGTH; // field id (name)  + type desc
     len += 1 + ION_BINARY_TYPE_DESC_LENGTH + ion_binary_len_uint_64(import->version); // field id(version) + type desc + int
-    if (import->max_id > 0) {
+    if (import->max_id > ION_SYS_SYMBOL_MAX_ID_UNDEFINED) {
         len += 1 + ION_BINARY_TYPE_DESC_LENGTH + ion_binary_len_uint_64(import->max_id); // field id(max_id) + type desc + int
     }
-
-    // cas 1 sept 2012 - this should be done by the caller! 
-    // now len is the length of the content of the import struct
-    // see if it's too big for a low nibble length
-    // if (len >= ION_lnIsVarLen) {
-    //    len += ion_binary_len_var_uint_64(len);  // whole struct has overflow length
-    // }
-    // len += ION_BINARY_TYPE_DESC_LENGTH; // type desc ion_struct
 
     return len;
 }

--- a/test/gather_vectors.cpp
+++ b/test/gather_vectors.cpp
@@ -128,8 +128,6 @@ void add_to_skip(std::string prefix, std::string suffix) {
 std::vector<std::string> *skip_list() {
     // Assumption: these tests are single-threaded.
     if (_skip_list.size() == 0) {
-        add_to_skip(good_path, "item1.10n");
-
         add_to_skip(good_path, "utf16.ion");
         add_to_skip(good_path, "utf32.ion");
 

--- a/test/ion_assert.cpp
+++ b/test/ion_assert.cpp
@@ -310,6 +310,14 @@ BOOL assertIonEventStreamEq(IonEventStream *expected, IonEventStream *actual, AS
     size_t index_expected = 0;
     size_t index_actual = 0;
     while (index_expected < expected->size() && index_actual < actual->size()) {
+        if (expected->at(index_expected)->event_type == SYMBOL_TABLE) {
+            index_expected++;
+            continue;
+        }
+        if (actual->at(index_actual)->event_type == SYMBOL_TABLE) {
+            index_actual++;
+            continue;
+        }
         ION_ACCUMULATE_ASSERTION(assertIonEventsEq(expected, index_expected, actual, index_actual, assertion_type));
         index_expected += valueEventLength(expected, index_expected);
         index_actual += valueEventLength(actual, index_actual);

--- a/test/ion_event_stream.h
+++ b/test/ion_event_stream.h
@@ -36,6 +36,7 @@ typedef enum _ion_event_type {
     SCALAR = 0,
     CONTAINER_START,
     CONTAINER_END,
+    SYMBOL_TABLE,
     STREAM_END
 } ION_EVENT_TYPE;
 


### PR DESCRIPTION
This allows the tests to correctly roundtrip valid Ion data with not-found imports, and leads to the removal of `good/item1.10n` from the skip list.