### PR TITLE
Adds basic test coverage for ion_reader_seek and fixes bugs to allow these tests to pass.

### DIFF
--- a/ionc/include/ionc/ion_reader.h
+++ b/ionc/include/ionc/ion_reader.h
@@ -274,12 +274,12 @@ ION_API_EXPORT iERR ion_reader_get_catalog             (hREADER hreader, hCATALO
 
 /** moves the stream position to the specified offset. Resets the 
  *  the state of the reader to be at the top level. As long as the
- *  specified position is at the first byte of a value (just before 
- *  the type description byte) this will work neatly. If the seek
- *  is into the middle of a value (including a collection) the
+ *  specified position is at the first byte of a top-level value
+ *  (just before the type description byte) this will work neatly.
+ *  Do not attempt to seek to a value below the top level, as the
  *  view of the data is likely to be invalid.
  *
- *  if a length is specified (default is -1 or no limit) eof will
+ *  If a length is specified (default is -1 or no limit) eof will
  *  be returned when length bytes are consumed.
  *
  *  A common pattern when using this interface would be to open
@@ -310,7 +310,14 @@ ION_API_EXPORT iERR ion_reader_get_value_offset    (hREADER   hreader
  *  positioned on.  This length is appropriate to use later
  *  when calling ion_reader_seek to limit "over-reading" in
  *  the underlying stream which could result in errors that
- *  are not really of intereest.
+ *  are not really of interest. NOTE: readers of text data
+ *  will always set *p_length to -1 because text Ion data is
+ *  not length-prefixed. When the reader may be reading text
+ *  Ion data, the correct way to calculate a value's length
+ *  is by subtracting the current value's offset (see
+ *  `ion_reader_get_value_offset`) from the next value's
+ *  offset. This technique will work for both binary and text
+ *  Ion data.
  */
 ION_API_EXPORT iERR ion_reader_get_value_length    (hREADER  hreader
                                                    ,SIZE   *p_length);

--- a/ionc/ion_reader.c
+++ b/ionc/ion_reader.c
@@ -111,7 +111,7 @@ iERR ion_reader_reset_stream_with_length(hREADER   *p_hreader
             IONCHECK(_ion_reader_text_open(*p_hreader));
             break;
         case ion_type_binary_reader:
-            IONCHECK(_ion_reader_binary_reset((*p_hreader), TID_DATAGRAM, local_end));
+            IONCHECK(_ion_reader_binary_reset((*p_hreader), tid_DATAGRAM, 0, local_end));
             break;
         case ion_type_unknown_reader:
         default:
@@ -2020,7 +2020,8 @@ iERR ion_reader_seek(hREADER hreader, POSITION offset, SIZE length)
         local_end = offset + length;
     }
     else {
-        local_end = -1;
+        // This causes the reader to return EOF only when the stream runs out of data.
+        local_end = ION_STREAM_MAX_LENGTH;
     }
 
     // here we reset what little state the reader need to address directly
@@ -2034,7 +2035,7 @@ iERR ion_reader_seek(hREADER hreader, POSITION offset, SIZE length)
         IONCHECK(_ion_reader_text_reset(preader, tid_DATAGRAM, local_end));
         break;
     case ion_type_binary_reader:
-        IONCHECK(_ion_reader_text_reset(preader, tid_DATAGRAM, local_end));
+        IONCHECK(_ion_reader_binary_reset(preader, tid_DATAGRAM, offset, local_end));
         break;
     case ion_type_unknown_reader:
     default:

--- a/ionc/ion_reader_impl.h
+++ b/ionc/ion_reader_impl.h
@@ -268,7 +268,7 @@ iERR _ion_reader_get_position_helper(ION_READER *preader, int64_t *p_bytes, int3
 // binary reader routines
 //
 iERR _ion_reader_binary_open                (ION_READER *preader);
-iERR _ion_reader_binary_reset               (ION_READER *preader, int parent_tid, POSITION local_end);
+iERR _ion_reader_binary_reset               (ION_READER *preader, ION_TYPE parent_tid, POSITION value_start, POSITION local_end);
 
 iERR _ion_reader_binary_next                (ION_READER *preader, ION_TYPE *p_value_type);
 iERR _ion_reader_binary_get_local_symbol_table_helper(ION_READER *preader, ION_SYMBOL_TABLE **pplocal );

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(all_tests
     test_ion_extractor.cpp
     test_ion_cli.cpp
     test_ion_stream.cpp
+    test_ion_reader_seek.cpp
 )
 
 add_subdirectory(googletest)

--- a/test/test_ion_reader_seek.cpp
+++ b/test/test_ion_reader_seek.cpp
@@ -1,0 +1,519 @@
+/*
+ * Copyright 2009 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "ion_event_util.h"
+#include <ionc/ion_types.h>
+#include <ionc/ion_stream.h>
+#include <ionc/ion_collection.h>
+#include "ion_index.h"
+#include "ion_stream_impl.h"
+#include <ionc/ion.h>
+#include "ion_helpers.h"
+#include "ion_test_util.h"
+#include "ion_assert.h"
+
+
+class TextAndBinary : public ::testing::TestWithParam<bool> {
+    virtual void SetUp() {
+        is_binary = GetParam();
+    }
+public:
+    BOOL is_binary;
+};
+
+
+INSTANTIATE_TEST_CASE_P(IonReaderSeek, TextAndBinary, ::testing::Bool());
+
+
+TEST_P(TextAndBinary, SeekToTopLevelScalar) {
+    hWRITER writer = NULL;
+    hREADER reader = NULL;
+    ION_TYPE type;
+    ION_STREAM *ion_stream = NULL;
+    ION_STRING abc_written, def_written, abc_read, def_read;
+    int32_t int_written = 123, int_read;
+    BYTE *data;
+    SIZE data_length;
+    POSITION abc_value_position, def_value_position;
+
+    ion_string_from_cstr("abc", &abc_written);
+    ion_string_from_cstr("def", &def_written);
+    ION_ASSERT_OK(ion_test_new_writer(&writer, &ion_stream, is_binary));
+    ION_ASSERT_OK(ion_writer_write_int32(writer, int_written));
+    ION_ASSERT_OK(ion_writer_write_symbol(writer, &abc_written));
+    ION_ASSERT_OK(ion_writer_write_string(writer, &def_written));
+    ION_ASSERT_OK(ion_test_writer_get_bytes(writer, ion_stream, &data, &data_length));
+
+    ION_ASSERT_OK(ion_test_new_reader(data, data_length, &reader));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    // Record the desired value's position so it make be seeked to later.
+    ION_ASSERT_OK(ion_reader_get_value_offset(reader, &abc_value_position));
+    // Skip to the next value.
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    // Seek back to the desired value without specifying an end.
+    ION_ASSERT_OK(ion_reader_seek(reader, abc_value_position, -1));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_SYMBOL, type);
+    ION_ASSERT_OK(ion_reader_read_string(reader, &abc_read));
+    assertStringsEqual((char *)abc_written.value, (char *)abc_read.value, abc_written.length);
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_STRING, type);
+    ION_ASSERT_OK(ion_reader_read_string(reader, &def_read));
+    assertStringsEqual((char *)def_written.value, (char *)def_read.value, def_written.length);
+    ION_ASSERT_OK(ion_reader_get_value_offset(reader, &def_value_position));
+    ION_ASSERT_OK(ion_reader_seek(reader, 0, -1));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_INT, type);
+    ION_ASSERT_OK(ion_reader_read_int32(reader, &int_read));
+    ASSERT_EQ(int_written, int_read);
+    ION_ASSERT_OK(ion_reader_seek(reader, def_value_position, -1));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_STRING, type);
+    ION_ASSERT_OK(ion_reader_read_string(reader, &def_read));
+    assertStringsEqual((char *)def_written.value, (char *)def_read.value, def_written.length);
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_EOF, type);
+    ION_ASSERT_OK(ion_reader_close(reader));
+
+    free(data);
+}
+
+
+TEST_P(TextAndBinary, SeekToTopLevelAnnotatedScalar) {
+    hWRITER writer = NULL;
+    hREADER reader = NULL;
+    ION_TYPE type;
+    ION_STREAM *ion_stream = NULL;
+    ION_STRING abc_written, def_written, abc_read, def_read;
+    ION_STRING annotation_written, annotation_read_on_123, annotation_read_on_abc, annotation_read_on_def;
+    int32_t int_written = 123, int_read;
+    BYTE *data;
+    SIZE data_length;
+    POSITION abc_value_position, def_value_position;
+
+    ion_string_from_cstr("abc", &abc_written);
+    ion_string_from_cstr("def", &def_written);
+    ion_string_from_cstr("str", &annotation_written);
+    ION_ASSERT_OK(ion_test_new_writer(&writer, &ion_stream, is_binary));
+    ION_ASSERT_OK(ion_writer_add_annotation(writer, &annotation_written));
+    ION_ASSERT_OK(ion_writer_write_int32(writer, int_written));
+    ION_ASSERT_OK(ion_writer_add_annotation(writer, &annotation_written));
+    ION_ASSERT_OK(ion_writer_write_symbol(writer, &abc_written));
+    ION_ASSERT_OK(ion_writer_add_annotation(writer, &annotation_written));
+    ION_ASSERT_OK(ion_writer_write_string(writer, &def_written));
+    ION_ASSERT_OK(ion_test_writer_get_bytes(writer, ion_stream, &data, &data_length));
+
+    ION_ASSERT_OK(ion_test_new_reader(data, data_length, &reader));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    // Record the desired value's position so it make be seeked to later.
+    ION_ASSERT_OK(ion_reader_get_value_offset(reader, &abc_value_position));
+    // Skip to the next value.
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    // Seek back to the desired value without specifying an end.
+    ION_ASSERT_OK(ion_reader_seek(reader, abc_value_position, -1));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_SYMBOL, type);
+    ION_ASSERT_OK(ion_reader_read_string(reader, &abc_read));
+    assertStringsEqual((char *)abc_written.value, (char *)abc_read.value, abc_written.length);
+    ION_ASSERT_OK(ion_reader_get_an_annotation(reader, 0, &annotation_read_on_abc));
+    assertStringsEqual((char *)annotation_written.value, (char *)annotation_read_on_abc.value, annotation_written.length);
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_STRING, type);
+    ION_ASSERT_OK(ion_reader_read_string(reader, &def_read));
+    assertStringsEqual((char *)def_written.value, (char *)def_read.value, def_written.length);
+    ION_ASSERT_OK(ion_reader_get_value_offset(reader, &def_value_position));
+    ION_ASSERT_OK(ion_reader_seek(reader, 0, -1));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_INT, type);
+    ION_ASSERT_OK(ion_reader_read_int32(reader, &int_read));
+    ASSERT_EQ(int_written, int_read);
+    ION_ASSERT_OK(ion_reader_get_an_annotation(reader, 0, &annotation_read_on_123));
+    assertStringsEqual((char *)annotation_written.value, (char *)annotation_read_on_123.value, annotation_written.length);
+    ION_ASSERT_OK(ion_reader_seek(reader, def_value_position, -1));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_STRING, type);
+    ION_ASSERT_OK(ion_reader_get_an_annotation(reader, 0, &annotation_read_on_def));
+    assertStringsEqual((char *)annotation_written.value, (char *)annotation_read_on_def.value, annotation_written.length);
+    ION_ASSERT_OK(ion_reader_read_string(reader, &def_read));
+    assertStringsEqual((char *)def_written.value, (char *)def_read.value, def_written.length);
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_EOF, type);
+    ION_ASSERT_OK(ion_reader_close(reader));
+
+    free(data);
+}
+
+TEST_P(TextAndBinary, SeekToTopLevelContainer) {
+    hWRITER writer = NULL;
+    hREADER reader = NULL;
+    ION_TYPE type;
+    ION_STREAM *ion_stream = NULL;
+    ION_STRING abc_written, def_written, abc_read, def_read;
+    int32_t int_written = 123, int_read;
+    double float_written = 0., float_read;
+    BYTE *data;
+    SIZE data_length;
+    POSITION first_struct_position, second_struct_position;
+    BOOL is_in_struct;
+
+    ion_string_from_cstr("abc", &abc_written);
+    ion_string_from_cstr("def", &def_written);
+    ION_ASSERT_OK(ion_test_new_writer(&writer, &ion_stream, is_binary));
+    ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
+    ION_ASSERT_OK(ion_writer_write_field_name(writer, &abc_written));
+    ION_ASSERT_OK(ion_writer_write_int32(writer, int_written));
+    ION_ASSERT_OK(ion_writer_finish_container(writer));
+    ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
+    ION_ASSERT_OK(ion_writer_write_field_name(writer, &def_written));
+    ION_ASSERT_OK(ion_writer_write_double(writer, float_written));
+    ION_ASSERT_OK(ion_writer_finish_container(writer));
+    ION_ASSERT_OK(ion_test_writer_get_bytes(writer, ion_stream, &data, &data_length));
+
+    ION_ASSERT_OK(ion_test_new_reader(data, data_length, &reader));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ION_ASSERT_OK(ion_reader_get_value_offset(reader, &first_struct_position));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ION_ASSERT_OK(ion_reader_get_value_offset(reader, &second_struct_position));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_EOF, type);
+
+    ION_ASSERT_OK(ion_reader_seek(reader, first_struct_position, -1));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_STRUCT, type);
+    ION_ASSERT_OK(ion_reader_step_in(reader));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_INT, type);
+    ION_ASSERT_OK(ion_reader_get_field_name(reader, &abc_read));
+    assertStringsEqual((char *)abc_written.value, (char *)abc_read.value, abc_written.length);
+    ION_ASSERT_OK(ion_reader_read_int32(reader, &int_read));
+    ASSERT_EQ(int_written, int_read);
+    ION_ASSERT_OK(ion_reader_is_in_struct(reader, &is_in_struct));
+    ASSERT_TRUE(is_in_struct);
+    // Seek without stepping out.
+    ION_ASSERT_OK(ion_reader_seek(reader, second_struct_position, -1));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_STRUCT, type);
+    ION_ASSERT_OK(ion_reader_step_in(reader));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_FLOAT, type);
+    ION_ASSERT_OK(ion_reader_get_field_name(reader, &def_read));
+    assertStringsEqual((char *)def_written.value, (char *)def_read.value, def_written.length);
+    ION_ASSERT_OK(ion_reader_read_double(reader, &float_read));
+    ASSERT_EQ(float_written, float_read);
+    ION_ASSERT_OK(ion_reader_is_in_struct(reader, &is_in_struct));
+    ASSERT_TRUE(is_in_struct);
+    ION_ASSERT_OK(ion_reader_step_out(reader));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_EOF, type);
+    ION_ASSERT_OK(ion_reader_close(reader));
+
+    free(data);
+}
+
+TEST_P(TextAndBinary, SeekToTopLevelAnnotatedContainer) {
+    hWRITER writer = NULL;
+    hREADER reader = NULL;
+    ION_TYPE type;
+    ION_STREAM *ion_stream = NULL;
+    ION_STRING abc_written, def_written, abc_read, def_read;
+    ION_STRING annotation_written, annotation_read_on_first_struct, annotation_read_on_second_struct;
+    int32_t int_written = 123, int_read;
+    double float_written = 0., float_read;
+    BYTE *data;
+    SIZE data_length;
+    POSITION first_struct_position, second_struct_position;
+    BOOL is_in_struct;
+
+    ion_string_from_cstr("abc", &abc_written);
+    ion_string_from_cstr("def", &def_written);
+    ion_string_from_cstr("str", &annotation_written);
+    ION_ASSERT_OK(ion_test_new_writer(&writer, &ion_stream, is_binary));
+    ION_ASSERT_OK(ion_writer_add_annotation(writer, &annotation_written));
+    ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
+    ION_ASSERT_OK(ion_writer_write_field_name(writer, &abc_written));
+    ION_ASSERT_OK(ion_writer_write_int32(writer, int_written));
+    ION_ASSERT_OK(ion_writer_finish_container(writer));
+    ION_ASSERT_OK(ion_writer_add_annotation(writer, &annotation_written));
+    ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
+    ION_ASSERT_OK(ion_writer_write_field_name(writer, &def_written));
+    ION_ASSERT_OK(ion_writer_write_double(writer, float_written));
+    ION_ASSERT_OK(ion_writer_finish_container(writer));
+    ION_ASSERT_OK(ion_test_writer_get_bytes(writer, ion_stream, &data, &data_length));
+
+    ION_ASSERT_OK(ion_test_new_reader(data, data_length, &reader));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ION_ASSERT_OK(ion_reader_get_value_offset(reader, &first_struct_position));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ION_ASSERT_OK(ion_reader_get_value_offset(reader, &second_struct_position));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_EOF, type);
+
+    ION_ASSERT_OK(ion_reader_seek(reader, first_struct_position, -1));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ION_ASSERT_OK(ion_reader_get_an_annotation(reader, 0, &annotation_read_on_first_struct));
+    assertStringsEqual((char *)annotation_written.value, (char *)annotation_read_on_first_struct.value, annotation_written.length);
+    ASSERT_EQ(tid_STRUCT, type);
+    ION_ASSERT_OK(ion_reader_step_in(reader));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_INT, type);
+    ION_ASSERT_OK(ion_reader_get_field_name(reader, &abc_read));
+    assertStringsEqual((char *)abc_written.value, (char *)abc_read.value, abc_written.length);
+    ION_ASSERT_OK(ion_reader_read_int32(reader, &int_read));
+    ASSERT_EQ(int_written, int_read);
+    ION_ASSERT_OK(ion_reader_is_in_struct(reader, &is_in_struct));
+    ASSERT_TRUE(is_in_struct);
+    // Seek without stepping out.
+    ION_ASSERT_OK(ion_reader_seek(reader, second_struct_position, -1));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ION_ASSERT_OK(ion_reader_get_an_annotation(reader, 0, &annotation_read_on_second_struct));
+    assertStringsEqual((char *)annotation_written.value, (char *)annotation_read_on_second_struct.value, annotation_written.length);
+    ASSERT_EQ(tid_STRUCT, type);
+    ION_ASSERT_OK(ion_reader_step_in(reader));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_FLOAT, type);
+    ION_ASSERT_OK(ion_reader_get_field_name(reader, &def_read));
+    assertStringsEqual((char *)def_written.value, (char *)def_read.value, def_written.length);
+    ION_ASSERT_OK(ion_reader_read_double(reader, &float_read));
+    ASSERT_EQ(float_written, float_read);
+    ION_ASSERT_OK(ion_reader_is_in_struct(reader, &is_in_struct));
+    ASSERT_TRUE(is_in_struct);
+    ION_ASSERT_OK(ion_reader_step_out(reader));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_EOF, type);
+    ION_ASSERT_OK(ion_reader_close(reader));
+
+    free(data);
+}
+
+TEST_P(TextAndBinary, SeekAcrossSymbolTableBoundary) {
+    hWRITER writer = NULL;
+    hREADER reader = NULL;
+    ION_TYPE type;
+    ION_STREAM *ion_stream = NULL;
+    ION_STRING abc_written, def_written, abc_read, def_read;
+    int32_t int_written = 123, int_read;
+    BYTE *data;
+    SIZE data_length;
+    POSITION abc_value_position, def_value_position;
+    ION_SYMBOL_TABLE *abc_table, *def_table, *abc_table_clone, *def_table_clone;
+
+    ion_string_from_cstr("abc", &abc_written);
+    ion_string_from_cstr("def", &def_written);
+    ION_ASSERT_OK(ion_test_new_writer(&writer, &ion_stream, is_binary));
+    ION_ASSERT_OK(ion_writer_write_int32(writer, int_written));
+    ION_ASSERT_OK(ion_writer_write_symbol(writer, &abc_written));
+    // Forces a symbol table boundary.
+    ION_ASSERT_OK(ion_writer_finish(writer, NULL));
+    ION_ASSERT_OK(ion_writer_write_symbol(writer, &def_written));
+    ION_ASSERT_OK(ion_test_writer_get_bytes(writer, ion_stream, &data, &data_length));
+
+    ION_ASSERT_OK(ion_test_new_reader(data, data_length, &reader));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    // Record the desired value's position so it make be seeked to later.
+    ION_ASSERT_OK(ion_reader_get_value_offset(reader, &abc_value_position));
+    ION_ASSERT_OK(ion_reader_get_symbol_table(reader, &abc_table));
+    ION_ASSERT_OK(ion_symbol_table_clone_with_owner(abc_table, &abc_table_clone, reader));
+    // Skip to the next value.
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    // Seek back to the desired value without specifying an end.
+    ION_ASSERT_OK(ion_reader_seek(reader, abc_value_position, -1));
+    ION_ASSERT_OK(ion_reader_set_symbol_table(reader, abc_table_clone));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_SYMBOL, type);
+    ION_ASSERT_OK(ion_reader_read_string(reader, &abc_read));
+    assertStringsEqual((char *)abc_written.value, (char *)abc_read.value, abc_written.length);
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_SYMBOL, type);
+    ION_ASSERT_OK(ion_reader_read_string(reader, &def_read));
+    assertStringsEqual((char *)def_written.value, (char *)def_read.value, def_written.length);
+    ION_ASSERT_OK(ion_reader_get_value_offset(reader, &def_value_position));
+    ION_ASSERT_OK(ion_reader_get_symbol_table(reader, &def_table));
+    ION_ASSERT_OK(ion_symbol_table_clone_with_owner(def_table, &def_table_clone, reader));
+    ION_ASSERT_OK(ion_reader_seek(reader, 0, -1));
+    // This int value doesn't require a symbol table.
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_INT, type);
+    ION_ASSERT_OK(ion_reader_read_int32(reader, &int_read));
+    ASSERT_EQ(int_written, int_read);
+    ION_ASSERT_OK(ion_reader_seek(reader, def_value_position, -1));
+    ION_ASSERT_OK(ion_reader_set_symbol_table(reader, def_table_clone));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_SYMBOL, type);
+    ION_ASSERT_OK(ion_reader_read_string(reader, &def_read));
+    assertStringsEqual((char *)def_written.value, (char *)def_read.value, def_written.length);
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_EOF, type);
+    ION_ASSERT_OK(ion_reader_close(reader));
+
+    free(data);
+}
+
+TEST_P(TextAndBinary, SeekWithLimitsUsingGetValueLength) {
+    if (!is_binary) {
+        // TODO this test is skipped for text because the text reader does not currently provide a useful value
+        // from ion_reader_get_value_length. Text readers always provide -1 from this method, which imposes no
+        // limit on the amount of data consumed after ion_reader_seek.
+        return;
+    }
+    hWRITER writer = NULL;
+    hREADER reader = NULL;
+    ION_TYPE type;
+    ION_STREAM *ion_stream = NULL;
+    ION_STRING abc_written, abc_read;
+    ION_STRING annotation_written, annotation_read_on_abc;
+    int32_t int_written = 123, int_read;
+    BYTE *data;
+    SIZE data_length;
+    POSITION int_value_position, list_value_position, abc_value_position;
+    SIZE int_value_length, list_value_length, abc_value_length;
+
+    ion_string_from_cstr("abc", &abc_written);
+    ion_string_from_cstr("str", &annotation_written);
+    ION_ASSERT_OK(ion_test_new_writer(&writer, &ion_stream, is_binary));
+    ION_ASSERT_OK(ion_writer_write_int32(writer, int_written));
+    ION_ASSERT_OK(ion_writer_start_container(writer, tid_LIST));
+    ION_ASSERT_OK(ion_writer_write_int32(writer, 12345678));
+    ION_ASSERT_OK(ion_writer_finish_container(writer));
+    ION_ASSERT_OK(ion_writer_add_annotation(writer, &annotation_written));
+    ION_ASSERT_OK(ion_writer_write_string(writer, &abc_written));
+    ION_ASSERT_OK(ion_test_writer_get_bytes(writer, ion_stream, &data, &data_length));
+
+    ION_ASSERT_OK(ion_test_new_reader(data, data_length, &reader));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ION_ASSERT_OK(ion_reader_get_value_offset(reader, &int_value_position));
+    ION_ASSERT_OK(ion_reader_get_value_length(reader, &int_value_length));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ION_ASSERT_OK(ion_reader_get_value_offset(reader, &list_value_position));
+    ION_ASSERT_OK(ion_reader_get_value_length(reader, &list_value_length));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ION_ASSERT_OK(ion_reader_get_value_offset(reader, &abc_value_position));
+    ION_ASSERT_OK(ion_reader_get_value_length(reader, &abc_value_length));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_EOF, type);
+
+    ION_ASSERT_OK(ion_reader_seek(reader, list_value_position, list_value_length));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_LIST, type);
+    ION_ASSERT_OK(ion_reader_step_in(reader));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_INT, type);
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_EOF, type);
+    ION_ASSERT_OK(ion_reader_step_out(reader));
+    // The limit has been reached.
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_EOF, type);
+
+    ION_ASSERT_OK(ion_reader_seek(reader, int_value_position, int_value_length));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_INT, type);
+    ION_ASSERT_OK(ion_reader_read_int32(reader, &int_read));
+    ASSERT_EQ(int_written, int_read);
+    // The limit has been reached.
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_EOF, type);
+
+    ION_ASSERT_OK(ion_reader_seek(reader, abc_value_position, abc_value_length));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_STRING, type);
+    ION_ASSERT_OK(ion_reader_get_an_annotation(reader, 0, &annotation_read_on_abc));
+    assertStringsEqual((char *)annotation_written.value, (char *)annotation_read_on_abc.value, annotation_written.length);
+    ION_ASSERT_OK(ion_reader_read_string(reader, &abc_read));
+    assertStringsEqual((char *)abc_written.value, (char *)abc_read.value, abc_written.length);
+    // The limit has been reached.
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_EOF, type);
+    ION_ASSERT_OK(ion_reader_close(reader));
+
+    free(data);
+}
+
+TEST_P(TextAndBinary, SeekWithLimitsUsingLengthCalculatedFromPosition) {
+    hWRITER writer = NULL;
+    hREADER reader = NULL;
+    ION_TYPE type;
+    ION_STREAM *ion_stream = NULL;
+    ION_STRING abc_written, abc_read;
+    ION_STRING annotation_written, annotation_read_on_abc;
+    int32_t int_written = 123, int_read;
+    BYTE *data;
+    SIZE data_length;
+    POSITION int_value_position, list_value_position, abc_value_position, end_position;
+    SIZE int_value_length, list_value_length, abc_value_length;
+
+    ion_string_from_cstr("abc", &abc_written);
+    ion_string_from_cstr("str", &annotation_written);
+    ION_ASSERT_OK(ion_test_new_writer(&writer, &ion_stream, is_binary));
+    ION_ASSERT_OK(ion_writer_write_int32(writer, int_written));
+    ION_ASSERT_OK(ion_writer_start_container(writer, tid_LIST));
+    ION_ASSERT_OK(ion_writer_write_int32(writer, 12345678));
+    ION_ASSERT_OK(ion_writer_finish_container(writer));
+    ION_ASSERT_OK(ion_writer_add_annotation(writer, &annotation_written));
+    ION_ASSERT_OK(ion_writer_write_string(writer, &abc_written));
+    ION_ASSERT_OK(ion_test_writer_get_bytes(writer, ion_stream, &data, &data_length));
+
+    ION_ASSERT_OK(ion_test_new_reader(data, data_length, &reader));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ION_ASSERT_OK(ion_reader_get_value_offset(reader, &int_value_position));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ION_ASSERT_OK(ion_reader_get_value_offset(reader, &list_value_position));
+    int_value_length = list_value_position - int_value_position;
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ION_ASSERT_OK(ion_reader_get_value_offset(reader, &abc_value_position));
+    list_value_length = abc_value_position - list_value_position;
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ION_ASSERT_OK(ion_reader_get_value_offset(reader, &end_position));
+    abc_value_length = end_position - abc_value_position;
+    ASSERT_EQ(tid_EOF, type);
+
+    ION_ASSERT_OK(ion_reader_seek(reader, list_value_position, list_value_length));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_LIST, type);
+    ION_ASSERT_OK(ion_reader_step_in(reader));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_INT, type);
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_EOF, type);
+    ION_ASSERT_OK(ion_reader_step_out(reader));
+    // The limit has been reached.
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_EOF, type);
+
+    ION_ASSERT_OK(ion_reader_seek(reader, int_value_position, int_value_length));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_INT, type);
+    ION_ASSERT_OK(ion_reader_read_int32(reader, &int_read));
+    ASSERT_EQ(int_written, int_read);
+    // The limit has been reached.
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_EOF, type);
+
+    ION_ASSERT_OK(ion_reader_seek(reader, abc_value_position, abc_value_length));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_STRING, type);
+    ION_ASSERT_OK(ion_reader_get_an_annotation(reader, 0, &annotation_read_on_abc));
+    assertStringsEqual((char *)annotation_written.value, (char *)annotation_read_on_abc.value, annotation_written.length);
+    ION_ASSERT_OK(ion_reader_read_string(reader, &abc_read));
+    assertStringsEqual((char *)abc_written.value, (char *)abc_read.value, abc_written.length);
+    // The limit has been reached.
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_EOF, type);
+    ION_ASSERT_OK(ion_reader_close(reader));
+
+    free(data);
+}


### PR DESCRIPTION
*Issue #, if available:*
#138 

*Description of changes:*
`ion_reader_seek` now has some tests, parameterized for both binary and text Ion. This uncovered a few bugs that are fixed as part of this PR. The inline comments should explain most of the fixes; please comment if anything is unclear.

I've opened a couple of issues to track improvements that could be made that I've left outside the scope of this PR:
#148 
#149 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
