### PR TITLE
Removes inline specifiers for functions used across compilation units; performs both debug and release builds through CI.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,6 +7,7 @@ platform:
 
 configuration:
   - Debug
+  - Release
 
 install:
   - git submodule update --init --recursive

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,10 @@ matrix:
 before_install:
   - eval "${MATRIX_EVAL}"
 
-install: ./build-debug.sh
+install:
+  - ./build-debug.sh
+  - ./build-release.sh
 
-script: ./build/debug/test/all_tests
+script:
+  - ./build/debug/test/all_tests
+  - ./build/release/test/all_tests

--- a/test/gather_vectors.cpp
+++ b/test/gather_vectors.cpp
@@ -67,7 +67,7 @@ static std::string *test_concat_filenames(std::string *dst, int num_components, 
     return dst;
 }
 
-inline std::string join_path(std::string prefix, std::string suffix) {
+std::string join_path(std::string prefix, std::string suffix) {
     std::string path;
     test_concat_filenames(&path, 2, prefix.c_str(), suffix.c_str());
     return path;
@@ -80,7 +80,7 @@ inline BOOL directory_exists(std::string path) {
     return (info.st_mode & S_IFDIR);
 }
 
-inline std::string find_ion_tests_path() {
+std::string find_ion_tests_path() {
     // IDEs typically perform in-source builds, in which case this will be executed directly from either the root or the
     // tests directory. Common out-of-source builds, including those performed by build-release.sh script, will be run
     // from build/release/test. This attempts to locate the ion-tests directory from those locations.


### PR DESCRIPTION
*Issue #, if available:*
#106 

*Description of changes:*
* Removes unnecessary 'inline' specifiers on test utilities that were behaving differently depending on the build configuration.
* Adds Travis and AppVeyor configuration to perform both debug and release builds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
