### PR TITLE
(Docs) Add link to api documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ A C implementation of the [Ion data notation](http://amzn.github.io/ion-docs).
 
 [![Build Status](https://travis-ci.org/amzn/ion-c.svg?branch=master)](https://travis-ci.org/amzn/ion-c)
 [![Build status](https://ci.appveyor.com/api/projects/status/x6xfom3x3hs3y945/branch/master?svg=true)](https://ci.appveyor.com/project/tgregg/ion-c-3akm7/branch/master)
+<a title="docs" href="https://amzn.github.io/ion-c"><img src="https://img.shields.io/badge/docs-api-green.svg"/></a>
 
 ## Setup
 This repository contains a [git submodule](https://git-scm.com/docs/git-submodule)


### PR DESCRIPTION
Add link to Ion C API documentation in README.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
