### PR TITLE
(Docs) autogenerate documentation and deploy to gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,9 @@ matrix:
           packages:
             - gcc-4.9
             - g++-4.9 # docopt uses <regex>, which requires 4.9+
+            - doxygen
       env:
-         - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+         - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9" DOCS="true"
     - os: linux
       addons:
         apt:
@@ -40,3 +41,18 @@ install:
 script:
   - ./build/debug/test/all_tests
   - ./build/release/test/all_tests
+
+after_success: |   
+    if [ "$DOCS" = "true" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
+      doxygen ./Doxyfile
+    fi 
+
+deploy: 
+  provider: pages
+  local-dir: "./docs/html/"
+  skip-cleanup: true
+  github-token: "$GITHUB_TOKEN"
+  keep-history: true # keeps commit history of gh-pages branch
+  on:
+     branch: master
+     condition: $DOCS = true

--- a/Doxyfile
+++ b/Doxyfile
@@ -771,7 +771,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ionc
+INPUT                  = ionc/inc/
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Auto-generates and deploys documentation to gh-pages. 
Steps are attached to the first entry in the build matrix. Not ideal but could not get Travis stages to work with matrix.include. 

For sample see (https://therapon.github.io/ion-c/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
