### PR TITLE
Correctly interprets newline characters within text clob literals.

### DIFF
--- a/ionc/ion_scanner.c
+++ b/ionc/ion_scanner.c
@@ -1624,6 +1624,11 @@ iERR _ion_scanner_read_as_string_to_quote(ION_SCANNER *scanner, BYTE *buf, SIZE 
             if (c > 0xFF) {
                 FAILWITHMSG(IERR_INVALID_TOKEN_CHAR, "Illegal character in clob.");
             }
+            if (c == NEW_LINE_1) {
+                // Note: all newlines were previously normalized to NEW_LINE_1. However, NEW_LINE_1 is a sentinel
+                // value; the LF character is what actually needs to be pushed.
+                c = '\n';
+            }
             PUSH_VALUE_BYTE(c);
         }
         else {


### PR DESCRIPTION
*Issue #, if available:*
Fixes #146 

*Description of changes:*
Fixes a bug that caused the text reader to return a bogus byte instead of a line feed character inside of clob literals.

*Testing:*
A good/equivs test has been added to ion-tests [here](https://github.com/amzn/ion-tests/pull/54). This change passes the tests with the new file. I will update ion-c's submodule to the latest ion-tests revision in a separate PR once the ion-tests PR is merged.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
