### PR TITLE
Fixes handling of timezone offsets in ion_timestamp_to_time_t

### DIFF
--- a/ionc/ion_timestamp.c
+++ b/ionc/ion_timestamp.c
@@ -96,7 +96,7 @@ iERR ion_timestamp_to_time_t(const ION_TIMESTAMP *ptime, time_t *time)
 #endif
 
     if (HAS_TZ_OFFSET(ptime)) {
-        tm.tm_min += (ptime->tz_offset);
+        tm.tm_min -= (ptime->tz_offset);
     }
 
 #ifndef ION_PLATFORM_WINDOWS

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(all_tests
     test_ion_decimal.cpp
     test_ion_symbol.cpp
     test_ion_text.cpp
+    test_ion_timestamp.cpp
     test_ion_values.cpp
     test_ion_extractor.cpp
     test_ion_cli.cpp

--- a/test/test_ion_timestamp.cpp
+++ b/test/test_ion_timestamp.cpp
@@ -13,70 +13,69 @@
  * permissions and limitations under the License.
  */
 
+#include <tuple>
 #include "ion_assert.h"
 #include "ion_helpers.h"
 #include "ion_event_util.h"
 #include "ion_test_util.h"
 #include "ion_event_equivalence.h"
 
-struct timestamp_test {
-    const char *str;
+class IonTimestamp : public ::testing::TestWithParam< ::testing::tuple<std::string, int, time_t, std::string> > {
+public:
+    std::string str;
     int local_offset;
     time_t time;
-    const char *str_unknown_offset;
+    std::string str_unknown_offset;
+
+    virtual void SetUp() {
+        str = ::testing::get<0>(GetParam());
+        local_offset = ::testing::get<1>(GetParam());
+        time = ::testing::get<2>(GetParam());
+        str_unknown_offset = ::testing::get<3>(GetParam());
+    }
 };
 
-const int num_tests = 3;
-struct timestamp_test tests[num_tests] = {
-        {"2020-07-01T14:24:57-01:00", -60, 1593617097, "2020-07-01T15:24:57-00:00"},
-        {"2020-07-01T14:24:57+00:00",   0, 1593613497, "2020-07-01T14:24:57-00:00"},
-        {"2020-07-01T14:24:57+01:00",  60, 1593609897, "2020-07-01T13:24:57-00:00"},
-};
+INSTANTIATE_TEST_CASE_P(IonTimestamp, IonTimestamp, testing::Values(
+        std::tr1::make_tuple(std::string("2020-07-01T14:24:57-01:00"), -60, 1593617097, std::string("2020-07-01T15:24:57-00:00")),
+        std::tr1::make_tuple(std::string("2020-07-01T14:24:57+00:00"),   0, 1593613497, std::string("2020-07-01T14:24:57-00:00")),
+        std::tr1::make_tuple(std::string("2020-07-01T14:24:57+01:00"),  60, 1593609897, std::string("2020-07-01T13:24:57-00:00"))
+));
 
 // regression for https://github.com/amzn/ion-c/issues/144
-TEST(IonTimestamp, ion_timestamp_to_time_t) {
-    struct timestamp_test *test = tests;
-    for (int i = 0; i < num_tests; i++, test++ ) {
-        ION_TIMESTAMP timestamp;
-        SIZE chars_used;
-        time_t time;
+TEST_P(IonTimestamp, ion_timestamp_to_time_t) {
+    ION_TIMESTAMP timestamp;
+    SIZE chars_used;
+    time_t actual_time;
 
-        ION_ASSERT_OK(ion_timestamp_parse(&timestamp, (char *)test->str, (SIZE)strlen(test->str), &chars_used, &g_IonEventDecimalContext));
-        ION_ASSERT_OK(ion_timestamp_to_time_t(&timestamp, &time));
-        ASSERT_EQ(test->time, time);
-    }
+    ION_ASSERT_OK(ion_timestamp_parse(&timestamp, (char *)str.c_str(), (SIZE)strlen(str.c_str()), &chars_used, &g_IonEventDecimalContext));
+    ION_ASSERT_OK(ion_timestamp_to_time_t(&timestamp, &actual_time));
+    ASSERT_EQ(time, actual_time);
 }
 
-TEST(IonTimestamp, ion_timestamp_for_time_t) {
-    struct timestamp_test *test = tests;
-    for (int i = 0; i < num_tests; i++, test++ ) {
-        ION_TIMESTAMP timestamp;
-        SIZE chars_used;
+TEST_P(IonTimestamp, ion_timestamp_for_time_t) {
+    ION_TIMESTAMP timestamp;
+    SIZE chars_used;
 
-        ION_ASSERT_OK(ion_timestamp_for_time_t(&timestamp, &test->time));
-        char str_unknown_offset[ION_TIMESTAMP_STRING_LENGTH+1];
-        ION_ASSERT_OK(ion_timestamp_to_string(&timestamp, str_unknown_offset, (SIZE)sizeof(str_unknown_offset), &chars_used, &g_IonEventDecimalContext));
-        str_unknown_offset[chars_used] = '\0';
+    ION_ASSERT_OK(ion_timestamp_for_time_t(&timestamp, &time));
+    char to_string[ION_TIMESTAMP_STRING_LENGTH+1];
+    ION_ASSERT_OK(ion_timestamp_to_string(&timestamp, (char *)to_string, (SIZE)sizeof(to_string), &chars_used, &g_IonEventDecimalContext));
+    to_string[chars_used] = '\0';
 
-        ASSERT_STREQ(test->str_unknown_offset, str_unknown_offset);
-    }
+    ASSERT_STREQ(str_unknown_offset.c_str(), to_string);
 }
 
-TEST(IonTimestamp, has_and_get_local_offset) {
-    struct timestamp_test *test = tests;
-    for (int i = 0; i < num_tests; i++, test++ ) {
-        ION_TIMESTAMP timestamp;
-        SIZE chars_used;
-        int local_offset;
-        BOOL has_local_offset;
+TEST_P(IonTimestamp, has_and_get_local_offset) {
+    ION_TIMESTAMP timestamp;
+    SIZE chars_used;
+    int offset;
+    BOOL has_local_offset;
 
-        ION_ASSERT_OK(ion_timestamp_parse(&timestamp, (char *)test->str, (SIZE)strlen(test->str), &chars_used, &g_IonEventDecimalContext));
-        ION_ASSERT_OK(ion_timestamp_has_local_offset(&timestamp, &has_local_offset));
-        ASSERT_TRUE(has_local_offset);
+    ION_ASSERT_OK(ion_timestamp_parse(&timestamp, (char *)str.c_str(), (SIZE)strlen(str.c_str()), &chars_used, &g_IonEventDecimalContext));
+    ION_ASSERT_OK(ion_timestamp_has_local_offset(&timestamp, &has_local_offset));
+    ASSERT_TRUE(has_local_offset);
 
-        ION_ASSERT_OK(ion_timestamp_get_local_offset(&timestamp, &local_offset));
-        ASSERT_EQ(test->local_offset, local_offset);
-    }
+    ION_ASSERT_OK(ion_timestamp_get_local_offset(&timestamp, &offset));
+    ASSERT_EQ(local_offset, offset);
 }
 
 TEST(IonTimestamp, IgnoresSuperfluousOffset) {

--- a/test/test_ion_timestamp.cpp
+++ b/test/test_ion_timestamp.cpp
@@ -13,7 +13,6 @@
  * permissions and limitations under the License.
  */
 
-#include <err.h>
 #include "ion_assert.h"
 #include "ion_helpers.h"
 #include "ion_event_util.h"

--- a/test/test_ion_timestamp.cpp
+++ b/test/test_ion_timestamp.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2009 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <err.h>
+#include "ion_assert.h"
+#include "ion_helpers.h"
+#include "ion_event_util.h"
+#include "ion_test_util.h"
+#include "ion_event_equivalence.h"
+
+struct timestamp_test {
+    const char *str;
+    int local_offset;
+    time_t time;
+    const char *str_unknown_offset;
+};
+
+const int num_tests = 3;
+struct timestamp_test tests[num_tests] = {
+        {"2020-07-01T14:24:57-01:00", -60, 1593617097, "2020-07-01T15:24:57-00:00"},
+        {"2020-07-01T14:24:57+00:00",   0, 1593613497, "2020-07-01T14:24:57-00:00"},
+        {"2020-07-01T14:24:57+01:00",  60, 1593609897, "2020-07-01T13:24:57-00:00"},
+};
+
+// regression for https://github.com/amzn/ion-c/issues/144
+TEST(IonTimestamp, ion_timestamp_to_time_t) {
+    struct timestamp_test *test = tests;
+    for (int i = 0; i < num_tests; i++, test++ ) {
+        ION_TIMESTAMP timestamp;
+        SIZE chars_used;
+        time_t time;
+
+        ION_ASSERT_OK(ion_timestamp_parse(&timestamp, (char *)test->str, (SIZE)strlen(test->str), &chars_used, &g_IonEventDecimalContext));
+        ION_ASSERT_OK(ion_timestamp_to_time_t(&timestamp, &time));
+        ASSERT_EQ(test->time, time);
+    }
+}
+
+TEST(IonTimestamp, ion_timestamp_for_time_t) {
+    struct timestamp_test *test = tests;
+    for (int i = 0; i < num_tests; i++, test++ ) {
+        ION_TIMESTAMP timestamp;
+        SIZE chars_used;
+
+        ION_ASSERT_OK(ion_timestamp_for_time_t(&timestamp, &test->time));
+        char str_unknown_offset[ION_TIMESTAMP_STRING_LENGTH+1];
+        ION_ASSERT_OK(ion_timestamp_to_string(&timestamp, str_unknown_offset, (SIZE)sizeof(str_unknown_offset), &chars_used, &g_IonEventDecimalContext));
+        str_unknown_offset[chars_used] = '\0';
+
+        ASSERT_STREQ(test->str_unknown_offset, str_unknown_offset);
+    }
+}
+
+TEST(IonTimestamp, has_and_get_local_offset) {
+    struct timestamp_test *test = tests;
+    for (int i = 0; i < num_tests; i++, test++ ) {
+        ION_TIMESTAMP timestamp;
+        SIZE chars_used;
+        int local_offset;
+        BOOL has_local_offset;
+
+        ION_ASSERT_OK(ion_timestamp_parse(&timestamp, (char *)test->str, (SIZE)strlen(test->str), &chars_used, &g_IonEventDecimalContext));
+        ION_ASSERT_OK(ion_timestamp_has_local_offset(&timestamp, &has_local_offset));
+        ASSERT_TRUE(has_local_offset);
+
+        ION_ASSERT_OK(ion_timestamp_get_local_offset(&timestamp, &local_offset));
+        ASSERT_EQ(test->local_offset, local_offset);
+    }
+}
+
+TEST(IonTimestamp, IgnoresSuperfluousOffset) {
+    ION_TIMESTAMP expected1, expected2, actual;
+    BOOL has_local_offset;
+    int local_offset;
+
+    ION_ASSERT_OK(ion_timestamp_for_year(&expected1, 1));
+
+    ION_ASSERT_OK(ion_timestamp_for_year(&expected2, 1));
+    SET_FLAG_ON(expected2.precision, ION_TT_BIT_TZ);
+    expected2.tz_offset = 1;
+
+    ION_ASSERT_OK(ion_timestamp_for_year(&actual, 1));
+    ION_ASSERT_OK(ion_timestamp_set_local_offset(&actual, 1));
+    ION_ASSERT_OK(ion_timestamp_has_local_offset(&actual, &has_local_offset));
+    ION_ASSERT_OK(ion_timestamp_get_local_offset(&actual, &local_offset));
+
+    ASSERT_FALSE(has_local_offset);
+    ASSERT_EQ(0, actual.tz_offset);
+    ASSERT_EQ(0, local_offset);
+    ASSERT_TRUE(ion_equals_timestamp(&expected1, &actual));
+    ASSERT_TRUE(ion_equals_timestamp(&expected2, &actual)); // Equivalence ignores the superfluous offset as well.
+}
+

--- a/test/test_ion_timestamp.cpp
+++ b/test/test_ion_timestamp.cpp
@@ -33,29 +33,13 @@ public:
         time = testing::get<2>(GetParam());
         str_unknown_offset = testing::get<3>(GetParam());
     }
-
-    struct PrintToStringParamName
-    {
-        template <class ParamType>
-        std::string operator()( const testing::TestParamInfo<ParamType>& info ) const
-        {
-            testing::tuple<std::string, int, time_t, std::string> test
-                    = static_cast< testing::tuple<std::string, int, time_t, std::string> >(info.param);
-            std::string s = testing::get<0>(test);
-            std::replace(s.begin(), s.end(), '-', '_');
-            std::replace(s.begin(), s.end(), ':', '_');
-            std::replace(s.begin(), s.end(), '+', 'p');
-            return s;
-        }
-    };
 };
 
 INSTANTIATE_TEST_CASE_P(IonTimestampParameterized, IonTimestamp, testing::Values(
         std::tr1::make_tuple(std::string("2020-07-01T14:24:57-01:00"), -60, 1593617097, std::string("2020-07-01T15:24:57-00:00")),
         std::tr1::make_tuple(std::string("2020-07-01T14:24:57+00:00"),   0, 1593613497, std::string("2020-07-01T14:24:57-00:00")),
-        std::tr1::make_tuple(std::string("2020-07-01T14:24:57+01:00"),  60, 1593609897, std::string("2020-07-01T13:24:57-00:00"))),
-    IonTimestamp::PrintToStringParamName()
-);
+        std::tr1::make_tuple(std::string("2020-07-01T14:24:57+01:00"),  60, 1593609897, std::string("2020-07-01T13:24:57-00:00"))
+));
 
 // regression for https://github.com/amzn/ion-c/issues/144
 TEST_P(IonTimestamp, ion_timestamp_to_time_t) {

--- a/test/test_ion_timestamp.cpp
+++ b/test/test_ion_timestamp.cpp
@@ -20,7 +20,7 @@
 #include "ion_test_util.h"
 #include "ion_event_equivalence.h"
 
-class IonTimestamp : public ::testing::TestWithParam< ::testing::tuple<std::string, int, time_t, std::string> > {
+class IonTimestamp : public testing::TestWithParam< testing::tuple<std::string, int, time_t, std::string> > {
 public:
     std::string str;
     int local_offset;
@@ -28,18 +28,34 @@ public:
     std::string str_unknown_offset;
 
     virtual void SetUp() {
-        str = ::testing::get<0>(GetParam());
-        local_offset = ::testing::get<1>(GetParam());
-        time = ::testing::get<2>(GetParam());
-        str_unknown_offset = ::testing::get<3>(GetParam());
+        str = testing::get<0>(GetParam());
+        local_offset = testing::get<1>(GetParam());
+        time = testing::get<2>(GetParam());
+        str_unknown_offset = testing::get<3>(GetParam());
     }
+
+    struct PrintToStringParamName
+    {
+        template <class ParamType>
+        std::string operator()( const testing::TestParamInfo<ParamType>& info ) const
+        {
+            testing::tuple<std::string, int, time_t, std::string> test
+                    = static_cast< testing::tuple<std::string, int, time_t, std::string> >(info.param);
+            std::string s = testing::get<0>(test);
+            std::replace(s.begin(), s.end(), '-', '_');
+            std::replace(s.begin(), s.end(), ':', '_');
+            std::replace(s.begin(), s.end(), '+', 'p');
+            return s;
+        }
+    };
 };
 
-INSTANTIATE_TEST_CASE_P(IonTimestamp, IonTimestamp, testing::Values(
+INSTANTIATE_TEST_CASE_P(IonTimestampParameterized, IonTimestamp, testing::Values(
         std::tr1::make_tuple(std::string("2020-07-01T14:24:57-01:00"), -60, 1593617097, std::string("2020-07-01T15:24:57-00:00")),
         std::tr1::make_tuple(std::string("2020-07-01T14:24:57+00:00"),   0, 1593613497, std::string("2020-07-01T14:24:57-00:00")),
-        std::tr1::make_tuple(std::string("2020-07-01T14:24:57+01:00"),  60, 1593609897, std::string("2020-07-01T13:24:57-00:00"))
-));
+        std::tr1::make_tuple(std::string("2020-07-01T14:24:57+01:00"),  60, 1593609897, std::string("2020-07-01T13:24:57-00:00"))),
+    IonTimestamp::PrintToStringParamName()
+);
 
 // regression for https://github.com/amzn/ion-c/issues/144
 TEST_P(IonTimestamp, ion_timestamp_to_time_t) {

--- a/test/test_ion_timestamp.cpp
+++ b/test/test_ion_timestamp.cpp
@@ -13,7 +13,6 @@
  * permissions and limitations under the License.
  */
 
-#include <tuple>
 #include "ion_assert.h"
 #include "ion_helpers.h"
 #include "ion_event_util.h"

--- a/test/test_ion_values.cpp
+++ b/test/test_ion_values.cpp
@@ -17,29 +17,6 @@
 #include "ion_test_util.h"
 #include "ion_event_equivalence.h"
 
-TEST(IonTimestamp, IgnoresSuperfluousOffset) {
-    ION_TIMESTAMP expected1, expected2, actual;
-    BOOL has_local_offset;
-    int local_offset;
-
-    ION_ASSERT_OK(ion_timestamp_for_year(&expected1, 1));
-
-    ION_ASSERT_OK(ion_timestamp_for_year(&expected2, 1));
-    SET_FLAG_ON(expected2.precision, ION_TT_BIT_TZ);
-    expected2.tz_offset = 1;
-
-    ION_ASSERT_OK(ion_timestamp_for_year(&actual, 1));
-    ION_ASSERT_OK(ion_timestamp_set_local_offset(&actual, 1));
-    ION_ASSERT_OK(ion_timestamp_has_local_offset(&actual, &has_local_offset));
-    ION_ASSERT_OK(ion_timestamp_get_local_offset(&actual, &local_offset));
-
-    ASSERT_FALSE(has_local_offset);
-    ASSERT_EQ(0, actual.tz_offset);
-    ASSERT_EQ(0, local_offset);
-    ASSERT_TRUE(ion_equals_timestamp(&expected1, &actual));
-    ASSERT_TRUE(ion_equals_timestamp(&expected2, &actual)); // Equivalence ignores the superfluous offset as well.
-}
-
 iERR test_stream_handler(struct _ion_user_stream *pstream) {
     iENTER;
     _ion_user_stream *next_stream = (_ion_user_stream *)pstream->handler_state;


### PR DESCRIPTION
Resolves #144 

Also adds some unit tests for ion_timestamp.c, and moves the existing `IgnoresSuperfluousOffset` test to be with its new siblings in test_ion_timestamp.cpp.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
