### PR TITLE
Disable std::tr1 deprecation warning in MSVC for googletest.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,8 @@ if (MSVC)
     # Prevent googletest from linking against different versions of the C Runtime Library on
     # Windows.
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    # Prevent deprecation errors for std::tr1 in googletest
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING")
 else()
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -O0 -Wall")
     set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g -O0 -Wall")


### PR DESCRIPTION
Visual Studio 17, tools update 2 (15.5) makes the use of std::tr1
deprecated and an error at /W3.  This ignores that error and should
be removed once googletest fixes this upstream.

see: https://github.com/google/googletest/issues/1111