### PR TITLE
Adds install targets for static libaries.

### DIFF
--- a/decNumber/CMakeLists.txt
+++ b/decNumber/CMakeLists.txt
@@ -35,21 +35,21 @@ set_target_properties(decNumber
 
 # ---
 
-add_library(decNumberStatic STATIC ${declibsrc})
-set_property(TARGET decNumberStatic PROPERTY POSITION_INDEPENDENT_CODE 1)
+add_library(decNumber_static STATIC ${declibsrc})
+set_property(TARGET decNumber_static PROPERTY POSITION_INDEPENDENT_CODE 1)
 
-target_include_directories(decNumberStatic
+target_include_directories(decNumber_static
         PUBLIC
         $<INSTALL_INTERFACE:include>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 
-set_target_properties(decNumberStatic
+set_target_properties(decNumber_static
     PROPERTIES
         PUBLIC_HEADER "${DEC_PUB_HEADERS}")
 
 # ---
 
-install(TARGETS decNumber
+install(TARGETS decNumber decNumber_static
         EXPORT IonCTargets
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/ionc/CMakeLists.txt
+++ b/ionc/CMakeLists.txt
@@ -81,13 +81,14 @@ else()
             ${CMAKE_CURRENT_SOURCE_DIR}
 
 )
-  add_library(ionc_static STATIC $<TARGET_OBJECTS:objlib>)
   set_target_properties(ionc
         PROPERTIES
         VERSION ${PROJECT_VERSION}
         SOVERSION ${PROJECT_VERSION}
         PUBLIC_HEADER "${LIB_PUB_HEADERS}")
 endif()
+
+add_library(ionc_static STATIC $<TARGET_OBJECTS:objlib>)
 
 
 if (MSVC)

--- a/ionc/CMakeLists.txt
+++ b/ionc/CMakeLists.txt
@@ -99,7 +99,7 @@ endif()
 
 set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/IonC)
 
-install(TARGETS ionc
+install(TARGETS ionc ionc_static
         EXPORT IonCTargets
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}


### PR DESCRIPTION
Also makes `decNumberStatic.a` be `decNumber_static.a` to be consistent with
`ion_static.a`

Previously, we were building these static library targets but not actually installing them.

Tested this by building/installing in a local prefix:

```bash
$ (mkdir -p build/dist && \
    cd build && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(pwd)/dist .. && \
    cmake --build . --target install -- -j30)
...
$ tree build/dist/lib
build/dist/lib
├── cmake
│   └── IonC
│       ├── IonCConfig.cmake
│       ├── IonCConfigVersion.cmake
│       ├── IonCTargets.cmake
│       └── IonCTargets-release.cmake
├── libdecNumber.so
├── libdecNumber_static.a
├── libgmock.a
├── libgmock_main.a
├── libgtest.a
├── libgtest_main.a
├── libionc.so -> libionc.so.1.0.3
├── libionc.so.1.0.3
└── libionc_static.a
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
