### PR TITLE
Fixes a bug that prevented the CLI from emitting reports for the non-equivs comparison type.

### DIFF
--- a/test/test_ion_cli.cpp
+++ b/test/test_ion_cli.cpp
@@ -169,12 +169,36 @@ TEST(IonCli, CompareListsEquivs) {
     ASSERT_FALSE(report.hasComparisonFailures());
 }
 
+TEST(IonCli, CompareNonEquivalentIntsAsEquivs) {
+    std::string test_file = join_path(full_good_nonequivs_path, "ints.ion");
+    IonEventReport report;
+    test_ion_cli_assert_comparison(&test_file, 1, COMPARISON_TYPE_EQUIVS, &report);
+    ASSERT_FALSE(report.hasErrors());
+    ASSERT_TRUE(report.hasComparisonFailures());
+    std::vector<IonEventComparisonResult> *comparison_results = report.getComparisonResults();
+    ASSERT_EQ(1, comparison_results->size());
+    test_ion_cli_assert_comparison_result_equals(&comparison_results->at(0), COMPARISON_RESULT_NOT_EQUAL, test_file,
+                                                 test_file, 1, 2);
+}
+
 TEST(IonCli, CompareSexpsNonequivs) {
     std::string test_file = join_path(full_good_nonequivs_path, "sexps.ion");
     IonEventReport report;
     test_ion_cli_assert_comparison(&test_file, 1, COMPARISON_TYPE_NONEQUIVS, &report);
     ASSERT_FALSE(report.hasErrors());
     ASSERT_FALSE(report.hasComparisonFailures());
+}
+
+TEST(IonCli, CompareEquivalentIntsAsNonequivs) {
+    std::string test_file = join_path(full_good_equivs_path, "ints.ion");
+    IonEventReport report;
+    test_ion_cli_assert_comparison(&test_file, 1, COMPARISON_TYPE_NONEQUIVS, &report);
+    ASSERT_FALSE(report.hasErrors());
+    ASSERT_TRUE(report.hasComparisonFailures());
+    std::vector<IonEventComparisonResult> *comparison_results = report.getComparisonResults();
+    ASSERT_EQ(1, comparison_results->size());
+    test_ion_cli_assert_comparison_result_equals(&comparison_results->at(0), COMPARISON_RESULT_EQUAL, test_file,
+                                                 test_file, 1, 2);
 }
 
 TEST(IonCli, CompareAnnotatedIvmsEmbeddedNonequivs) {

--- a/tools/events/ion_event_equivalence.cpp
+++ b/tools/events/ion_event_equivalence.cpp
@@ -29,8 +29,12 @@ void _ion_event_set_comparison_result(IonEventResult *result, ION_EVENT_COMPARIS
                                       IonEvent *rhs, size_t lhs_index, size_t rhs_index, std::string lhs_location,
                                       std::string rhs_location, std::string message) {
     if (result != NULL) {
+        if (result->comparison_result.lhs.event != NULL) {
+            // A pair of offending events has already been specified in the result. Only set the first pair.
+            return;
+        }
         if (ion_event_copy(&result->comparison_result.lhs.event, lhs, &lhs_location, result)
-            || ion_event_copy(&result->comparison_result.rhs.event, rhs, &lhs_location, result)) {
+            || ion_event_copy(&result->comparison_result.rhs.event, rhs, &rhs_location, result)) {
             return;
         }
         result->comparison_result.lhs.event_index = lhs_index;
@@ -260,9 +264,6 @@ BOOL ion_compare_sets_nonequivs(ION_EVENT_EQUIVALENCE_PARAMS) {
     // The corresponding indices are assumed to be equivalent.
     if (ION_INDEX_EXPECTED_ARG != ION_INDEX_ACTUAL_ARG) {
         ION_PREPARE_COMPARISON;
-        // Since inequality is expected here, passing a NULL result here prevents the comparison report from being
-        // polluted. If the events are equal, a comparison result stating such will be added to the report.
-        ION_RESULT_ARG = NULL;
         ION_EXPECT_FALSE(ion_compare_events(ION_EVENT_EQUIVALENCE_ARGS), "Equivalent values in a non-equivs set.");
     }
     ION_PASS_ASSERTIONS;


### PR DESCRIPTION
*Description of changes:*
Previously, the CLI would not emit a comparison report for the non-equivs comparison type, even for equivalent values.

Note: this does not affect the non-equivs tests in `test_vectors.cpp`, as those have always relied upon the return value of the comparison method, which was correct.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
