### PR TITLE
Fixes an array-out-of-bounds bug in ion_extractor_path_create_from_ion.

### DIFF
--- a/ionc/ion_extractor.c
+++ b/ionc/ion_extractor.c
@@ -204,6 +204,8 @@ iERR ion_extractor_path_create_from_ion(ION_EXTRACTOR *extractor, ION_EXTRACTOR_
     ASSERT(callback);
     ASSERT(ion_data_length > 0);
     ASSERT(p_path);
+    ASSERT(extractor->_options.max_path_length <= ION_EXTRACTOR_MAX_PATH_LENGTH);
+    ASSERT(extractor->_options.max_num_paths <= ION_EXTRACTOR_MAX_NUM_PATHS);
 
     field_annotation.value = (BYTE *)ION_EXTRACTOR_FIELD_ANNOTATION;
     field_annotation.length = (int32_t)strlen(ION_EXTRACTOR_FIELD_ANNOTATION);
@@ -220,6 +222,9 @@ iERR ion_extractor_path_create_from_ion(ION_EXTRACTOR *extractor, ION_EXTRACTOR_
     }
     IONCHECK(ion_reader_step_in(reader));
     for (;;) {
+        if (path_length >= extractor->_options.max_path_length) {
+            FAILWITHMSG(IERR_INVALID_ARG, "Exceeded maximum number of path components.");
+        }
         component = &components[path_length];
         IONCHECK(ion_reader_next(reader, &type));
         if (type == tid_EOF) {

--- a/test/test_ion_extractor.cpp
+++ b/test/test_ion_extractor.cpp
@@ -841,6 +841,18 @@ TEST(IonExtractorFailsWhen, PathExceedsMaxLength) {
     ION_ASSERT_OK(ion_extractor_close(extractor));
 }
 
+TEST(IonExtractorFailsWhen, PathFromIonExceedsMaxLength) {
+    hEXTRACTOR extractor;
+    hPATH path;
+    ION_EXTRACTOR_OPTIONS options;
+    options.max_path_length = 1;
+    options.max_num_paths = ION_EXTRACTOR_MAX_NUM_PATHS;
+    const char *ion_text = "(foo bar)"; // Length: 2, max_length: 1.
+    ION_ASSERT_OK(ion_extractor_open(&extractor, &options));
+    ION_ASSERT_FAIL(ion_extractor_path_create_from_ion(extractor, &testCallbackBasic, NULL, (BYTE *)ion_text, (SIZE)strlen(ion_text), &path));
+    ION_ASSERT_OK(ion_extractor_close(extractor));
+}
+
 TEST(IonExtractorFailsWhen, PathIsIncomplete) {
     hEXTRACTOR extractor;
     hPATH path;


### PR DESCRIPTION
*Description of changes:*

When creating a path from Ion data, the length needs to be checked after each path component is iterated to verify that the max length isn't exceeded. Failing to do this can cause the pointer to go past the end of the array when attempting to create a path that exceeds `ION_EXTRACTOR_MAX_PATH_LENGTH` using this function.

Successful AppVeyor build: https://ci.appveyor.com/project/tgregg/ion-c/build/1.0.30

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
