### PR TITLE
Added static build targets.

### DIFF
--- a/decNumber/CMakeLists.txt
+++ b/decNumber/CMakeLists.txt
@@ -33,6 +33,21 @@ set_target_properties(decNumber
     PROPERTIES
         PUBLIC_HEADER "${DEC_PUB_HEADERS}")
 
+# ---
+
+add_library(decNumberStatic STATIC ${declibsrc})
+set_property(TARGET decNumberStatic PROPERTY POSITION_INDEPENDENT_CODE 1)
+
+target_include_directories(decNumberStatic
+        PUBLIC
+        $<INSTALL_INTERFACE:include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+
+set_target_properties(decNumberStatic
+    PROPERTIES
+        PUBLIC_HEADER "${DEC_PUB_HEADERS}")
+
+# ---
 
 install(TARGETS decNumber
         EXPORT IonCTargets

--- a/tools/cli/CMakeLists.txt
+++ b/tools/cli/CMakeLists.txt
@@ -21,6 +21,21 @@ target_include_directories(ion
 
 target_link_libraries(ion ionc ion_events)
 
+# A static library version of `ion` that does not include a main()
+# function, allowing other programs to wrap it.
+add_library(ion_cli_main STATIC main.cpp argtable/argtable3.c cli.cpp)
+target_compile_definitions(ion_cli_main PUBLIC EXTERNAL_DRIVER)
+target_include_directories(ion_cli_main
+        PRIVATE
+            ./
+            ../events
+            ../events/inc
+            ../../ionc
+            ../../ionc/include
+            argtable)
+target_link_libraries(ion_cli_main ionc ion_events)
+
+
 # A library for testing.
 add_library(ion_cli cli.cpp)
 target_include_directories(ion_cli

--- a/tools/cli/main.cpp
+++ b/tools/cli/main.cpp
@@ -730,7 +730,9 @@ bool arg_tables_not_initalized() {
     return result;
 }
 
-int main(int argc, char **argv) {
+extern "C" int ion_c_cli_main(int argc, char **argv);
+
+int ion_c_cli_main(int argc, char **argv) {
     iENTER;
 
     IonEventReport report;
@@ -859,3 +861,14 @@ int main(int argc, char **argv) {
 
     iRETURN;
 }
+
+/**
+ * External programs may compile the CLI as a library and invoke
+ * ion_c_cli_main() themselves.
+ */ 
+#ifndef EXTERNAL_DRIVER
+int main(int argc, char **argv) {
+    return ion_c_cli_main(argc, argv);
+}
+#endif
+

--- a/tools/events/CMakeLists.txt
+++ b/tools/events/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(ion_events STATIC
+add_library(ion_events 
         ion_event_util.cpp
         ion_event_stream.cpp
         ion_event_equivalence.cpp)
@@ -13,3 +13,19 @@ target_include_directories(ion_events
 )
 
 target_link_libraries(ion_events ionc)
+
+add_library(ion_events_static STATIC
+        ion_event_util.cpp
+        ion_event_stream.cpp
+        ion_event_equivalence.cpp)
+
+target_include_directories(ion_events_static
+        PUBLIC
+            ${CMAKE_CURRENT_SOURCE_DIR}/inc
+        PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}
+            ${CMAKE_CURRENT_SOURCE_DIR}/../../ionc
+            ${CMAKE_CURRENT_SOURCE_DIR}/../../ionc/include
+)
+
+target_link_libraries(ion_events_static ionc)

--- a/tools/events/CMakeLists.txt
+++ b/tools/events/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(ion_events
+add_library(ion_events STATIC
         ion_event_util.cpp
         ion_event_stream.cpp
         ion_event_equivalence.cpp)
@@ -11,7 +11,5 @@ target_include_directories(ion_events
             ${CMAKE_CURRENT_SOURCE_DIR}/../../ionc
             ${CMAKE_CURRENT_SOURCE_DIR}/../../ionc/include
 )
-
-
 
 target_link_libraries(ion_events ionc)


### PR DESCRIPTION
*Description of changes:*

* Creates a static library build target for the CLI that does not have a `main()` function. This allows other programs to use the CLI's functionality while defining their own entry points.
* Makes `ion_events` a static library.
* Adds a static build target for `decNumber`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
