### PR TITLE
Adds depth zero and case insensitive matching support.

### DIFF
--- a/ionc/inc/ion_extractor.h
+++ b/ionc/inc/ion_extractor.h
@@ -155,6 +155,13 @@ typedef struct _ion_extractor_options {
      */
     bool match_relative_paths;
 
+    /**
+     * If `true`, the extractor will treat paths as case-insensitive.
+     *
+     * Defaults to `false`.
+     */
+    bool match_case_insensitive;
+
 } ION_EXTRACTOR_OPTIONS;
 
 /**

--- a/ionc/inc/ion_extractor.h
+++ b/ionc/inc/ion_extractor.h
@@ -249,7 +249,8 @@ ION_API_EXPORT iERR ion_extractor_open(hEXTRACTOR *extractor, ION_EXTRACTOR_OPTI
 /**
  * Registers the given callback and user context to a new empty path. To finish constructing the path, the user
  * must append exactly `path_length` components to the resulting path before calling `ion_extractor_match` on this
- * extractor.
+ * extractor. A zero-length path will match every value at the extractor's initial depth (which must be zero unless
+ * `extractor.options.match_relative_paths` is true).
  *
  * NOTE: registering a sub-path of another registered path is not supported. For example, if the path `(foo bar)` is
  * registered to a given extractor, the path `(foo bar 2)` should not be registered to the same extractor.
@@ -304,11 +305,16 @@ ION_API_EXPORT iERR ion_extractor_path_append_wildcard(hPATH path);
 /**
  * Registers a path from text or binary Ion data. The data must contain exactly one top-level value: an ordered sequence
  * (list or sexp) containing a number of elements less than or equal to the extractor's `max_path_length`. The elements
- * must be either text types (string or symbol), representing fields or wildcards, or integers, representing ordinals.
- * In order for a text value to represent a wildcard, it must be equivalent to one of the supported wildcards (currently
- * only `*`). Field elements with the same text as a wildcard must be annotated with the special annotation
+ * (if any) must be either text types (string or symbol), representing fields or wildcards, or integers, representing
+ * ordinals. In order for a text value to represent a wildcard, it must be equivalent to one of the supported wildcards
+ * (currently only `*`). Field elements with the same text as a wildcard must be annotated with the special annotation
  * `$ion_extractor_field` as its first annotation.
  * For example,
+ *  <pre>
+ *    ()
+ *  </pre>
+ * represents a path of length zero, which will match all top-level values when the extractor's initial depth is zero,
+ * while
  *  <pre>
  *    (abc * 2 $ion_extractor_field::*)
  *  </pre>

--- a/ionc/ion_extractor_impl.h
+++ b/ionc/ion_extractor_impl.h
@@ -160,18 +160,18 @@ struct _ion_extractor {
     ION_EXTRACTOR_OPTIONS _options;
 
     /**
-     * The initial depth at which the extractor begins matching. This extractor will finish matching once it has
-     * processed all siblings of the first value encountered at this depth. NOTE: if `options.match_relative_paths` is
-     * `true`, this MUST be zero.
-     */
-    SIZE _initial_depth;
-
-    /**
      * Nonzero if the user has started, but not finished, a path. When nonzero, the user cannot start matching.
      * When bit i is set, the path with _path_id=i is in progress, meaning that its actual length does not match its
      * declared length.
      */
     ION_EXTRACTOR_ACTIVE_PATH_MAP _path_in_progress;
+
+    /**
+     * When bit i is set, the path with _path_id=i has zero length, meaning that it matches every value that is
+     * considered depth zero by the extractor. If `_options.match_relative_paths=false` this must be absolute depth
+     * zero; otherwise, this is the depth at which the reader is positioned at the start of matching.
+     */
+    ION_EXTRACTOR_ACTIVE_PATH_MAP _depth_zero_active_paths;
 
     /**
      * Path components from all registered paths organized by depth. Components at depth 1 begin at index 0, components

--- a/test/test_ion_extractor.cpp
+++ b/test/test_ion_extractor.cpp
@@ -47,6 +47,7 @@
     options.max_path_length = ION_EXTRACTOR_TEST_PATH_LENGTH; \
     options.max_num_paths = ION_EXTRACTOR_TEST_MAX_PATHS; \
     options.match_relative_paths = false; \
+    options.match_case_insensitive = false; \
     ION_EXTRACTOR_TEST_INIT_OPTIONS(options);
 
 /**
@@ -717,6 +718,27 @@ TEST(IonExtractorSucceedsWhen, BothTopLevelWildcardAndLengthOnePathAreRegistered
     ION_EXTRACTOR_TEST_MATCH;
     ION_EXTRACTOR_TEST_ASSERT_MATCHED(0, 1);
     ION_EXTRACTOR_TEST_ASSERT_MATCHED(1, 3);
+}
+
+TEST(IonExtractorSucceedsWhen, CaseInsensitiveMatches) {
+    ION_EXTRACTOR_OPTIONS options;
+    options.max_path_length = ION_EXTRACTOR_TEST_PATH_LENGTH;
+    options.max_num_paths = ION_EXTRACTOR_TEST_MAX_PATHS;
+    options.match_case_insensitive = true;
+    const char *ion_text = "{abc:def, AbC: 123}";
+    ION_EXTRACTOR_TEST_INIT_OPTIONS(options);
+    ION_EXTRACTOR_TEST_PATH_FROM_TEXT("(ABC)", &assertMatchesTextDEForInt123);
+    ION_EXTRACTOR_TEST_MATCH;
+    ION_EXTRACTOR_TEST_ASSERT_MATCHED(0, 2);
+}
+
+
+TEST(IonExtractorSucceedsWhen, CaseSensitiveDoesNotMatch) {
+    ION_EXTRACTOR_TEST_INIT;
+    const char *ion_text = "{abc:def, AbC: 123}";
+    ION_EXTRACTOR_TEST_PATH_FROM_TEXT("(ABC)", &assertPathNeverMatches);
+    ION_EXTRACTOR_TEST_MATCH;
+    ION_EXTRACTOR_TEST_ASSERT_MATCHED(0, 0);
 }
 
 /* -----------------------


### PR DESCRIPTION
Zero-length paths are now allowed, and match any depth zero (absolute or relative) path.

There is now an option to enable case-insensitive path matching. This is disabled by default.