### PR TITLE
Fixes a bug that caused long strings to fail to concatenate when components were separated by comments.

### DIFF
--- a/ionc/ion_scanner.h
+++ b/ionc/ion_scanner.h
@@ -449,7 +449,7 @@ iERR _ion_scanner_encode_utf8_char                  (ION_SCANNER *scanner, int c
 
 iERR _ion_scanner_read_escaped_char                 (ION_SCANNER *scanner, ION_SUB_TYPE ist, int *p_char);
 iERR _ion_scanner_read_hex_escape_value             (ION_SCANNER *scanner, int hex_len, int *p_hexchar);
-iERR _ion_scanner_peek_for_next_triple_quote        (ION_SCANNER *scanner, BOOL *p_triple_quote_found);
+iERR _ion_scanner_peek_for_next_triple_quote        (ION_SCANNER *scanner, BOOL is_clob, BOOL *p_triple_quote_found);
 iERR _ion_scanner_read_lob_closing_braces           (ION_SCANNER *scanner);
 
 iERR _ion_scanner_read_as_base64                    (ION_SCANNER *scanner, BYTE *buf, SIZE len, SIZE *p_bytes_written, BOOL *p_eos_encountered);


### PR DESCRIPTION
*Issue #, if available:*
Fixes #147 

*Description of changes:*
Previously, clob whitespace-skipping logic was used between all triple-quoted string literals. Because clobs do not allow comments, this logic did not skip comments. This change makes clobs use the existing path, while regular strings will use the comment-skipping path.

*Testing:*
A good/equivs test has been added to ion-tests [here](https://github.com/amzn/ion-tests/pull/53). This change passes the tests with the new file. I will update ion-c's submodule to the latest ion-tests revision in a separate PR once the ion-tests PR is merged.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
