### PR TITLE
Inverts tid_*_INT and tid_* declarations to enable switch statements on newer C++ compilers.

### DIFF
--- a/ionc/inc/ion_types.h
+++ b/ionc/inc/ion_types.h
@@ -70,44 +70,44 @@ typedef struct ion_type    *ION_TYPE;
 /** Current value type not known (has not been checked)
  *
  */
-#define tid_none      ((ION_TYPE)(-0x200))
+#define tid_none      ((ION_TYPE)(tid_none_INT))
 
 /** Stands for both End of File and End of Container, unfortunately.
  */
-#define tid_EOF       ((ION_TYPE)(-0x100))
+#define tid_EOF       ((ION_TYPE)(tid_EOF_INT))
 
 /** Ion Value Type NULL.*/
-#define tid_NULL         ((ION_TYPE) 0x000)
-#define tid_BOOL         ((ION_TYPE) 0x100)
-#define tid_INT          ((ION_TYPE) 0x200)
-#define tid_FLOAT        ((ION_TYPE) 0x400)
-#define tid_DECIMAL      ((ION_TYPE) 0x500)
-#define tid_TIMESTAMP    ((ION_TYPE) 0x600)
-#define tid_SYMBOL       ((ION_TYPE) 0x700)
-#define tid_STRING       ((ION_TYPE) 0x800)
-#define tid_CLOB         ((ION_TYPE) 0x900)
-#define tid_BLOB         ((ION_TYPE) 0xA00)
-#define tid_LIST         ((ION_TYPE) 0xB00)
-#define tid_SEXP         ((ION_TYPE) 0xC00)
-#define tid_STRUCT       ((ION_TYPE) 0xD00)
-#define tid_DATAGRAM     ((ION_TYPE) 0xF00)
+#define tid_NULL         ((ION_TYPE) tid_NULL_INT)
+#define tid_BOOL         ((ION_TYPE) tid_BOOL_INT)
+#define tid_INT          ((ION_TYPE) tid_INT_INT)
+#define tid_FLOAT        ((ION_TYPE) tid_FLOAT_INT)
+#define tid_DECIMAL      ((ION_TYPE) tid_DECIMAL_INT)
+#define tid_TIMESTAMP    ((ION_TYPE) tid_TIMESTAMP_INT)
+#define tid_SYMBOL       ((ION_TYPE) tid_SYMBOL_INT)
+#define tid_STRING       ((ION_TYPE) tid_STRING_INT)
+#define tid_CLOB         ((ION_TYPE) tid_CLOB_INT)
+#define tid_BLOB         ((ION_TYPE) tid_BLOB_INT)
+#define tid_LIST         ((ION_TYPE) tid_LIST_INT)
+#define tid_SEXP         ((ION_TYPE) tid_SEXP_INT)
+#define tid_STRUCT       ((ION_TYPE) tid_STRUCT_INT)
+#define tid_DATAGRAM     ((ION_TYPE) tid_DATAGRAM_INT)
 
-#define tid_none_INT       ION_TYPE_INT(tid_none)
-#define tid_EOF_INT        ION_TYPE_INT(tid_EOF)
-#define tid_NULL_INT       ION_TYPE_INT(tid_NULL)
-#define tid_BOOL_INT       ION_TYPE_INT(tid_BOOL)
-#define tid_INT_INT        ION_TYPE_INT( tid_INT)
-#define tid_FLOAT_INT      ION_TYPE_INT(tid_FLOAT)
-#define tid_DECIMAL_INT    ION_TYPE_INT(tid_DECIMAL)
-#define tid_TIMESTAMP_INT  ION_TYPE_INT(tid_TIMESTAMP)
-#define tid_SYMBOL_INT     ION_TYPE_INT(tid_SYMBOL)
-#define tid_STRING_INT     ION_TYPE_INT(tid_STRING)
-#define tid_CLOB_INT       ION_TYPE_INT(tid_CLOB)
-#define tid_BLOB_INT       ION_TYPE_INT(tid_BLOB)
-#define tid_STRUCT_INT     ION_TYPE_INT(tid_STRUCT)
-#define tid_LIST_INT       ION_TYPE_INT(tid_LIST)
-#define tid_SEXP_INT       ION_TYPE_INT(tid_SEXP)
-#define tid_DATAGRAM_INT   ION_TYPE_INT(tid_DATAGRAM)
+#define tid_none_INT       -0x200
+#define tid_EOF_INT        -0x100
+#define tid_NULL_INT       0x000
+#define tid_BOOL_INT       0x100
+#define tid_INT_INT        0x200
+#define tid_FLOAT_INT      0x400
+#define tid_DECIMAL_INT    0x500
+#define tid_TIMESTAMP_INT  0x600
+#define tid_SYMBOL_INT     0x700
+#define tid_STRING_INT     0x800
+#define tid_CLOB_INT       0x900
+#define tid_BLOB_INT       0xA00
+#define tid_LIST_INT       0xB00
+#define tid_SEXP_INT       0xC00
+#define tid_STRUCT_INT     0xD00
+#define tid_DATAGRAM_INT   0xF00
 
 typedef int32_t             SID;
 typedef int32_t             SIZE;

--- a/tools/events/ion_event_equivalence.cpp
+++ b/tools/events/ion_event_equivalence.cpp
@@ -55,35 +55,33 @@ BOOL ion_compare_scalars(ION_EVENT_EQUIVALENCE_PARAMS) {
     ION_PREPARE_COMPARISON;
     void *expected_value = ION_EXPECTED_ARG->value;
     void *actual_value = ION_ACTUAL_ARG->value;
-    int tid = ION_TID_INT(ION_EXPECTED_ARG->ion_type);
     ION_EXPECT_FALSE((expected_value == NULL) ^ (actual_value == NULL), "Only one value was null.");
     if (expected_value == NULL) {
         // Equivalence of ion types has already been tested.
         return TRUE;
     }
-    switch (tid) {
-        case TID_BOOL:
+    switch (ION_TYPE_INT(ION_EXPECTED_ARG->ion_type)) {
+        case tid_BOOL_INT:
             ION_EXPECT_BOOL_EQ((BOOL *)expected_value, (BOOL *)actual_value);
             break;
-        case TID_POS_INT:
-        case TID_NEG_INT:
+        case tid_INT_INT:
             ION_EXPECT_INT_EQ((ION_INT *)expected_value, (ION_INT *)actual_value);
             break;
-        case TID_FLOAT:
+        case tid_FLOAT_INT:
             ION_EXPECT_DOUBLE_EQ((double *)expected_value, (double *)actual_value);
             break;
-        case TID_DECIMAL:
+        case tid_DECIMAL_INT:
             ION_EXPECT_DECIMAL_EQ((ION_DECIMAL *)expected_value, (ION_DECIMAL *)actual_value);
             break;
-        case TID_TIMESTAMP:
+        case tid_TIMESTAMP_INT:
             ION_EXPECT_TIMESTAMP_EQ((ION_TIMESTAMP *)expected_value, (ION_TIMESTAMP *)actual_value);
             break;
-        case TID_SYMBOL:
+        case tid_SYMBOL_INT:
             ION_EXPECT_SYMBOL_EQ((ION_SYMBOL *)expected_value, (ION_SYMBOL *)actual_value);
             break;
-        case TID_STRING:
-        case TID_CLOB:
-        case TID_BLOB: // Clobs and blobs are stored in ION_STRINGs too...
+        case tid_STRING_INT:
+        case tid_BLOB_INT:
+        case tid_CLOB_INT: // Clobs and blobs are stored in ION_STRINGs too...
             ION_EXPECT_STRING_EQ((ION_STRING *)expected_value, (ION_STRING *)actual_value);
             break;
         default:
@@ -188,7 +186,6 @@ BOOL ion_compare_sequences(ION_EVENT_EQUIVALENCE_PARAMS) {
  */
 BOOL ion_compare_events(ION_EVENT_EQUIVALENCE_PARAMS) {
     ION_PREPARE_COMPARISON;
-    int tid = ION_TID_INT(ION_EXPECTED_ARG->ion_type);
     ION_EXPECT_EVENT_TYPE_EQ(ION_EXPECTED_ARG->event_type, ION_ACTUAL_ARG->event_type);
     ION_EXPECT_EQ(ION_EXPECTED_ARG->ion_type, ION_ACTUAL_ARG->ion_type, "Ion types did not match.");
     ION_EXPECT_EQ(ION_EXPECTED_ARG->depth, ION_ACTUAL_ARG->depth, "Depths did not match.");
@@ -203,12 +200,12 @@ BOOL ion_compare_events(ION_EVENT_EQUIVALENCE_PARAMS) {
         case CONTAINER_END:
             break;
         case CONTAINER_START:
-            switch (tid) {
-                case TID_STRUCT:
+            switch (ION_TYPE_INT(ION_EXPECTED_ARG->ion_type)) {
+                case tid_STRUCT_INT:
                     ION_CHECK_ASSERTION(ion_compare_structs(ION_EVENT_EQUIVALENCE_ARGS));
                     break;
-                case TID_SEXP: // intentional fall-through
-                case TID_LIST:
+                case tid_SEXP_INT: // intentional fall-through
+                case tid_LIST_INT:
                     ION_CHECK_ASSERTION(ion_compare_sequences(ION_EVENT_EQUIVALENCE_ARGS));
                     break;
                 default:

--- a/tools/events/ion_event_util.cpp
+++ b/tools/events/ion_event_util.cpp
@@ -58,21 +58,20 @@ ION_EVENT_TYPE ion_event_type_from_string(ION_STRING *type_str) {
 }
 
 ION_STRING *ion_event_ion_type_to_string(ION_TYPE type) {
-    switch (ION_TID_INT(type)) {
-        case TID_NULL: return &ion_event_ion_type_null;
-        case TID_BOOL: return &ion_event_ion_type_bool;
-        case TID_POS_INT:
-        case TID_NEG_INT: return &ion_event_ion_type_int;
-        case TID_FLOAT: return &ion_event_ion_type_float;
-        case TID_DECIMAL: return &ion_event_ion_type_decimal;
-        case TID_TIMESTAMP: return &ion_event_ion_type_timestamp;
-        case TID_SYMBOL: return &ion_event_ion_type_symbol;
-        case TID_STRING: return &ion_event_ion_type_string;
-        case TID_BLOB: return &ion_event_ion_type_blob;
-        case TID_CLOB: return &ion_event_ion_type_clob;
-        case TID_LIST: return &ion_event_ion_type_list;
-        case TID_SEXP: return &ion_event_ion_type_sexp;
-        case TID_STRUCT: return &ion_event_ion_type_struct;
+    switch (ION_TYPE_INT(type)) {
+        case tid_NULL_INT: return &ion_event_ion_type_null;
+        case tid_BOOL_INT: return &ion_event_ion_type_bool;
+        case tid_INT_INT: return &ion_event_ion_type_int;
+        case tid_FLOAT_INT: return &ion_event_ion_type_float;
+        case tid_DECIMAL_INT: return &ion_event_ion_type_decimal;
+        case tid_TIMESTAMP_INT: return &ion_event_ion_type_timestamp;
+        case tid_SYMBOL_INT: return &ion_event_ion_type_symbol;
+        case tid_STRING_INT: return &ion_event_ion_type_string;
+        case tid_BLOB_INT: return &ion_event_ion_type_blob;
+        case tid_CLOB_INT: return &ion_event_ion_type_clob;
+        case tid_LIST_INT: return &ion_event_ion_type_list;
+        case tid_SEXP_INT: return &ion_event_ion_type_sexp;
+        case tid_STRUCT_INT: return &ion_event_ion_type_struct;
         default: return NULL;
     }
 }

--- a/tools/events/ion_event_util.h
+++ b/tools/events/ion_event_util.h
@@ -18,11 +18,6 @@
 #include "ion.h"
 #include "ion_event_stream.h"
 
-/**
- * Converts an ION_TYPE to a switchable int representing the given type's ID.
- */
-#define ION_TID_INT(type) (int)(ION_TYPE_INT(type) >> 8)
-
 // The following limits are arbitrarily high.
 #define ION_EVENT_CONTAINER_DEPTH_MAX 100
 #define ION_EVENT_ANNOTATION_MAX 100


### PR DESCRIPTION
*Description of changes:*
Many C++ compilers don't allow casts to pointers in switch blocks, causing failures on macros like tid_INT_INT. [This](https://github.com/amzn/ion-c/commit/f6811b256465cca8572bc37b7f923762e0cabe66) commit shows where this change was necessary in the ion-c tests, which require a C++ compiler. This change makes the new macros available publicly and uses them within the tools and test modules.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
