### PR TITLE
Adds a space after a fieldname's colon when pretty-printing

### DIFF
--- a/ionc/ion_writer_text.c
+++ b/ionc/ion_writer_text.c
@@ -287,6 +287,9 @@ iERR _ion_writer_text_start_value(ION_WRITER *pwriter)
         IONCHECK(_ion_writer_get_field_name_as_string_helper(pwriter, &str, NULL));
         IONCHECK(_ion_writer_text_append_symbol_string(pwriter->output, &str, pwriter->options.escape_all_non_ascii, !ION_STRING_IS_NULL(&pwriter->field_name.value)));
         ION_TEXT_WRITER_APPEND_CHAR(':');
+        if (ION_TEXT_WRITER_IS_PRETTY()) {
+            ION_TEXT_WRITER_APPEND_CHAR(' ');
+        }
         IONCHECK(_ion_writer_clear_field_name_helper(pwriter));
     }
 


### PR DESCRIPTION
Resolves #174 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
