### PR TITLE
Fixes a lexing bug that caused lookahead to fail after a partial keyword match.

### DIFF
--- a/ionc/ion_scanner.c
+++ b/ionc/ion_scanner.c
@@ -956,7 +956,8 @@ iERR _ion_scanner_peek_keyword(ION_SCANNER *scanner, char *tail, BOOL *p_is_matc
     // we're looking for an the "nf" following the "i" and the
     // sign we saw at the beginning of our token
 
-    while ((match_c = *cp++) != '\0') {
+    while ((match_c = *cp) != '\0') {
+        cp++;
         IONCHECK(_ion_scanner_read_char(scanner, &c));
         if (c != match_c) {
             cp--; // we didn't match this char, so we don't unread it (we unread c which we just read)
@@ -967,13 +968,12 @@ iERR _ion_scanner_peek_keyword(ION_SCANNER *scanner, char *tail, BOOL *p_is_matc
     // we may have a match (if we have a terminator next)
     // we'll peek ahead and see if we have that terminator
     IONCHECK(_ion_scanner_read_char(scanner, &c));
-    IONCHECK(_ion_scanner_unread_char(scanner, c));
     IONCHECK(_ion_scanner_is_value_terminator(scanner, c, &is_match));
 
 unread_tail:
+    IONCHECK(_ion_scanner_unread_char(scanner, c));
     if (!is_match) {
-        // no luck so we unread 
-        IONCHECK(_ion_scanner_unread_char(scanner, c));
+        // no luck so we unread
         while (cp > tail) {
             cp--;
             c = *cp;

--- a/test/test_ion_text.cpp
+++ b/test/test_ion_text.cpp
@@ -575,3 +575,23 @@ TEST(IonTextDecimal, FailsEarlyOnInvalidDecimal) {
     ION_ASSERT_FAIL(ion_reader_read_ion_decimal(reader, &decimal));
     ION_ASSERT_OK(ion_reader_close(reader));
 }
+
+TEST(IonTextStruct, AcceptsFieldNameWithKeywordPrefix) {
+    const char *ion_text = "{falsehood: 123}";
+    hREADER  reader;
+    ION_TYPE type;
+    ION_STRING field_name;
+    int value;
+    ION_ASSERT_OK(ion_test_new_text_reader(ion_text, &reader));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_STRUCT, type);
+    ION_ASSERT_OK(ion_reader_step_in(reader));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_INT, type);
+    ION_ASSERT_OK(ion_reader_get_field_name(reader, &field_name));
+    assertStringsEqual("falsehood", (char *)field_name.value, field_name.length);
+    ION_ASSERT_OK(ion_reader_read_int(reader, &value));
+    ASSERT_EQ(123, value);
+    ION_ASSERT_OK(ion_reader_step_out(reader));
+    ION_ASSERT_OK(ion_reader_close(reader));
+}


### PR DESCRIPTION
*Description of changes:*
* Properly un-reads the partial keyword match after a terminator character is not found.
* Updates the ion-tests submodule to a version which includes coverage for this case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
