### PR TITLE
Fixes skipping over nested structs with quoted field names.

### DIFF
--- a/ionc/ion_scanner.c
+++ b/ionc/ion_scanner.c
@@ -1351,6 +1351,21 @@ just_another_char: // yes this is evil
                 // do nothing, we've just finished an empty struct
             }
             else {
+                if (c == '"') {
+                    IONCHECK(_ion_scanner_skip_plain_string(scanner))
+                }
+                else if (c == '\'') {
+                    IONCHECK(_ion_scanner_read_char(scanner, &c));
+                    if (c == '\'') {
+                        IONCHECK(_ion_scanner_read_char(scanner, &c));
+                        if (c == '\'') {
+                            IONCHECK(_ion_scanner_skip_one_long_string(scanner));
+                        }
+                    }
+                    else {
+                        IONCHECK(_ion_scanner_skip_single_quoted_string(scanner));
+                    }
+                }
                 IONCHECK(_ion_scanner_skip_container(scanner, '}'));
             }
             break;

--- a/test/test_ion_extractor.cpp
+++ b/test/test_ion_extractor.cpp
@@ -745,8 +745,43 @@ TEST(IonExtractorSucceedsWhen, PathContainsSpace) {
     ION_EXTRACTOR_TEST_INIT;
     const char *ion_text = "{\"foo bar\": 3}";
     ION_EXTRACTOR_TEST_PATH_FROM_TEXT("(\"foo bar\")", &assertMatchesInt3);
+
+
     ION_EXTRACTOR_TEST_MATCH;
     ION_EXTRACTOR_TEST_ASSERT_MATCHED(0, 1);
+}
+
+TEST(IonExtractorSucceedsWhen, SkippingNestedStructs) {
+    // The extractor makes use of skipping, which currently is not well-exercised in other tests. This test was added
+    // to exercise skipping in nested structs, and was added after discovery of a bug involving skipping nested structs
+    // with quoted field names without whitespace between the { and the open-quote.
+    ION_EXTRACTOR_TEST_INIT;
+    const char *ion_text = "{ \"abc\": [ { \"foo\": \"bar\", \"baz\": 1},{\"foo\": \"bar\",\"baz\": 2}, {'''foo''':1, '''bar''':2}, {'':1}, {'foo':1, 'bar': 2}]}";
+
+    ION_EXTRACTOR_TEST_PATH_FROM_TEXT("(Abc Def)", &assertPathNeverMatches);
+
+    ION_EXTRACTOR_TEST_MATCH;
+    ION_EXTRACTOR_TEST_ASSERT_MATCHED(0, 0);
+}
+
+TEST(IonExtractorSucceedsWhen, SkippingNestedLists) {
+    ION_EXTRACTOR_TEST_INIT;
+    const char *ion_text = "{abc: [[[foo, [bar], {baz:zar}]]]}";
+
+    ION_EXTRACTOR_TEST_PATH_FROM_TEXT("(Abc Def)", &assertPathNeverMatches);
+
+    ION_EXTRACTOR_TEST_MATCH;
+    ION_EXTRACTOR_TEST_ASSERT_MATCHED(0, 0);
+}
+
+TEST(IonExtractorSucceedsWhen, SkippingNestedSexps) {
+    ION_EXTRACTOR_TEST_INIT;
+    const char *ion_text = "{abc: (((foo, (bar), {baz:zar})))}";
+
+    ION_EXTRACTOR_TEST_PATH_FROM_TEXT("(Abc Def)", &assertPathNeverMatches);
+
+    ION_EXTRACTOR_TEST_MATCH;
+    ION_EXTRACTOR_TEST_ASSERT_MATCHED(0, 0);
 }
 
 /* -----------------------


### PR DESCRIPTION
The path extractor makes use of skipping, which currently is not well-exercised in tests. This will be addressed in the future through fuzz testing with traversals generated by the ion-test-driver. In the meantime, the extractor tests are a good place to add missing skip coverage.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
