### PR TITLE
Fixes a bug that allowed a struct to have a field name without an associated value.

### DIFF
--- a/ionc/ion_reader_text.c
+++ b/ionc/ion_reader_text.c
@@ -255,6 +255,15 @@ iERR _ion_reader_text_next(ION_READER *preader, ION_TYPE *p_value_type)
         text->_state = IPS_ERROR;
         FAILWITH(IERR_INVALID_STATE);
     }
+
+    if (text->_state == IPS_BEFORE_FIELDNAME
+        && ist == IST_CLOSE_SINGLE_BRACE
+        && !ION_SYMBOL_IS_NULL(&text->_field_name)
+        && ION_STRING_IS_NULL(&text->_scanner._value_image)
+    ) {
+        // There is a field name with no associated value.
+        FAILWITH(IERR_INVALID_SYNTAX);
+    }
     
     // we're after the uta's and have recognized the value
     // it's ready for the caller - save off the state we'll

--- a/test/test_ion_text.cpp
+++ b/test/test_ion_text.cpp
@@ -595,3 +595,26 @@ TEST(IonTextStruct, AcceptsFieldNameWithKeywordPrefix) {
     ION_ASSERT_OK(ion_reader_step_out(reader));
     ION_ASSERT_OK(ion_reader_close(reader));
 }
+
+TEST(IonTextStruct, FailsOnFieldNameWithNoValueAtStructEnd) {
+    const char *ion_text = "{a: }";
+    hREADER  reader;
+    ION_TYPE type;
+    ION_ASSERT_OK(ion_test_new_text_reader(ion_text, &reader));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_STRUCT, type);
+    ION_ASSERT_OK(ion_reader_step_in(reader));
+    ASSERT_EQ(IERR_INVALID_SYNTAX, ion_reader_next(reader, &type));
+}
+
+TEST(IonTextStruct, FailsOnFieldNameWithNoValueInMiddle) {
+    const char *ion_text = "{a: 123, b:, c:456}";
+    hREADER  reader;
+    ION_TYPE type;
+    ION_ASSERT_OK(ion_test_new_text_reader(ion_text, &reader));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_STRUCT, type);
+    ION_ASSERT_OK(ion_reader_step_in(reader));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(IERR_INVALID_SYNTAX, ion_reader_next(reader, &type));
+}


### PR DESCRIPTION
*Description of changes:*
Struct field names must have an associated value. This change updates the ion-tests submodule, which now contains a file to exercise this case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
