### PR TITLE
Fixes ion_timestamp_to_time_t on Windows

### DIFF
--- a/ionc/ion_timestamp.c
+++ b/ionc/ion_timestamp.c
@@ -105,7 +105,7 @@ iERR ion_timestamp_to_time_t(const ION_TIMESTAMP *ptime, time_t *time)
     // See http://www.kernel.org/doc/man-pages/online/pages/man3/timegm.3.html
     *time = timegm(&tm);
 #else
-    *time = _mktime64(&tm);
+    *time = _mkgmtime64(&tm);
 #endif
     if (*time == -1) {
         FAILWITH(IERR_INVALID_TIMESTAMP);


### PR DESCRIPTION
The conversion originally used `_mktime64` which expects a `struct tm`
that is in local time, but for `ION_TIMESTAMP` the representation is
always UTC, so we should've been using `_mkgmtime64`.

`test_ion_timestamp.cpp` had three failing tests that now succeed with this fix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
