### PR TITLE
(Tests) Qualify calls to isnan in tests

### DIFF
--- a/test/test_ion_binary.cpp
+++ b/test/test_ion_binary.cpp
@@ -453,6 +453,6 @@ TEST(IonBinaryFloat, ReaderSupports32BitFloatNan) {
     ION_ASSERT_OK(ion_reader_next(reader, &type));
     ASSERT_EQ(tid_FLOAT, type);
     ION_ASSERT_OK(ion_reader_read_double(reader, &actual));
-    ASSERT_TRUE(isnan(nan));
-    ASSERT_TRUE(isnan(actual));
+    ASSERT_TRUE(std::isnan(nan));
+    ASSERT_TRUE(std::isnan(actual));
 }


### PR DESCRIPTION


*Description of changes:*

While updating my branch I got a compiler error for calls to `isnan` in test. Added qualifier `std::` to both calls. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
