### PR TITLE
Fix(CLI): use arg_freetable() instead of arg_free().

### DIFF
--- a/tools/cli/main.cpp
+++ b/tools/cli/main.cpp
@@ -853,7 +853,8 @@ int main(int argc, char **argv) {
     exit:
     // deallocate each non-null entry in each argtable
     for (int i = 0; i < all_arg_tables_size; i++) {
-        arg_free(all_arg_tables[i]);
+        void **current_arg_table = all_arg_tables[i];
+        arg_freetable(current_arg_table, sizeof(current_arg_table) / sizeof(current_arg_table[0]));
     }
 
     iRETURN;


### PR DESCRIPTION
From the argtable docs, arg_free() is problematic and arg_freetable()
should be used instead. See https://github.com/argtable/argtable3/blob/57febf80ffeddbb393bc9bc626d0470c5e2fa247/src/argtable3.c#L1014

*Issue #, if available:*
Closes #163 

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
