### PR TITLE
Updates ion-tests and fixes a bug that prevented the text writer from writing timestamps with high-precision fractional seconds.

### DIFF
--- a/ionc/ion_timestamp_impl.h
+++ b/ionc/ion_timestamp_impl.h
@@ -101,6 +101,15 @@ iERR ion_timestamp_instant_equals(const ION_TIMESTAMP *ptime1, const ION_TIMESTA
  */
 iERR _ion_timestamp_to_utc(const ION_TIMESTAMP *ptime, ION_TIMESTAMP *pout);
 
+/**
+ * Validates that the given fraction is at least zero is less than one.
+ * @param p_fraction the fraction to validate.
+ * @param pcontext the decContext to use for the comparison.
+ * @param error_code the error code to return if validation fails.
+ * @return IERR_OK, unless p_fraction is out of range.
+ */
+iERR _ion_timestamp_validate_fraction(decQuad *p_fraction, decContext *pcontext, iERR error_code);
+
 #ifdef __cplusplus
 }
 #endif

--- a/ionc/ion_writer_binary.c
+++ b/ionc/ion_writer_binary.c
@@ -976,10 +976,20 @@ iERR _ion_writer_binary_write_timestamp_with_fraction( ION_WRITER *pwriter, ION_
     decQuad big_mantissa;
     int32_t exponent;
     BOOL is_negative, overflow;
+    decContext context = {
+            DECQUAD_Pmax,         // max digits
+            DEC_MAX_MATH,         // max exponent
+            -DEC_MAX_MATH,        // min exponent
+            DEC_ROUND_HALF_EVEN,  // rounding mode
+            DEC_Errors,           // trap conditions
+            0,                    // status flags
+            0                     // apply exponent clamp?
+    };
 
     ASSERT(pwriter != NULL);
     ASSERT(IS_FLAG_ON(ptime->precision, ION_TT_BIT_FRAC));
 
+    IONCHECK(_ion_timestamp_validate_fraction(&ptime->fraction, &context, IERR_INVALID_TIMESTAMP));
     IONCHECK(_ion_writer_binary_decimal_quad_components(&ptime->fraction, &pwriter->deccontext, &small_mantissa,
                                                         &big_mantissa, &exponent, &is_negative, &overflow));
 


### PR DESCRIPTION
*Description of changes:*
* Updates the ion-tests submodule to commit [2a1f3f4](https://github.com/amzn/ion-tests/commit/2a1f3f4f272256108e89f1c53bfae5b3a9ede812), which is current as of December 20, 2019.
* Fixes a bug uncovered by the addition of `good/timestampsLargeFractionalPrecision.ion` that prevented the text writer from writing timestamps with high-precision, low-magnitude fractional seconds (e.g. 1E-8). Previously, the implementation required on `decQuadToString` to create the string representation for these fractions, but did not handle the case when the result was in scientific notation. `decQuadToString` does not allow the caller to specify that the expanded notation should always be used, so the fix expands the scientific notation manually.
* Ensures that the binary and text writers have the same behavior when attempting to write a timestamp with a fraction outside the interval [0, 1) (that is, to throw `IERR_INVALID_TIMESTAMP`). This involved refactoring the bounds verification into `_ion_timestamp_validate_fraction` and calling it in the binary writer, which previously did not validate the fraction.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
