### PR TITLE
Removes public APIs that allow directly reading or writing local SIDs.

### DIFF
--- a/ionc/inc/ion_reader.h
+++ b/ionc/inc/ion_reader.h
@@ -338,14 +338,11 @@ ION_API_EXPORT iERR ion_reader_has_annotation      (hREADER hreader, iSTRING ann
 ION_API_EXPORT iERR ion_reader_is_null             (hREADER hreader, BOOL *p_is_null);
 ION_API_EXPORT iERR ion_reader_is_in_struct        (hREADER preader, BOOL *p_is_in_struct);
 ION_API_EXPORT iERR ion_reader_get_field_name      (hREADER hreader, iSTRING p_str);
-ION_API_EXPORT iERR ion_reader_get_field_sid       (hREADER hreader, SID *p_sid);
 ION_API_EXPORT iERR ion_reader_get_field_name_symbol(hREADER hreader, ION_SYMBOL **p_psymbol);
 ION_API_EXPORT iERR ion_reader_get_annotations     (hREADER hreader, iSTRING p_strs, SIZE max_count, SIZE *p_count);
-ION_API_EXPORT iERR ion_reader_get_annotation_sids (hREADER hreader, SID *p_sids, SIZE max_count, SIZE *p_count);
 ION_API_EXPORT iERR ion_reader_get_annotation_symbols(hREADER hreader, ION_SYMBOL *p_symbols, SIZE max_count, SIZE *p_count);
 ION_API_EXPORT iERR ion_reader_get_annotation_count(hREADER hreader, SIZE *p_count);
 ION_API_EXPORT iERR ion_reader_get_an_annotation   (hREADER hreader, int idx, iSTRING p_strs);
-ION_API_EXPORT iERR ion_reader_get_an_annotation_sid(hREADER hreader, int idx, SID *p_sid);
 ION_API_EXPORT iERR ion_reader_get_an_annotation_symbol(hREADER hreader, int idx, ION_SYMBOL *p_symbol);
 ION_API_EXPORT iERR ion_reader_read_null           (hREADER hreader, ION_TYPE *p_value);
 ION_API_EXPORT iERR ion_reader_read_bool           (hREADER hreader, BOOL *p_value);
@@ -391,18 +388,9 @@ ION_API_EXPORT iERR ion_reader_read_ion_decimal    (hREADER hreader, ION_DECIMAL
  */
 ION_API_EXPORT iERR ion_reader_read_timestamp      (hREADER hreader, iTIMESTAMP p_value);
 
-/** Read the local symbol ID of the current symbol value.
- * @deprecated use of this function is discouraged, as it can have different results for text and binary data. In Ion text,
- * which is not required to explicitly include a local symbol table, known symbols are not necessarily assigned symbol
- * IDs. For those symbols, this function would return UNKNOWN_SID even though the text is known.
- * Prefer `ion_reader_read_symbol` or `ion_reader_read_string`, which provides an ION_STRING for which
- * ION_STRING_IS_NULL() will evaluate to TRUE if the current symbol value's text is unknown.
- */
-ION_API_EXPORT iERR ion_reader_read_symbol_sid     (hREADER hreader, SID *p_value);
-
 /** Read the current symbol value as an ION_SYMBOL.
  */
-ION_API_EXPORT iERR ion_reader_read_symbol         (hREADER hreader, ION_SYMBOL *p_symbol);
+ION_API_EXPORT iERR ion_reader_read_ion_symbol(hREADER hreader, ION_SYMBOL *p_symbol);
 
 /**
  * Determines the content of the current text value, which must be an

--- a/ionc/inc/ion_writer.h
+++ b/ionc/inc/ion_writer.h
@@ -207,11 +207,6 @@ ION_API_EXPORT iERR ion_writer_add_imported_tables  (hWRITER hwriter, ION_COLLEC
 ION_API_EXPORT iERR ion_writer_write_field_name     (hWRITER hwriter, iSTRING name);
 
 /**
- * Sets the writer's current field name from a local symbol ID. Only valid if the writer is currently in a struct.
- */
-ION_API_EXPORT iERR ion_writer_write_field_sid      (hWRITER hwriter, SID sid);
-
-/**
  * Sets the writer's current field name from the given Ion symbol. Only valid if the writer is currently in a struct.
  * It is the caller's responsibility to keep `field_name` in scope until the writer's next value is written.
  */
@@ -219,10 +214,8 @@ ION_API_EXPORT iERR ion_writer_write_field_name_symbol(hWRITER hwriter, ION_SYMB
 
 ION_API_EXPORT iERR ion_writer_clear_field_name     (hWRITER hwriter);
 ION_API_EXPORT iERR ion_writer_add_annotation       (hWRITER hwriter, iSTRING annotation);
-ION_API_EXPORT iERR ion_writer_add_annotation_sid   (hWRITER hwriter, SID sid);
 ION_API_EXPORT iERR ion_writer_add_annotation_symbol(hWRITER hwriter, ION_SYMBOL *annotation);
 ION_API_EXPORT iERR ion_writer_write_annotations    (hWRITER hwriter, iSTRING *p_annotations, SIZE count);
-ION_API_EXPORT iERR ion_writer_write_annotation_sids(hWRITER hwriter, SID *p_sids, SIZE count);
 ION_API_EXPORT iERR ion_writer_write_annotation_symbols(hWRITER hwriter, ION_SYMBOL **annotations, SIZE count);
 ION_API_EXPORT iERR ion_writer_clear_annotations    (hWRITER hwriter);
 
@@ -242,7 +235,6 @@ ION_API_EXPORT iERR ion_writer_write_double         (hWRITER hwriter, double val
 ION_API_EXPORT iERR ion_writer_write_decimal        (hWRITER hwriter, decQuad *value);
 ION_API_EXPORT iERR ion_writer_write_ion_decimal    (hWRITER hwriter, ION_DECIMAL *value);
 ION_API_EXPORT iERR ion_writer_write_timestamp      (hWRITER hwriter, iTIMESTAMP value);
-ION_API_EXPORT iERR ion_writer_write_symbol_sid     (hWRITER hwriter, SID value);
 ION_API_EXPORT iERR ion_writer_write_symbol         (hWRITER hwriter, iSTRING p_value);
 ION_API_EXPORT iERR ion_writer_write_ion_symbol     (hWRITER hwriter, ION_SYMBOL *symbol);
 ION_API_EXPORT iERR ion_writer_write_string         (hWRITER hwriter, iSTRING p_value);

--- a/ionc/ion_reader.c
+++ b/ionc/ion_reader.c
@@ -872,43 +872,6 @@ iERR _ion_reader_get_an_annotation_helper(ION_READER *preader, int32_t idx, ION_
     iRETURN;
 }
 
-iERR ion_reader_get_an_annotation_sid(hREADER hreader, int idx, SID *p_sid)
-{
-    iENTER;
-    ION_READER *preader;
-
-    if (!hreader) FAILWITH(IERR_INVALID_ARG);
-    preader = HANDLE_TO_PTR(hreader, ION_READER);
-    if (idx < 0) FAILWITH(IERR_INVALID_ARG);
-    if (!p_sid) FAILWITH(IERR_INVALID_ARG);
-
-
-    IONCHECK(_ion_reader_get_an_annotation_sid_helper(preader, idx, p_sid));
-
-    iRETURN;
-}
-
-iERR _ion_reader_get_an_annotation_sid_helper(ION_READER *preader, int32_t idx, SID *p_sid)
-{
-    iENTER;
-
-    ASSERT(preader);
-
-    switch(preader->type) {
-        case ion_type_text_reader:
-            IONCHECK(_ion_reader_text_get_an_annotation_sid(preader, idx, p_sid));
-            break;
-        case ion_type_binary_reader:
-            IONCHECK(_ion_reader_binary_get_an_annotation_sid(preader, idx, p_sid));
-            break;
-        case ion_type_unknown_reader:
-        default:
-            FAILWITH(IERR_INVALID_STATE);
-    }
-
-    iRETURN;
-}
-
 iERR ion_reader_get_an_annotation_symbol(hREADER hreader, int idx, ION_SYMBOL *p_symbol)
 {
     iENTER;
@@ -1047,20 +1010,6 @@ iERR _ion_reader_get_field_name_helper(ION_READER *preader, ION_STRING **p_pstr)
     iRETURN;
 }
 
-iERR ion_reader_get_field_sid(hREADER hreader, SID *p_sid)
-{
-    iENTER;
-    ION_READER *preader;
-
-    if (!hreader) FAILWITH(IERR_INVALID_ARG);
-    preader = HANDLE_TO_PTR(hreader, ION_READER);
-    if (!p_sid) FAILWITH(IERR_INVALID_ARG);
-
-    IONCHECK(_ion_reader_get_field_sid_helper(preader, p_sid));
-
-    iRETURN;
-}
-
 iERR _ion_reader_get_field_sid_helper(ION_READER *preader, SID *p_sid)
 {
     iENTER;
@@ -1148,31 +1097,6 @@ iERR _ion_reader_get_annotations_helper(ION_READER *preader, ION_STRING *p_strs,
         break;
     case ion_type_binary_reader:
         IONCHECK(_ion_reader_binary_get_annotations(preader, p_strs, max_count, p_count));
-        break;
-    case ion_type_unknown_reader:
-    default:
-        FAILWITH(IERR_INVALID_STATE);
-    }
-
-    iRETURN;
-}
-
-iERR ion_reader_get_annotation_sids(hREADER hreader, SID *p_sids, SIZE max_count, SIZE *p_count)
-{
-    iENTER;
-    ION_READER *preader;
-
-    if (!hreader) FAILWITH(IERR_INVALID_ARG);
-    preader = HANDLE_TO_PTR(hreader, ION_READER);
-    if (!p_sids) FAILWITH(IERR_INVALID_ARG);
-    if (!p_count) FAILWITH(IERR_INVALID_ARG);
-
-    switch(preader->type) {
-    case ion_type_text_reader:
-        IONCHECK(_ion_reader_text_get_annotation_sids(preader, p_sids, max_count, p_count));
-        break;
-    case ion_type_binary_reader:
-        IONCHECK(_ion_reader_binary_get_annotation_sids(preader, p_sids, max_count, p_count));
         break;
     case ion_type_unknown_reader:
     default:
@@ -1594,43 +1518,7 @@ iERR _ion_reader_read_timestamp_helper(ION_READER *preader, ION_TIMESTAMP *p_val
     iRETURN;
 }
 
-iERR ion_reader_read_symbol_sid(hREADER hreader, SID *p_value)
-{
-    iENTER;
-    ION_READER *preader;
-
-    if (!hreader) FAILWITH(IERR_INVALID_ARG);
-    preader = HANDLE_TO_PTR(hreader, ION_READER);
-    if (!p_value) FAILWITH(IERR_INVALID_ARG);
-
-    IONCHECK(_ion_reader_read_symbol_sid_helper(preader, p_value));
-
-    iRETURN;
-}
-
-iERR _ion_reader_read_symbol_sid_helper(ION_READER *preader, SID *p_value)
-{
-    iENTER;
-
-    ASSERT(preader);
-    ASSERT(p_value);
-
-    switch(preader->type) {
-    case ion_type_text_reader:
-        IONCHECK(_ion_reader_text_read_symbol_sid(preader, p_value));
-        break;
-    case ion_type_binary_reader:
-        IONCHECK(_ion_reader_binary_read_symbol_sid(preader, p_value));
-        break;
-    case ion_type_unknown_reader:
-    default:
-        FAILWITH(IERR_INVALID_STATE);
-    }
-
-    iRETURN;
-}
-
-iERR ion_reader_read_symbol(hREADER hreader, ION_SYMBOL *p_symbol)
+iERR ion_reader_read_ion_symbol(hREADER hreader, ION_SYMBOL *p_symbol)
 {
     iENTER;
     ION_READER *preader;

--- a/ionc/ion_reader_binary.c
+++ b/ionc/ion_reader_binary.c
@@ -733,41 +733,6 @@ iERR _ion_reader_binary_get_annotation_symbols(ION_READER *preader, ION_SYMBOL *
     iRETURN;
 }
 
-iERR _ion_reader_binary_get_annotation_sids(ION_READER *preader, SID *p_sids, SIZE max_count, SIZE *p_count)
-{
-    iENTER;
-    ION_BINARY_READER    *binary;
-    int                   ii, count;
-    SID                  *psid;
-    ION_COLLECTION_CURSOR cursor;
-
-    ASSERT(preader && preader->type == ion_type_binary_reader);
-
-    binary = &preader->typed_reader.binary;
-
-    count = ION_COLLECTION_SIZE(&binary->_annotation_sids);
-    if (count > max_count) {
-        FAILWITH(IERR_BUFFER_TOO_SMALL);
-    }
-
-    ION_COLLECTION_OPEN(&binary->_annotation_sids, cursor);
-    for (ii=0; ;ii++) {
-        ION_COLLECTION_NEXT(cursor, psid);
-        if (!psid) break;
-        IONCHECK(_ion_reader_binary_validate_symbol_token(preader, *psid));
-        p_sids[ii++] = *psid;
-    }
-
-    ION_COLLECTION_CLOSE(cursor);
-    goto return_value;
-
-return_value:
-    *p_count = count;
-    SUCCEED();
-
-    iRETURN;
-}
-
 iERR _ion_reader_binary_get_field_name(ION_READER *preader, ION_STRING **p_pstr)
 {
     iENTER;

--- a/ionc/ion_reader_impl.h
+++ b/ionc/ion_reader_impl.h
@@ -232,7 +232,6 @@ iERR _ion_reader_read_double_helper(ION_READER *preader, double *p_value);
 iERR _ion_reader_read_decimal_helper(ION_READER *preader, decQuad *p_value);
 iERR _ion_reader_read_ion_decimal_helper(ION_READER *preader, ION_DECIMAL *p_value);
 iERR _ion_reader_read_timestamp_helper(ION_READER *preader, ION_TIMESTAMP *p_value);
-iERR _ion_reader_read_symbol_sid_helper(ION_READER *preader, SID *p_value);
 iERR _ion_reader_read_symbol_helper(ION_READER *preader, ION_SYMBOL *p_symbol);
 
 iERR _ion_reader_get_string_length_helper(ION_READER *preader, SIZE *p_length);
@@ -291,7 +290,6 @@ iERR _ion_reader_binary_get_field_name     (ION_READER *preader, ION_STRING **ps
 iERR _ion_reader_binary_get_field_sid      (ION_READER *preader, SID *p_sid);
 iERR _ion_reader_binary_get_field_name_symbol(ION_READER *preader, ION_SYMBOL **p_psymbol);
 iERR _ion_reader_binary_get_annotations    (ION_READER *preader, iSTRING p_strs, SIZE max_count, SIZE *p_count);
-iERR _ion_reader_binary_get_annotation_sids(ION_READER *preader, SID *p_sids, SIZE max_count, SIZE *p_count);
 iERR _ion_reader_binary_get_annotation_symbols(ION_READER *preader, ION_SYMBOL *p_annotations, SIZE max_count, SIZE *p_count);
 
 iERR _ion_reader_binary_is_null             (ION_READER *preader, BOOL *p_is_null);
@@ -343,8 +341,6 @@ iERR _ion_reader_read_double_helper(ION_READER *preader, double *p_double_value)
 iERR _ion_reader_read_decimal_helper(ION_READER *preader, decQuad *p_decimal_value);
 iERR _ion_reader_read_timestamp_helper(ION_READER *preader, ION_TIMESTAMP *p_timestamp_value);
 iERR _ion_reader_read_string_helper(ION_READER *preader, ION_STRING *p_string_value);
-iERR _ion_reader_read_symbol_as_string_helper(ION_READER *preader, ION_STRING *p_string_value);
-iERR _ion_reader_read_symbol_as_sid_helper(ION_READER *preader, SID *p_sid);
 iERR _ion_reader_get_lob_size_helper(ION_READER *preader, int32_t *p_len);
 iERR _ion_reader_step_in_helper(ION_READER *preader);
 iERR _ion_reader_step_out_helper(ION_READER *preader);

--- a/ionc/ion_reader_text.h
+++ b/ionc/ion_reader_text.h
@@ -302,14 +302,12 @@ iERR _ion_reader_text_has_any_annotations       (ION_READER *preader, BOOL *p_ha
 iERR _ion_reader_text_has_annotation            (ION_READER *preader, ION_STRING *annotation, BOOL *p_annotation_found);
 iERR _ion_reader_text_get_annotation_count      (ION_READER *preader, int32_t *p_count);
 iERR _ion_reader_text_get_an_annotation         (ION_READER *preader, int32_t idx, ION_STRING *p_str);
-iERR _ion_reader_text_get_an_annotation_sid     (ION_READER *preader, int32_t idx, SID *p_sid);
 iERR _ion_reader_text_get_an_annotation_symbol  (ION_READER *preader, int32_t idx, ION_SYMBOL *p_symbol);
 iERR _ion_reader_text_get_field_name            (ION_READER *preader, ION_STRING **p_pstr);
 iERR _ion_reader_text_get_field_name_symbol     (ION_READER *preader, ION_SYMBOL **p_psymbol);
 iERR _ion_reader_text_get_symbol_table          (ION_READER *preader, ION_SYMBOL_TABLE **p_return);
 iERR _ion_reader_text_get_field_sid             (ION_READER *preader, SID *p_sid);
 iERR _ion_reader_text_get_annotations           (ION_READER *preader, ION_STRING *p_strs, SIZE max_count, SIZE *p_count);
-iERR _ion_reader_text_get_annotation_sids       (ION_READER *preader, SID *p_sids, SIZE max_count, SIZE *p_count);
 iERR _ion_reader_text_get_annotation_symbols    (ION_READER *preader, ION_SYMBOL *p_symbols, SIZE max_count, SIZE *p_count);
 iERR _ion_reader_text_get_value_offset          (ION_READER *preader, POSITION *p_offset);
 iERR _ion_reader_text_get_value_length          (ION_READER *preader, SIZE *p_length);
@@ -325,7 +323,6 @@ iERR _ion_reader_text_read_double               (ION_READER *preader, double *p_
 //iERR _ion_reader_text_read_float32              (ION_READER *preader, float *p_value);
 iERR _ion_reader_text_read_decimal              (ION_READER *preader, decQuad *p_quad, decNumber **p_num);
 iERR _ion_reader_text_read_timestamp            (ION_READER *preader, ION_TIMESTAMP *p_value);
-iERR _ion_reader_text_read_symbol_sid           (ION_READER *preader, SID *p_value);
 iERR _ion_reader_text_read_symbol               (ION_READER *preader, ION_SYMBOL *p_symbol);
 
 // get string functions, these work over value of type string or type symbol

--- a/ionc/ion_writer_impl.h
+++ b/ionc/ion_writer_impl.h
@@ -232,7 +232,6 @@ iERR _ion_writer_add_annotation_helper(ION_WRITER *pwriter, ION_STRING *annotati
 iERR _ion_writer_add_annotation_sid_helper(ION_WRITER *pwriter, SID sid);
 iERR _ion_writer_add_annotation_symbol_helper(ION_WRITER *pwriter, ION_SYMBOL *annotation);
 iERR _ion_writer_write_annotations_helper(ION_WRITER *pwriter, ION_STRING **p_annotations, int32_t count);
-iERR _ion_writer_write_annotation_sids_helper(ION_WRITER *pwriter, int32_t *p_sids, SIZE count);
 iERR _ion_writer_write_annotation_symbols_helper(ION_WRITER *pwriter, ION_SYMBOL **annotations, SIZE count);
 iERR _ion_writer_clear_annotations_helper(ION_WRITER *pwriter);
 iERR _ion_writer_write_typed_null_helper(ION_WRITER *pwriter, ION_TYPE type);

--- a/test/ion_event_stream.cpp
+++ b/test/ion_event_stream.cpp
@@ -276,7 +276,7 @@ iERR read_next_value(hREADER hreader, IonEventStream *stream, ION_TYPE t, BOOL i
         case tid_SYMBOL_INT:
         {
             ION_SYMBOL tmp, *symbol_value;
-            IONCHECKORFREE2(ion_reader_read_symbol(hreader, &tmp));
+            IONCHECKORFREE2(ion_reader_read_ion_symbol(hreader, &tmp));
             copy_ion_symbol(&symbol_value, &tmp);
             event->value = symbol_value;
             break;

--- a/test/ion_test_util.cpp
+++ b/test/ion_test_util.cpp
@@ -53,6 +53,33 @@ iERR ion_test_writer_get_bytes(hWRITER writer, ION_STREAM *ion_stream, BYTE **ou
     iRETURN;
 }
 
+iERR ion_test_writer_write_symbol_sid(ION_WRITER *writer, SID sid) {
+    iENTER;
+    ION_SYMBOL symbol;
+    memset(&symbol, 0, sizeof(ION_SYMBOL));
+    symbol.sid = sid;
+    IONCHECK(ion_writer_write_ion_symbol(writer, &symbol));
+    iRETURN;
+}
+
+iERR ion_test_writer_add_annotation_sid(ION_WRITER *writer, SID sid) {
+    iENTER;
+    ION_SYMBOL symbol;
+    memset(&symbol, 0, sizeof(ION_SYMBOL));
+    symbol.sid = sid;
+    IONCHECK(ion_writer_add_annotation_symbol(writer, &symbol));
+    iRETURN;
+}
+
+iERR ion_test_writer_write_field_name_sid(ION_WRITER *writer, SID sid) {
+    iENTER;
+    ION_SYMBOL symbol;
+    memset(&symbol, 0, sizeof(ION_SYMBOL));
+    symbol.sid = sid;
+    IONCHECK(ion_writer_write_field_name_symbol(writer, &symbol));
+    iRETURN;
+}
+
 iERR ion_string_from_cstr(const char *cstr, ION_STRING *out) {
     iENTER;
     if (!out) FAILWITH(IERR_INVALID_ARG);
@@ -79,6 +106,15 @@ iERR ion_test_new_reader(BYTE *ion_data, SIZE buffer_length, hREADER *reader) {
 iERR ion_test_new_text_reader(const char *ion_text, hREADER *reader) {
     iENTER;
     IONCHECK(ion_test_new_reader((BYTE *)ion_text, (SIZE)strlen(ion_text), reader));
+    iRETURN;
+}
+
+iERR ion_test_reader_read_symbol_sid(ION_READER *reader, SID *sid) {
+    iENTER;
+    ASSERT(sid);
+    ION_SYMBOL symbol;
+    IONCHECK(ion_reader_read_ion_symbol(reader, &symbol));
+    *sid = symbol.sid;
     iRETURN;
 }
 

--- a/test/ion_test_util.h
+++ b/test/ion_test_util.h
@@ -58,6 +58,30 @@ iERR ion_test_new_writer(hWRITER *writer, ION_STREAM **ion_stream, BOOL is_binar
 iERR ion_test_writer_get_bytes(hWRITER writer, ION_STREAM *ion_stream, BYTE **out, SIZE *len);
 
 /**
+ * Creates an ION_SYMBOL with the given SID and calls `ion_writer_write_ion_symbol`.
+ * @param writer - the writer to write to.
+ * @param sid - the local SID of the symbol to be written.
+ * @return the result of `ion_writer_write_ion_symbol`.
+ */
+iERR ion_test_writer_write_symbol_sid(ION_WRITER *writer, SID sid);
+
+/**
+ * Creates an ION_SYMBOL with the given SID and calls `ion_writer_add_annotation_symbol`.
+ * @param writer - the writer to write to.
+ * @param sid - the local SID of the symbol to be written.
+ * @return the result of `ion_writer_add_annotation_symbol`.
+ */
+iERR ion_test_writer_add_annotation_sid(ION_WRITER *writer, SID sid);
+
+/**
+ * Creates an ION_SYMBOL with the given SID and calls `ion_writer_write_field_name_symbol`.
+ * @param writer - the writer to write to.
+ * @param sid - the local SID of the symbol to be written.
+ * @return the result of `ion_writer_write_field_name_symbol`.
+ */
+iERR ion_test_writer_write_field_name_sid(ION_WRITER *writer, SID sid);
+
+/**
  * Assigns the given char * to an ION_STRING, without copying.
  * @param cstr - the char * to assign.
  * @param out - the ION_STRING to assign to.
@@ -88,6 +112,14 @@ iERR ion_test_new_reader(BYTE *ion_data, SIZE buffer_length, hREADER *reader);
  * @return IERR_OK, unless the reader fails to open.
  */
 iERR ion_test_new_text_reader(const char *ion_text, hREADER *reader);
+
+/**
+ * Reads an ION_SYMBOL and provides its local SID.
+ * @param reader - the reader from which to read.
+ * @param sid - Output parameter for the local SID of the symbol
+ * @return the result of `ion_reader_read_symbol.`
+ */
+iERR ion_test_reader_read_symbol_sid(ION_READER *reader, SID *sid);
 
 /**
  * Reads the Ion string at the given reader's current position and assigns its contents

--- a/test/test_ion_binary.cpp
+++ b/test/test_ion_binary.cpp
@@ -155,7 +155,7 @@ TEST(IonBinarySymbol, WriterWritesSymbolValueSymbolZero) {
     SIZE result_len;
 
     ION_ASSERT_OK(ion_test_new_writer(&writer, &ion_stream, TRUE));
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 0));
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 0));
     ION_ASSERT_OK(ion_test_writer_get_bytes(writer, ion_stream, &result, &result_len));
 
     // NOTE: symbol zero is NOT added to the local symbol table. Symbol zero is not present in ANY symbol table.
@@ -173,7 +173,7 @@ TEST(IonBinarySymbol, WriterWritesAnnotationThatLooksLikeSymbolZero) {
 
     ION_ASSERT_OK(ion_test_new_writer(&writer, &ion_stream, TRUE));
     ION_ASSERT_OK(ion_writer_add_annotation(writer, &symbol_zero));
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 0));
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 0));
     ION_ASSERT_OK(ion_test_writer_get_bytes(writer, ion_stream, &result, &result_len));
 
     // NOTE: the annotation refers to \x8A (i.e. SID 10 -- a local symbol), NOT \x80 (SID 0). This is because the
@@ -188,8 +188,8 @@ TEST(IonBinarySymbol, WriterWritesAnnotationSymbolZero) {
     SIZE result_len;
 
     ION_ASSERT_OK(ion_test_new_writer(&writer, &ion_stream, TRUE));
-    ION_ASSERT_OK(ion_writer_add_annotation_sid(writer, 0));
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 0));
+    ION_ASSERT_OK(ion_test_writer_add_annotation_sid(writer, 0));
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 0));
     ION_ASSERT_OK(ion_test_writer_get_bytes(writer, ion_stream, &result, &result_len));
 
     // NOTE: symbol zero is NOT added to the local symbol table. Symbol zero is not present in ANY symbol table.
@@ -209,7 +209,7 @@ TEST(IonBinarySymbol, WriterWritesFieldNameThatLooksLikeSymbolZero) {
     ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
     ION_ASSERT_OK(ion_writer_write_field_name(writer, &symbol_zero));
     ION_ASSERT_OK(ion_writer_add_annotation(writer, &symbol_zero));
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 0));
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 0));
     ION_ASSERT_OK(ion_writer_finish_container(writer));
     ION_ASSERT_OK(ion_test_writer_get_bytes(writer, ion_stream, &result, &result_len));
 
@@ -226,9 +226,9 @@ TEST(IonBinarySymbol, WriterWritesFieldNameSymbolZero) {
 
     ION_ASSERT_OK(ion_test_new_writer(&writer, &ion_stream, TRUE));
     ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
-    ION_ASSERT_OK(ion_writer_write_field_sid(writer, 0));
-    ION_ASSERT_OK(ion_writer_add_annotation_sid(writer, 0));
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 0));
+    ION_ASSERT_OK(ion_test_writer_write_field_name_sid(writer, 0));
+    ION_ASSERT_OK(ion_test_writer_add_annotation_sid(writer, 0));
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 0));
     ION_ASSERT_OK(ion_writer_finish_container(writer));
     ION_ASSERT_OK(ion_test_writer_get_bytes(writer, ion_stream, &result, &result_len));
 
@@ -261,7 +261,7 @@ TEST(IonBinarySymbol, ReaderReadsSymbolValueZeroAsSID) {
     ION_ASSERT_OK(ion_reader_open_buffer(&reader, symbol_zero, 5, NULL));
     ION_ASSERT_OK(ion_reader_next(reader, &actual_type));
     ASSERT_EQ(tid_SYMBOL, actual_type);
-    ION_ASSERT_OK(ion_reader_read_symbol_sid(reader, &actual));
+    ION_ASSERT_OK(ion_test_reader_read_symbol_sid(reader, &actual));
     ION_ASSERT_OK(ion_reader_close(reader));
 
     ASSERT_EQ(0, actual);
@@ -284,7 +284,7 @@ TEST(IonBinarySymbol, WriterWritesSymbolValueIVM) {
     ION_ASSERT_OK(ion_writer_write_int(writer, 0));
     ION_ASSERT_OK(ion_writer_write_symbol(writer, &ivm_text)); // This is a no-op.
     ION_ASSERT_OK(ion_writer_write_int(writer, 1));
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 2)); // This is a no-op.
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 2)); // This is a no-op.
     ION_ASSERT_OK(ion_writer_write_int(writer, 2));
 
     ION_ASSERT_OK(ion_test_writer_get_bytes(writer, ion_stream, &result, &result_len));
@@ -312,7 +312,7 @@ TEST(IonBinarySymbol, ReaderReadsSymbolValueIVMNoOp) {
     ION_ASSERT_OK(ion_reader_open_buffer(&reader, data, 8, NULL));
     ION_ASSERT_OK(ion_reader_next(reader, &actual_type));
     ASSERT_EQ(tid_SYMBOL, actual_type);
-    ION_ASSERT_OK(ion_reader_read_symbol_sid(reader, &sid));
+    ION_ASSERT_OK(ion_test_reader_read_symbol_sid(reader, &sid));
     ASSERT_EQ(4, sid);
     ION_ASSERT_OK(ion_reader_close(reader));
 }
@@ -329,7 +329,7 @@ TEST(IonBinarySymbol, ReaderReadsIVMInsideAnnotationWrapper) {
     ASSERT_EQ(tid_SYMBOL, actual_type);
     ION_ASSERT_OK(ion_reader_get_an_annotation(reader, 0, &annotation));
     assertStringsEqual("name", (char *)annotation.value, annotation.length); // SID 4 is "name"
-    ION_ASSERT_OK(ion_reader_read_symbol_sid(reader, &sid));
+    ION_ASSERT_OK(ion_test_reader_read_symbol_sid(reader, &sid));
     ASSERT_EQ(2, sid);
     ION_ASSERT_OK(ion_reader_close(reader));
 }

--- a/test/test_ion_symbol.cpp
+++ b/test/test_ion_symbol.cpp
@@ -132,15 +132,15 @@ TEST(IonSymbolTable, WriterAppendsLocalSymbolsOnFlush) {
     ASSERT_NE(0, bytes_flushed);
 
     ION_ASSERT_OK(ion_writer_write_symbol(writer, &sym3)); // This gets SID 12.
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 10)); // sym1 is still in scope.
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 12)); // This corresponds to sym3.
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 10)); // sym1 is still in scope.
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 12)); // This corresponds to sym3.
 
     // This flushes the writer and forces an IVM upon next write, thereby resetting the symbol table context.
     ION_ASSERT_OK(ion_writer_finish(writer, &bytes_flushed));
     ASSERT_NE(0, bytes_flushed);
 
     ION_ASSERT_OK(ion_writer_write_symbol(writer, &sym4));
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 10)); // sym1 is no longer in scope. This refers to sym4.
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 10)); // sym1 is no longer in scope. This refers to sym4.
 
     ION_SYMBOL_TEST_REWRITE_FROM_WRITER_AND_ASSERT_TEXT("sym1 sym2 sym3 sym1 sym3 sym4 sym4");
 }
@@ -154,18 +154,18 @@ TEST_P(BinaryAndTextTest, WriterAppendsLocalSymbolsWithImportsOnFlush) {
     ION_SYMBOL_TEST_POPULATE_CATALOG;
     ION_SYMBOL_TEST_OPEN_WRITER_WITH_IMPORTS(is_binary, writer_imports, 2);
 
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 10));
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 11));
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 12));
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 10));
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 11));
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 12));
 
     ION_ASSERT_OK(ion_writer_flush(writer, &bytes_flushed));
     ASSERT_NE(0, bytes_flushed);
 
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 10));
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 10));
     ION_ASSERT_OK(ion_writer_write_symbol(writer, &sym3)); // sym3 is already in the symbol table, with SID 12
     ION_ASSERT_OK(ion_writer_write_symbol(writer, &sym4));
     if (is_binary) {
-        ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 13)); // Corresponds to sym4.
+        ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 13)); // Corresponds to sym4.
     }
     else {
         // When local symbols are written by a text writer, they are not assigned SIDs, so trying to write SID 13 would
@@ -288,16 +288,16 @@ TEST_P(BinaryAndTextTest, ManuallyWritingSymbolTableStructIsRecognizedAsSymbolTa
     ION_ASSERT_OK(ion_string_from_cstr("sym2", &sym2));
 
     ION_ASSERT_OK(ion_test_new_writer(&writer, &stream, is_binary));
-    ION_ASSERT_OK(ion_writer_add_annotation_sid(writer, ION_SYS_SID_SYMBOL_TABLE)); // $ion_symbol_table
+    ION_ASSERT_OK(ion_test_writer_add_annotation_sid(writer, ION_SYS_SID_SYMBOL_TABLE)); // $ion_symbol_table
     ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
-    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_SYMBOLS));
+    ION_ASSERT_OK(ion_test_writer_write_field_name_sid(writer, ION_SYS_SID_SYMBOLS));
     ION_ASSERT_OK(ion_writer_start_container(writer, tid_LIST));
     ION_ASSERT_OK(ion_writer_write_string(writer, &sym1));
     ION_ASSERT_OK(ion_writer_write_string(writer, &sym2));
     ION_ASSERT_OK(ion_writer_finish_container(writer)); // end symbols list
     ION_ASSERT_OK(ion_writer_finish_container(writer)); // end LST struct
 
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 10)); // This maps to sym1.
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 10)); // This maps to sym1.
 
     ION_SYMBOL_TEST_REWRITE_FROM_WRITER_AND_ASSERT_TEXT("sym1");
 }
@@ -332,13 +332,13 @@ TEST_P(BinaryAndTextTest, ManuallyWritingSymbolTableStructWithImportsIsRecognize
     ION_ASSERT_OK(ion_writer_write_string(writer, &import1_name));
     ION_ASSERT_OK(ion_writer_write_field_name_symbol(writer, &version_symbol));
     ION_ASSERT_OK(ion_writer_write_int(writer, 1));
-    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_MAX_ID));
+    ION_ASSERT_OK(ion_test_writer_write_field_name_sid(writer, ION_SYS_SID_MAX_ID));
     ION_ASSERT_OK(ion_writer_write_int(writer, 1));
     ION_ASSERT_OK(ion_writer_finish_container(writer)); // end import struct
     ION_ASSERT_OK(ion_writer_finish_container(writer)); // end imports list
     ION_ASSERT_OK(ion_writer_finish_container(writer)); // end LST struct
 
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 10)); // This maps to sym1.
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 10)); // This maps to sym1.
 
     ION_SYMBOL_TEST_REWRITE_WITH_CATALOG_FROM_WRITER_AND_ASSERT_TEXT("$ion_symbol_table::{imports:[{name:\"import1\",version:1,max_id:1}]} sym1");
 }
@@ -370,12 +370,12 @@ TEST_P(BinaryAndTextTest, ManuallyWritingSymbolTableStructWithImportsAndOpenCont
 
     ION_ASSERT_OK(ion_writer_add_annotation_symbol(writer, &symbol_table_symbol)); // $ion_symbol_table
     ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
-    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_IMPORTS));
+    ION_ASSERT_OK(ion_test_writer_write_field_name_sid(writer, ION_SYS_SID_IMPORTS));
     ION_ASSERT_OK(ion_writer_start_container(writer, tid_LIST));
     ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
-    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_NAME));
+    ION_ASSERT_OK(ion_test_writer_write_field_name_sid(writer, ION_SYS_SID_NAME));
     ION_ASSERT_OK(ion_writer_write_string(writer, &import1_name));
-    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_VERSION));
+    ION_ASSERT_OK(ion_test_writer_write_field_name_sid(writer, ION_SYS_SID_VERSION));
     ION_ASSERT_OK(ion_writer_add_annotation(writer, &foo_name)); // open content; ignored.
     ION_ASSERT_OK(ion_writer_add_annotation_symbol(writer, &bar_symbol)); // open content; ignored.
     ION_ASSERT_OK(ion_writer_write_int(writer, 1));
@@ -383,15 +383,15 @@ TEST_P(BinaryAndTextTest, ManuallyWritingSymbolTableStructWithImportsAndOpenCont
     ION_ASSERT_OK(ion_writer_write_int(writer, 123)); // open content; ignored.
     ION_ASSERT_OK(ion_writer_write_field_name_symbol(writer, &bar_symbol)); // open content; ignored.
     ION_ASSERT_OK(ion_writer_write_int(writer, 456)); // open content; ignored.
-    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_MAX_ID));
+    ION_ASSERT_OK(ion_test_writer_write_field_name_sid(writer, ION_SYS_SID_MAX_ID));
     ION_ASSERT_OK(ion_writer_write_int(writer, 1)); // $10 = sym1
     ION_ASSERT_OK(ion_writer_finish_container(writer)); // end import struct
     ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
-    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_NAME));
+    ION_ASSERT_OK(ion_test_writer_write_field_name_sid(writer, ION_SYS_SID_NAME));
     ION_ASSERT_OK(ion_writer_write_string(writer, &foo_name)); // Not in catalog.
-    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_VERSION));
+    ION_ASSERT_OK(ion_test_writer_write_field_name_sid(writer, ION_SYS_SID_VERSION));
     ION_ASSERT_OK(ion_writer_write_int(writer, 1));
-    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_MAX_ID));
+    ION_ASSERT_OK(ion_test_writer_write_field_name_sid(writer, ION_SYS_SID_MAX_ID));
     ION_ASSERT_OK(ion_writer_write_int(writer, 2)); // $11 and $12
     ION_ASSERT_OK(ion_writer_write_field_name(writer, &foo_name)); // open content; ignored.
     ION_ASSERT_OK(ion_writer_start_container(writer, tid_LIST)); // open content; ignored.
@@ -402,8 +402,8 @@ TEST_P(BinaryAndTextTest, ManuallyWritingSymbolTableStructWithImportsAndOpenCont
     ION_ASSERT_OK(ion_writer_finish_container(writer)); // end imports list
     ION_ASSERT_OK(ion_writer_finish_container(writer)); // end LST struct
 
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 10)); // This maps to sym1.
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 12)); // This maps to unknown text.
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 10)); // This maps to sym1.
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 12)); // This maps to unknown text.
 
     hREADER reader;
     BYTE *result;
@@ -412,6 +412,7 @@ TEST_P(BinaryAndTextTest, ManuallyWritingSymbolTableStructWithImportsAndOpenCont
     ION_COLLECTION *imports;
     ION_SYMBOL_TABLE *reader_symtab;
     ION_TYPE type;
+    ION_SYMBOL symbol;
 
     ION_ASSERT_OK(ion_test_writer_get_bytes(writer, stream, &result, &bytes_flushed));
     ion_test_initialize_reader_options(&reader_options);
@@ -428,11 +429,11 @@ TEST_P(BinaryAndTextTest, ManuallyWritingSymbolTableStructWithImportsAndOpenCont
     ION_ASSERT_OK(ion_writer_open(&roundtrip_writer, stream, &writer_options));
     ION_ASSERT_OK(ion_writer_options_close_shared_imports(&writer_options));
 
-    ION_ASSERT_OK(ion_reader_read_symbol_sid(reader, &sid));
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(roundtrip_writer, sid));
+    ION_ASSERT_OK(ion_reader_read_ion_symbol(reader, &symbol));
+    ION_ASSERT_OK(ion_writer_write_ion_symbol(roundtrip_writer, &symbol));
     ION_ASSERT_OK(ion_reader_next(reader, &type));
-    ION_ASSERT_OK(ion_reader_read_symbol_sid(reader, &sid));
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(roundtrip_writer, sid));
+    ION_ASSERT_OK(ion_reader_read_ion_symbol(reader, &symbol));
+    ION_ASSERT_OK(ion_writer_write_ion_symbol(roundtrip_writer, &symbol));
     ION_ASSERT_OK(ion_reader_close(reader));
     free(result);
 
@@ -454,17 +455,17 @@ TEST_P(BinaryAndTextTest, ManuallyWritingSymbolTableAfterAutomaticSymbolTableSuc
     ION_ASSERT_OK(ion_writer_write_symbol(writer, &sym1));
     ION_ASSERT_OK(ion_writer_write_symbol(writer, &sym2));
 
-    ION_ASSERT_OK(ion_writer_add_annotation_sid(writer, ION_SYS_SID_SYMBOL_TABLE)); // $ion_symbol_table
+    ION_ASSERT_OK(ion_test_writer_add_annotation_sid(writer, ION_SYS_SID_SYMBOL_TABLE)); // $ion_symbol_table
     ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
-    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_SYMBOLS));
+    ION_ASSERT_OK(ion_test_writer_write_field_name_sid(writer, ION_SYS_SID_SYMBOLS));
     ION_ASSERT_OK(ion_writer_start_container(writer, tid_LIST));
     ION_ASSERT_OK(ion_writer_write_string(writer, &sym3));
     ION_ASSERT_OK(ion_writer_write_string(writer, &sym4));
     ION_ASSERT_OK(ion_writer_finish_container(writer)); // end symbols list
     ION_ASSERT_OK(ion_writer_finish_container(writer)); // end LST struct
 
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 10));
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 11));
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 10));
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 11));
 
     ION_SYMBOL_TEST_REWRITE_FROM_WRITER_AND_ASSERT_TEXT("sym1 sym2 sym3 sym4");
 }
@@ -484,18 +485,18 @@ TEST_P(BinaryAndTextTest, ManuallyWritingSymbolTableWithDuplicateFieldsFails) {
     name_symbol.import_location.location = ION_SYS_SID_NAME;
 
     ION_ASSERT_OK(ion_test_new_writer(&writer, &stream, is_binary));
-    ION_ASSERT_OK(ion_writer_add_annotation_sid(writer, ION_SYS_SID_SYMBOL_TABLE)); // $ion_symbol_table
+    ION_ASSERT_OK(ion_test_writer_add_annotation_sid(writer, ION_SYS_SID_SYMBOL_TABLE)); // $ion_symbol_table
     ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
-    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_IMPORTS));
+    ION_ASSERT_OK(ion_test_writer_write_field_name_sid(writer, ION_SYS_SID_IMPORTS));
     ION_ASSERT_OK(ion_writer_start_container(writer, tid_LIST));
     ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
     ION_ASSERT_OK(ion_writer_write_field_name_symbol(writer, &name_symbol));
     ION_ASSERT_OK(ion_writer_write_string(writer, &foo));
-    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_VERSION));
+    ION_ASSERT_OK(ion_test_writer_write_field_name_sid(writer, ION_SYS_SID_VERSION));
     ION_ASSERT_OK(ion_writer_write_int(writer, 1));
-    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_MAX_ID));
+    ION_ASSERT_OK(ion_test_writer_write_field_name_sid(writer, ION_SYS_SID_MAX_ID));
     ION_ASSERT_OK(ion_writer_write_int(writer, 1));
-    ASSERT_EQ(IERR_INVALID_SYMBOL_TABLE, ion_writer_write_field_sid(writer, ION_SYS_SID_VERSION));
+    ASSERT_EQ(IERR_INVALID_SYMBOL_TABLE, ion_test_writer_write_field_name_sid(writer, ION_SYS_SID_VERSION));
     ASSERT_EQ(IERR_INVALID_SYMBOL_TABLE, ion_writer_write_field_name_symbol(writer, &max_id_symbol));
     ASSERT_EQ(IERR_INVALID_SYMBOL_TABLE, ion_writer_write_field_name_symbol(writer, &name_symbol));
     ION_ASSERT_OK(ion_writer_finish_container(writer)); // end import struct
@@ -505,10 +506,10 @@ TEST_P(BinaryAndTextTest, ManuallyWritingSymbolTableWithDuplicateFieldsFails) {
     ION_ASSERT_OK(ion_writer_start_container(writer, tid_LIST));
     ION_ASSERT_OK(ion_writer_write_string(writer, &foo));
     ION_ASSERT_OK(ion_writer_finish_container(writer)); // end symbols list
-    ASSERT_EQ(IERR_INVALID_SYMBOL_TABLE, ion_writer_write_field_sid(writer, ION_SYS_SID_SYMBOLS));
+    ASSERT_EQ(IERR_INVALID_SYMBOL_TABLE, ion_test_writer_write_field_name_sid(writer, ION_SYS_SID_SYMBOLS));
     ION_ASSERT_OK(ion_writer_finish_container(writer)); // end LST struct
 
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 11)); // foo
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 11)); // foo
 
     ION_SYMBOL_TEST_REWRITE_FROM_WRITER_AND_ASSERT_TEXT("$ion_symbol_table::{imports:[{name:\"foo\",version:1,max_id:1}]} foo");
 }
@@ -520,28 +521,28 @@ TEST_P(BinaryAndTextTest, ManuallyWritingImportWithNoNameIsIgnored) {
     ION_ASSERT_OK(ion_string_from_cstr("foo", &foo));
 
     ION_ASSERT_OK(ion_test_new_writer(&writer, &stream, is_binary));
-    ION_ASSERT_OK(ion_writer_add_annotation_sid(writer, ION_SYS_SID_SYMBOL_TABLE)); // $ion_symbol_table
+    ION_ASSERT_OK(ion_test_writer_add_annotation_sid(writer, ION_SYS_SID_SYMBOL_TABLE)); // $ion_symbol_table
     ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
-    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_SYMBOLS));
+    ION_ASSERT_OK(ion_test_writer_write_field_name_sid(writer, ION_SYS_SID_SYMBOLS));
     ION_ASSERT_OK(ion_writer_start_container(writer, tid_LIST));
     ION_ASSERT_OK(ion_writer_write_string(writer, &foo));
     ION_ASSERT_OK(ion_writer_finish_container(writer));
-    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_IMPORTS));
+    ION_ASSERT_OK(ion_test_writer_write_field_name_sid(writer, ION_SYS_SID_IMPORTS));
     ION_ASSERT_OK(ion_writer_start_container(writer, tid_LIST));
     ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
-    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_NAME));
+    ION_ASSERT_OK(ion_test_writer_write_field_name_sid(writer, ION_SYS_SID_NAME));
     ION_ASSERT_OK(ion_writer_write_int(writer, 123)); // This is not a string, so it's ignored.
-    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_VERSION));
+    ION_ASSERT_OK(ion_test_writer_write_field_name_sid(writer, ION_SYS_SID_VERSION));
     ION_ASSERT_OK(ion_writer_write_int(writer, 1));
-    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_MAX_ID));
+    ION_ASSERT_OK(ion_test_writer_write_field_name_sid(writer, ION_SYS_SID_MAX_ID));
     ION_ASSERT_OK(ion_writer_write_int(writer, 1));
-    ASSERT_EQ(IERR_INVALID_SYMBOL_TABLE, ion_writer_write_field_sid(writer, ION_SYS_SID_NAME));
+    ASSERT_EQ(IERR_INVALID_SYMBOL_TABLE, ion_test_writer_write_field_name_sid(writer, ION_SYS_SID_NAME));
     ION_ASSERT_OK(ion_writer_finish_container(writer));
     ION_ASSERT_OK(ion_writer_finish_container(writer));
     ION_ASSERT_OK(ion_writer_finish_container(writer));
 
     // NOTE: the ignored import had space for one symbol. If it weren't ignored, SID 10 would fall within its range.
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 10));
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 10));
 
     ION_SYMBOL_TEST_REWRITE_FROM_WRITER_AND_ASSERT_TEXT("foo");
 }
@@ -553,14 +554,14 @@ TEST_P(BinaryAndTextTest, ManuallyWritingAmbiguousImportFails) {
     ION_ASSERT_OK(ion_string_from_cstr("foo", &foo));
 
     ION_ASSERT_OK(ion_test_new_writer(&writer, &stream, is_binary));
-    ION_ASSERT_OK(ion_writer_add_annotation_sid(writer, ION_SYS_SID_SYMBOL_TABLE)); // $ion_symbol_table
+    ION_ASSERT_OK(ion_test_writer_add_annotation_sid(writer, ION_SYS_SID_SYMBOL_TABLE)); // $ion_symbol_table
     ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
-    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_IMPORTS));
+    ION_ASSERT_OK(ion_test_writer_write_field_name_sid(writer, ION_SYS_SID_IMPORTS));
     ION_ASSERT_OK(ion_writer_start_container(writer, tid_LIST));
     ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
-    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_NAME));
+    ION_ASSERT_OK(ion_test_writer_write_field_name_sid(writer, ION_SYS_SID_NAME));
     ION_ASSERT_OK(ion_writer_write_string(writer, &foo));
-    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_VERSION));
+    ION_ASSERT_OK(ion_test_writer_write_field_name_sid(writer, ION_SYS_SID_VERSION));
     ION_ASSERT_OK(ion_writer_write_int(writer, 1));
     ASSERT_EQ(IERR_INVALID_SYMBOL_TABLE, ion_writer_finish_container(writer));
     ASSERT_EQ(IERR_UNEXPECTED_EOF, ion_writer_close(writer));
@@ -579,27 +580,27 @@ TEST_P(BinaryAndTextTest, ManuallyWriteSymbolTableAppendSucceeds) {
     ION_ASSERT_OK(ion_writer_write_symbol(writer, &sym1));
     ION_ASSERT_OK(ion_writer_write_symbol(writer, &sym2));
 
-    ION_ASSERT_OK(ion_writer_add_annotation_sid(writer, ION_SYS_SID_SYMBOL_TABLE)); // $ion_symbol_table
+    ION_ASSERT_OK(ion_test_writer_add_annotation_sid(writer, ION_SYS_SID_SYMBOL_TABLE)); // $ion_symbol_table
     ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
-    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_IMPORTS));
+    ION_ASSERT_OK(ion_test_writer_write_field_name_sid(writer, ION_SYS_SID_IMPORTS));
     ION_ASSERT_OK(ion_writer_write_symbol(writer, &ION_SYMBOL_SYMBOL_TABLE_STRING));
-    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_SYMBOLS));
+    ION_ASSERT_OK(ion_test_writer_write_field_name_sid(writer, ION_SYS_SID_SYMBOLS));
     ION_ASSERT_OK(ion_writer_start_container(writer, tid_LIST));
     ION_ASSERT_OK(ion_writer_write_string(writer, &sym3));
     ION_ASSERT_OK(ion_writer_finish_container(writer));
     ION_ASSERT_OK(ion_writer_finish_container(writer));
 
     if (is_binary) {
-        ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 10));
-        ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 11));
-        ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 12));
+        ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 10));
+        ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 11));
+        ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 12));
     }
     else {
         // Text writers never intern symbols with known text, so sym1 and sym2 never had SID mappings.
         // Because sym3 is manually interned, it gets SID 10.
         ION_ASSERT_OK(ion_writer_write_symbol(writer, &sym1));
         ION_ASSERT_OK(ion_writer_write_symbol(writer, &sym2));
-        ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 10));
+        ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 10));
     }
 
     // This flushes the writer and forces an IVM upon next write, thereby resetting the symbol table context.
@@ -628,11 +629,11 @@ TEST_P(BinaryAndTextTest, ManuallyWriteSymbolTableAppendWithImportsSucceeds) {
     ION_SYMBOL_TEST_POPULATE_CATALOG;
     ION_SYMBOL_TEST_OPEN_WRITER_WITH_IMPORTS(is_binary, writer_imports, 2);
 
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 10));
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 11));
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 12));
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 10));
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 11));
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 12));
 
-    ION_ASSERT_OK(ion_writer_add_annotation_sid(writer, ION_SYS_SID_SYMBOL_TABLE)); // $ion_symbol_table
+    ION_ASSERT_OK(ion_test_writer_add_annotation_sid(writer, ION_SYS_SID_SYMBOL_TABLE)); // $ion_symbol_table
     ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
     ION_ASSERT_OK(ion_writer_write_field_name_symbol(writer, &imports_symbol));
     ION_ASSERT_OK(ion_writer_write_ion_symbol(writer, &symbol_table_symbol));
@@ -642,10 +643,10 @@ TEST_P(BinaryAndTextTest, ManuallyWriteSymbolTableAppendWithImportsSucceeds) {
     ION_ASSERT_OK(ion_writer_finish_container(writer));
     ION_ASSERT_OK(ion_writer_finish_container(writer));
 
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 10));
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 10));
     ION_ASSERT_OK(ion_writer_write_symbol(writer, &sym3)); // sym3 is already in the symbol table, with SID 12
     ION_ASSERT_OK(ion_writer_write_symbol(writer, &sym4));
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 13)); // Corresponds to sym4.
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 13)); // Corresponds to sym4.
 
     ION_SYMBOL_TEST_REWRITE_WITH_CATALOG_FROM_WRITER_AND_ASSERT_TEXT(
             "$ion_symbol_table::{imports:[{name:\"import1\",version:1,max_id:1},{name:\"import2\",version:1,max_id:2}]} sym1 sym2 sym3 sym1 sym3 sym4 sym4");
@@ -665,7 +666,7 @@ TEST_P(BinaryAndTextTest, SymbolTableGettersWithManualLSTInProgressReturnsPrevio
     ION_ASSERT_OK(ion_writer_write_symbol(writer, &sym1));
     ION_ASSERT_OK(ion_writer_get_symbol_table(writer, &symbol_table_1));
 
-    ION_ASSERT_OK(ion_writer_add_annotation_sid(writer, ION_SYS_SID_SYMBOL_TABLE)); // $ion_symbol_table
+    ION_ASSERT_OK(ion_test_writer_add_annotation_sid(writer, ION_SYS_SID_SYMBOL_TABLE)); // $ion_symbol_table
     ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
 
     ION_ASSERT_OK(ion_writer_get_symbol_table(writer, &symbol_table_2));
@@ -688,7 +689,7 @@ TEST_P(BinaryAndTextTest, SymbolTableSetterWithManualLSTInProgressFails) {
 
     ION_ASSERT_OK(ion_test_new_writer(&writer, &stream, is_binary));
 
-    ION_ASSERT_OK(ion_writer_add_annotation_sid(writer, ION_SYS_SID_SYMBOL_TABLE)); // $ion_symbol_table
+    ION_ASSERT_OK(ion_test_writer_add_annotation_sid(writer, ION_SYS_SID_SYMBOL_TABLE)); // $ion_symbol_table
     ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
 
     ASSERT_EQ(IERR_INVALID_STATE, ion_writer_set_symbol_table(writer, symbol_table));
@@ -708,9 +709,9 @@ TEST(IonSymbolTable, TextWritingKnownSymbolFromSIDResolvesText) {
     BYTE *result;
 
     ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
-    ION_ASSERT_OK(ion_writer_write_field_sid(writer, 10));
-    ION_ASSERT_OK(ion_writer_add_annotation_sid(writer, 11));
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 12));
+    ION_ASSERT_OK(ion_test_writer_write_field_name_sid(writer, 10));
+    ION_ASSERT_OK(ion_test_writer_add_annotation_sid(writer, 11));
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 12));
     ION_ASSERT_OK(ion_writer_finish_container(writer));
 
     ION_ASSERT_OK(ion_test_writer_get_bytes(writer, stream, &result, &bytes_flushed));
@@ -738,9 +739,9 @@ TEST(IonSymbolTable, TextWritingSymbolWithUnknownTextAsSidFromImportWritesIdenti
     ION_SYMBOL_TEST_OPEN_WRITER_WITH_IMPORTS(FALSE, &import, 1);
     ION_ASSERT_OK(ion_writer_options_close_shared_imports(&writer_options));
 
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 10));
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 11));
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 12));
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 10));
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 11));
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 12));
 
     ION_ASSERT_OK(ion_test_writer_get_bytes(writer, stream, &result, &bytes_flushed));
     assertStringsEqual("$ion_symbol_table::{imports:[{name:\"foo\",version:1,max_id:3}]} abc $11 def", (char *)result, bytes_flushed);
@@ -908,22 +909,22 @@ TEST(IonSymbolTable, TextWritingSymbolWithUnknownTextFromManuallyWrittenSymbolTa
     ION_ASSERT_OK(ion_string_from_cstr("foo", &foo));
 
     ION_ASSERT_OK(ion_test_new_writer(&writer, &stream, FALSE));
-    ION_ASSERT_OK(ion_writer_add_annotation_sid(writer, ION_SYS_SID_SYMBOL_TABLE)); // $ion_symbol_table
+    ION_ASSERT_OK(ion_test_writer_add_annotation_sid(writer, ION_SYS_SID_SYMBOL_TABLE)); // $ion_symbol_table
     ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
-    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_IMPORTS));
+    ION_ASSERT_OK(ion_test_writer_write_field_name_sid(writer, ION_SYS_SID_IMPORTS));
     ION_ASSERT_OK(ion_writer_start_container(writer, tid_LIST));
     ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
-    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_NAME));
+    ION_ASSERT_OK(ion_test_writer_write_field_name_sid(writer, ION_SYS_SID_NAME));
     ION_ASSERT_OK(ion_writer_write_string(writer, &foo));
-    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_VERSION));
+    ION_ASSERT_OK(ion_test_writer_write_field_name_sid(writer, ION_SYS_SID_VERSION));
     ION_ASSERT_OK(ion_writer_write_int(writer, 1));
-    ION_ASSERT_OK(ion_writer_write_field_sid(writer, ION_SYS_SID_MAX_ID));
+    ION_ASSERT_OK(ion_test_writer_write_field_name_sid(writer, ION_SYS_SID_MAX_ID));
     ION_ASSERT_OK(ion_writer_write_int(writer, 1));
     ION_ASSERT_OK(ion_writer_finish_container(writer)); // end import struct
     ION_ASSERT_OK(ion_writer_finish_container(writer)); // end imports list
     ION_ASSERT_OK(ion_writer_finish_container(writer)); // end LST struct
 
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 10)); // $10 (unknown text).
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 10)); // $10 (unknown text).
 
     ION_ASSERT_OK(ion_test_writer_get_bytes(writer, stream, &result, &bytes_flushed));
     assertStringsEqual("$ion_symbol_table::{imports:[{name:\"foo\",version:1,max_id:1}]} $10", (char *)result, bytes_flushed);
@@ -936,20 +937,26 @@ TEST_P(BinaryAndTextTest, WritingOutOfRangeSIDFails) {
     // on read.
     ION_SYMBOL_TEST_DECLARE_WRITER;
     ION_STRING sym1;
-    SID annotation_sids[2];
+    ION_SYMBOL *annotation_symbols[2];
+    ION_SYMBOL annotation_1, annotation_2;
 
     ION_ASSERT_OK(ion_string_from_cstr("sym1", &sym1));
-    annotation_sids[0] = 4; // i.e. name
-    annotation_sids[1] = 10; // out of range.
+    memset(&annotation_1, 0, sizeof(ION_SYMBOL));
+    memset(&annotation_2, 0, sizeof(ION_SYMBOL));
+    annotation_1.sid = 4; // i.e. name
+    annotation_2.sid = 10; // out of range.
+
+    annotation_symbols[0] = &annotation_1;
+    annotation_symbols[1] = &annotation_2;
 
     ION_ASSERT_OK(ion_test_new_writer(&writer, &stream, is_binary));
     ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
-    ASSERT_EQ(IERR_INVALID_SYMBOL, ion_writer_write_field_sid(writer, 10));
+    ASSERT_EQ(IERR_INVALID_SYMBOL, ion_test_writer_write_field_name_sid(writer, 10));
     ION_ASSERT_OK(ion_writer_write_field_name(writer, &sym1));
-    ASSERT_EQ(IERR_INVALID_SYMBOL, ion_writer_add_annotation_sid(writer, 10));
-    ASSERT_EQ(IERR_INVALID_SYMBOL, ion_writer_write_annotation_sids(writer, annotation_sids, 2));
-    ASSERT_EQ(IERR_INVALID_SYMBOL, ion_writer_write_symbol_sid(writer, 10));
-    ION_ASSERT_OK(ion_writer_write_annotation_sids(writer, annotation_sids, 1));
+    ASSERT_EQ(IERR_INVALID_SYMBOL, ion_test_writer_add_annotation_sid(writer, 10));
+    ASSERT_EQ(IERR_INVALID_SYMBOL, ion_writer_write_annotation_symbols(writer, annotation_symbols, 2));
+    ASSERT_EQ(IERR_INVALID_SYMBOL, ion_test_writer_write_symbol_sid(writer, 10));
+    ION_ASSERT_OK(ion_writer_write_annotation_symbols(writer, annotation_symbols, 1));
     ION_ASSERT_OK(ion_writer_write_symbol(writer, &sym1));
     ION_ASSERT_OK(ion_writer_finish_container(writer));
 
@@ -1016,19 +1023,19 @@ TEST_P(BinaryAndTextTest, WriterWithImportsListIncludesThoseImportsWithEveryNewL
     ION_SYMBOL_TEST_POPULATE_CATALOG;
     ION_SYMBOL_TEST_OPEN_WRITER_WITH_IMPORTS(is_binary, writer_imports, 2);
 
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 10));
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 11));
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 12));
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 10));
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 11));
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 12));
 
     ION_ASSERT_OK(ion_writer_finish(writer, &bytes_flushed));
     ASSERT_NE(0, bytes_flushed);
 
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 10));
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 11));
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 10));
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 11));
     ION_ASSERT_OK(ion_writer_write_symbol(writer, &sym3)); // sym3 is already in the symbol table, with SID 12
     ION_ASSERT_OK(ion_writer_write_symbol(writer, &sym4));
     if (is_binary) {
-        ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 13)); // Corresponds to sym4.
+        ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 13)); // Corresponds to sym4.
     }
     else {
         // When local symbols are written by a text writer, they are not assigned SIDs, so trying to write SID 13 would
@@ -1092,6 +1099,7 @@ TEST(IonSymbolTable, ReadThenWriteSymbolsWithUnknownText) {
     ION_WRITER_OPTIONS writer_options;
     BYTE *result;
     SID sid;
+    ION_SYMBOL *symbol;
 
     ION_ASSERT_OK(ion_test_new_text_reader(ion_data, &reader));
     ION_ASSERT_OK(ion_reader_next(reader, &type));
@@ -1111,10 +1119,10 @@ TEST(IonSymbolTable, ReadThenWriteSymbolsWithUnknownText) {
     ION_ASSERT_OK(ion_writer_start_container(writer, type));
     ION_ASSERT_OK(ion_reader_next(reader, &type));
     ASSERT_EQ(tid_SYMBOL, type);
-    ION_ASSERT_OK(ion_reader_get_field_sid(reader, &sid));
-    ION_ASSERT_OK(ion_writer_write_field_sid(writer, sid));
-    ION_ASSERT_OK(ion_reader_read_symbol_sid(reader, &sid));
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, sid));
+    ION_ASSERT_OK(ion_reader_get_field_name_symbol(reader, &symbol));
+    ION_ASSERT_OK(ion_writer_write_field_name_symbol(writer, symbol));
+    ION_ASSERT_OK(ion_test_reader_read_symbol_sid(reader, &sid));
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, sid));
     ION_ASSERT_OK(ion_reader_step_out(reader));
     ION_ASSERT_OK(ion_writer_finish_container(writer));
     ION_ASSERT_OK(ion_reader_close(reader));
@@ -1133,7 +1141,7 @@ TEST_P(BinaryAndTextTest, WriteAnnotationsFromSidAndText) {
 
     ION_ASSERT_OK(ion_test_new_writer(&writer, &stream, is_binary));
     ION_ASSERT_OK(ion_writer_add_annotation(writer, &foo));
-    ION_ASSERT_OK(ion_writer_add_annotation_sid(writer, 4));
+    ION_ASSERT_OK(ion_test_writer_add_annotation_sid(writer, 4));
     ION_ASSERT_OK(ion_writer_write_int(writer, 123));
 
     ION_SYMBOL_TEST_REWRITE_FROM_WRITER_AND_ASSERT_TEXT("foo::name::123");
@@ -1176,7 +1184,7 @@ TEST_P(BinaryAndTextTest, ReaderCorrectlySetsImportLocation) {
     ASSERT_TRUE(assertIonStringEq(&sym1, &field_name->value));
     ASSERT_EQ(10, field_name->sid);
 
-    ION_ASSERT_OK(ion_reader_read_symbol(reader, &value));
+    ION_ASSERT_OK(ion_reader_read_ion_symbol(reader, &value));
     ASSERT_TRUE(assertIonStringEq(&import2_name, &value.import_location.name));
     ASSERT_EQ(2, value.import_location.location);
     ASSERT_TRUE(assertIonStringEq(&sym3, &value.value));
@@ -1227,7 +1235,7 @@ TEST_P(BinaryAndTextTest, LocalSymbolHasNoImportLocation) {
     ASSERT_TRUE(ION_SYMBOL_IMPORT_LOCATION_IS_NULL(&annotation[0]));
     ASSERT_EQ(is_binary ? 11 : UNKNOWN_SID, annotation[0].sid);
 
-    ION_ASSERT_OK(ion_reader_read_symbol(reader, &value));
+    ION_ASSERT_OK(ion_reader_read_ion_symbol(reader, &value));
     ASSERT_TRUE(assertIonStringEq(&zaz, &value.value));
     ASSERT_TRUE(ION_SYMBOL_IMPORT_LOCATION_IS_NULL(&value));
     ASSERT_EQ(is_binary ? 12 : UNKNOWN_SID, value.sid);
@@ -1305,7 +1313,7 @@ TEST_P(BinaryAndTextTest, ReadingOutOfRangeSymbolValueSIDFails) {
     ION_ASSERT_OK(ion_reader_open_buffer(&reader, (BYTE *)ion_data, ion_data_len, NULL));
     ION_ASSERT_OK(ion_reader_next(reader, &type));
     ASSERT_EQ(tid_SYMBOL, type);
-    ASSERT_EQ(IERR_INVALID_SYMBOL, ion_reader_read_symbol(reader, &symbol));
+    ASSERT_EQ(IERR_INVALID_SYMBOL, ion_reader_read_ion_symbol(reader, &symbol));
     ION_ASSERT_OK(ion_reader_close(reader));
 }
 
@@ -1517,9 +1525,9 @@ TEST_P(BinaryAndTextTest, AddImportedTablesSkipsDuplicateImports) {
     import2_import->descriptor.max_id = 2;
 
     ION_ASSERT_OK(ion_writer_add_imported_tables(writer, &duplicate_1));
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 10));
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 10));
     ION_ASSERT_OK(ion_writer_add_imported_tables(writer, &duplicate_2));
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 11));
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 11));
 
     ION_ASSERT_OK(ion_test_writer_get_bytes(writer, stream, &result, &bytes_flushed));
 

--- a/test/test_ion_text.cpp
+++ b/test/test_ion_text.cpp
@@ -86,7 +86,7 @@ TEST(IonTextSymbol, WriterWritesSymbolValueZero) {
     ion_string_from_cstr("$0", &symbol_zero);
 
     ION_ASSERT_OK(ion_test_new_writer(&writer, &ion_stream, FALSE));
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 0));
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 0));
     ION_ASSERT_OK(ion_writer_write_symbol(writer, &symbol_zero));
     ION_ASSERT_OK(ion_test_writer_get_bytes(writer, ion_stream, &result, &result_len));
 
@@ -105,10 +105,10 @@ TEST(IonTextSymbol, WriterWritesSymbolAnnotationZero) {
     ION_ASSERT_OK(ion_test_new_writer(&writer, &ion_stream, FALSE));
 
     ION_ASSERT_OK(ion_writer_add_annotation(writer, &symbol_zero));
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 0));
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 0));
 
-    ION_ASSERT_OK(ion_writer_add_annotation_sid(writer, 0));
-    ION_ASSERT_OK(ion_writer_add_annotation_sid(writer, 0));
+    ION_ASSERT_OK(ion_test_writer_add_annotation_sid(writer, 0));
+    ION_ASSERT_OK(ion_test_writer_add_annotation_sid(writer, 0));
     ION_ASSERT_OK(ion_writer_write_symbol(writer, &symbol_zero));
 
     ION_ASSERT_OK(ion_test_writer_get_bytes(writer, ion_stream, &result, &result_len));
@@ -130,19 +130,19 @@ TEST(IonTextSymbol, WriterWritesSymbolFieldNameZero) {
 
     ION_ASSERT_OK(ion_writer_write_field_name(writer, &symbol_zero));
     ION_ASSERT_OK(ion_writer_add_annotation(writer, &symbol_zero));
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 0));
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 0));
 
-    ION_ASSERT_OK(ion_writer_write_field_sid(writer, 0));
+    ION_ASSERT_OK(ion_test_writer_write_field_name_sid(writer, 0));
     ION_ASSERT_OK(ion_writer_add_annotation(writer, &symbol_zero));
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 0));
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 0));
 
     ION_ASSERT_OK(ion_writer_write_field_name(writer, &symbol_zero));
-    ION_ASSERT_OK(ion_writer_add_annotation_sid(writer, 0));
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 0));
+    ION_ASSERT_OK(ion_test_writer_add_annotation_sid(writer, 0));
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 0));
 
-    ION_ASSERT_OK(ion_writer_write_field_sid(writer, 0));
-    ION_ASSERT_OK(ion_writer_add_annotation_sid(writer, 0));
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 0));
+    ION_ASSERT_OK(ion_test_writer_write_field_name_sid(writer, 0));
+    ION_ASSERT_OK(ion_test_writer_add_annotation_sid(writer, 0));
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 0));
 
     ION_ASSERT_OK(ion_writer_finish_container(writer));
     ION_ASSERT_OK(ion_test_writer_get_bytes(writer, ion_stream, &result, &result_len));
@@ -160,13 +160,13 @@ TEST(IonTextSymbol, ReaderReadsSymbolValueSymbolZero) {
 
     ION_ASSERT_OK(ion_reader_next(reader, &type));
     ASSERT_EQ(tid_SYMBOL, type);
-    ION_ASSERT_OK(ion_reader_read_symbol(reader, &symbol_value));
+    ION_ASSERT_OK(ion_reader_read_ion_symbol(reader, &symbol_value));
     ASSERT_TRUE(ION_STRING_IS_NULL(&symbol_value.value));
     ASSERT_EQ(0, symbol_value.sid); // Because it was unquoted, this represents symbol zero.
 
     ION_ASSERT_OK(ion_reader_next(reader, &type));
     ASSERT_EQ(tid_SYMBOL, type);
-    ION_ASSERT_OK(ion_reader_read_symbol(reader, &symbol_value));
+    ION_ASSERT_OK(ion_reader_read_ion_symbol(reader, &symbol_value));
     ASSERT_STREQ("$0", ionStringToString(&symbol_value.value)); // This one just looks like symbol zero, but it's actually a user symbol with the text $0
 
     ION_ASSERT_OK(ion_reader_close(reader));
@@ -177,7 +177,7 @@ TEST(IonTextSymbol, ReaderReadsAnnotationSymbolZero) {
     hREADER reader;
     ION_TYPE type;
     SID symbol_value;
-    SID annotations[1];
+    ION_SYMBOL annotations[1];
     ION_STRING annotation_strs[1];
     SIZE num_annotations;
     ION_SYMBOL symbol;
@@ -189,18 +189,18 @@ TEST(IonTextSymbol, ReaderReadsAnnotationSymbolZero) {
     ION_ASSERT_OK(ion_reader_get_annotations(reader, annotation_strs, 1, &num_annotations));
     ASSERT_EQ(1, num_annotations);
     ASSERT_STREQ("$0", ion_string_strdup(&annotation_strs[0]));
-    ION_ASSERT_OK(ion_reader_read_symbol_sid(reader, &symbol_value));
+    ION_ASSERT_OK(ion_test_reader_read_symbol_sid(reader, &symbol_value));
     ASSERT_EQ(0, symbol_value);
 
     ION_ASSERT_OK(ion_reader_next(reader, &type));
     ASSERT_EQ(tid_SYMBOL, type);
-    ION_ASSERT_OK(ion_reader_get_annotation_sids(reader, annotations, 1, &num_annotations));
+    ION_ASSERT_OK(ion_reader_get_annotation_symbols(reader, annotations, 1, &num_annotations));
     ASSERT_EQ(1, num_annotations);
-    ASSERT_EQ(0, annotations[0]); // Because it was unquoted, this represents symbol zero.
+    ASSERT_EQ(0, annotations[0].sid); // Because it was unquoted, this represents symbol zero.
     ION_ASSERT_OK(ion_reader_get_annotations(reader, annotation_strs, 1, &num_annotations));
     ASSERT_EQ(1, num_annotations);
     ASSERT_TRUE(ION_STRING_IS_NULL(&annotation_strs[0]));
-    ION_ASSERT_OK(ion_reader_read_symbol(reader, &symbol));
+    ION_ASSERT_OK(ion_reader_read_ion_symbol(reader, &symbol));
     ASSERT_STREQ("$0", ionStringToString(&symbol.value)); // This one just looks like symbol zero, but it's actually a user symbol with the text $0
 
     ION_ASSERT_OK(ion_reader_close(reader));
@@ -210,9 +210,10 @@ TEST(IonTextSymbol, ReaderReadsFieldNameSymbolZero) {
     const char *ion_text = "{'$0':'$0'::$0, $0:$0::'$0', $0:'$0'::$0}";
     hREADER reader;
     ION_TYPE type;
-    SID symbol_value, field_name;
+    SID symbol_value;
+    ION_SYMBOL *field_name;
     ION_STRING field_name_str;
-    SID annotation_sids[1];
+    ION_SYMBOL annotation_symbols[1];
     ION_STRING annotations[1];
     SIZE num_annotations;
     ION_STRING symbol_text;
@@ -229,18 +230,18 @@ TEST(IonTextSymbol, ReaderReadsFieldNameSymbolZero) {
     ION_ASSERT_OK(ion_reader_get_annotations(reader, annotations, 1, &num_annotations));
     ASSERT_EQ(1, num_annotations);
     ASSERT_STREQ("$0", ion_string_strdup(&annotations[0]));
-    ION_ASSERT_OK(ion_reader_read_symbol_sid(reader, &symbol_value));
+    ION_ASSERT_OK(ion_test_reader_read_symbol_sid(reader, &symbol_value));
     ASSERT_EQ(0, symbol_value);
 
     ION_ASSERT_OK(ion_reader_next(reader, &type));
     ASSERT_EQ(tid_SYMBOL, type);
-    ION_ASSERT_OK(ion_reader_get_field_sid(reader, &field_name));
-    ASSERT_EQ(0, field_name); // Because it was unquoted, this represents symbol zero.
+    ION_ASSERT_OK(ion_reader_get_field_name_symbol(reader, &field_name));
+    ASSERT_EQ(0, field_name->sid); // Because it was unquoted, this represents symbol zero.
     ION_ASSERT_OK(ion_reader_get_field_name(reader, &field_name_str));
     ASSERT_TRUE(ION_STRING_IS_NULL(&field_name_str));
-    ION_ASSERT_OK(ion_reader_get_annotation_sids(reader, annotation_sids, 1, &num_annotations));
+    ION_ASSERT_OK(ion_reader_get_annotation_symbols(reader, annotation_symbols, 1, &num_annotations));
     ASSERT_EQ(1, num_annotations);
-    ASSERT_EQ(0, annotation_sids[0]);
+    ASSERT_EQ(0, annotation_symbols[0].sid);
     ION_ASSERT_OK(ion_reader_read_string(reader, &symbol_text));
     ASSERT_STREQ("$0", ion_string_strdup(&symbol_text));
 
@@ -248,12 +249,12 @@ TEST(IonTextSymbol, ReaderReadsFieldNameSymbolZero) {
     ASSERT_EQ(tid_SYMBOL, type);
     ION_ASSERT_OK(ion_reader_get_field_name(reader, &field_name_str));
     ASSERT_TRUE(ION_STRING_IS_NULL(&field_name_str));
-    ION_ASSERT_OK(ion_reader_get_field_sid(reader, &field_name));
-    ASSERT_EQ(0, field_name); // Because it was unquoted, this represents symbol zero.
+    ION_ASSERT_OK(ion_reader_get_field_name_symbol(reader, &field_name));
+    ASSERT_EQ(0, field_name->sid); // Because it was unquoted, this represents symbol zero.
     ION_ASSERT_OK(ion_reader_get_annotations(reader, annotations, 1, &num_annotations));
     ASSERT_EQ(1, num_annotations);
     ASSERT_STREQ("$0", ion_string_strdup(&annotations[0]));
-    ION_ASSERT_OK(ion_reader_read_symbol_sid(reader, &symbol_value));
+    ION_ASSERT_OK(ion_test_reader_read_symbol_sid(reader, &symbol_value));
     ASSERT_EQ(0, symbol_value);
 
     ION_ASSERT_OK(ion_reader_step_out(reader));
@@ -321,7 +322,7 @@ TEST(IonTextSymbol, WriterWritesSymbolValueIVMTextAsNoOp) {
     ION_ASSERT_OK(ion_writer_write_int(writer, 123));
     ION_ASSERT_OK(ion_writer_write_symbol(writer, &ivm_text)); // This is a no-op.
     ION_ASSERT_OK(ion_writer_write_int(writer, 456));
-    ION_ASSERT_OK(ion_writer_write_symbol_sid(writer, 2)); // This is a no-op.
+    ION_ASSERT_OK(ion_test_writer_write_symbol_sid(writer, 2)); // This is a no-op.
     ION_ASSERT_OK(ion_writer_write_int(writer, 789));
 
     ION_ASSERT_OK(ion_test_writer_get_bytes(writer, ion_stream, &result, &result_len));
@@ -357,7 +358,7 @@ TEST(IonTextSymbol, ReaderReadsSymbolValueTrueIVM) {
 
     ION_ASSERT_OK(ion_test_new_text_reader(ion_text, &reader));
     ION_ASSERT_OK(ion_reader_next(reader, &type));
-    ASSERT_EQ(IERR_INVALID_SYMBOL, ion_reader_read_symbol_sid(reader, &sid));
+    ASSERT_EQ(IERR_INVALID_SYMBOL, ion_test_reader_read_symbol_sid(reader, &sid));
 
     ION_ASSERT_OK(ion_reader_close(reader));
 }
@@ -368,15 +369,15 @@ TEST(IonTextSymbol, ReaderReadsSymbolValueAnnotatedIVM) {
     const char *ion_text = "$ion_symbol_table::{symbols:[\"foo\"]} annotated::$ion_1_0 $10";
     hREADER reader;
     ION_TYPE type;
-    SID sid;
     SIZE annot_count;
     ION_STRING annot, result;
+    ION_SYMBOL symbol;
 
     ION_ASSERT_OK(ion_test_new_text_reader(ion_text, &reader));
     ION_ASSERT_OK(ion_reader_next(reader, &type));
     ASSERT_EQ(tid_SYMBOL, type);
-    ION_ASSERT_OK(ion_reader_read_symbol_sid(reader, &sid));
-    ASSERT_EQ(2, sid);
+    ION_ASSERT_OK(ion_reader_read_ion_symbol(reader, &symbol));
+    assertStringsEqual("$ion_1_0", (char *)symbol.value.value, symbol.value.length);
     ION_ASSERT_OK(ion_reader_get_annotation_count(reader, &annot_count));
     ASSERT_EQ(1, annot_count);
     ION_ASSERT_OK(ion_reader_get_an_annotation(reader, 0, &annot));
@@ -438,17 +439,18 @@ TEST(IonTextSymbol, ReaderChoosesLowestSIDForDuplicateSymbol) {
     ION_STRING result, *lookup;
     SID sid;
     ION_SYMBOL_TABLE *symbol_table;
+    ION_SYMBOL symbol;
 
     ION_ASSERT_OK(ion_test_new_text_reader(ion_text, &reader));
     ION_ASSERT_OK(ion_reader_next(reader, &type));
     ASSERT_EQ(tid_SYMBOL, type);
-    ION_ASSERT_OK(ion_reader_read_symbol_sid(reader, &sid));
-    ASSERT_EQ(4, sid); // SID 4 maps to "name" in the system symbol table.
+    ION_ASSERT_OK(ion_reader_read_ion_symbol(reader, &symbol));
+    assertStringsEqual("name", (char *)symbol.value.value, symbol.value.length);
     ION_ASSERT_OK(ion_reader_next(reader, &type));
     ASSERT_EQ(tid_SYMBOL, type);
     ION_ASSERT_OK(ion_reader_read_string(reader, &result));
     assertStringsEqual("name", (char *)result.value, result.length);
-    ION_ASSERT_OK(ion_reader_read_symbol_sid(reader, &sid));
+    ION_ASSERT_OK(ion_test_reader_read_symbol_sid(reader, &sid));
     ASSERT_EQ(10, sid); // SID 10 was explicitly declared.
 
     ION_ASSERT_OK(ion_reader_get_symbol_table(reader, &symbol_table));
@@ -509,7 +511,7 @@ TEST(IonTextSymbol, ReaderReadsUndefinedSymbol) {
 
     ION_ASSERT_OK(ion_reader_next(reader, &type));
     ASSERT_EQ(tid_SYMBOL, type);
-    ION_ASSERT_OK(ion_reader_read_symbol_sid(reader, &sid));
+    ION_ASSERT_OK(ion_test_reader_read_symbol_sid(reader, &sid));
     ION_ASSERT_OK(ion_reader_get_symbol_table(reader, &symtab));
     ION_ASSERT_OK(ion_symbol_table_find_by_sid(symtab, sid, &symbol));
     ASSERT_TRUE(ION_STRING_IS_NULL(symbol));
@@ -518,7 +520,7 @@ TEST(IonTextSymbol, ReaderReadsUndefinedSymbol) {
     ASSERT_EQ(tid_SYMBOL, type);
     ION_ASSERT_OK(ion_reader_read_string(reader, symbol));
     assertStringsEqual("rock", (char *)symbol->value, symbol->length);
-    ION_ASSERT_OK(ion_reader_read_symbol_sid(reader, &sid));
+    ION_ASSERT_OK(ion_test_reader_read_symbol_sid(reader, &sid));
     ION_ASSERT_OK(ion_symbol_table_find_by_sid(symtab, sid, &symbol));
     assertStringsEqual("rock", (char *)symbol->value, symbol->length);
 


### PR DESCRIPTION
Such APIs are problematic because the symbol table context of the writer is not guaranteed to be the same as that of the reader; the same local SID can map to different text in both.

APIs which use ION_SYMBOLs, which convey import location, should be used instead.