### PR TITLE
Removes `googletest` from all target.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,7 +29,7 @@ add_executable(all_tests
     test_ion_reader_seek.cpp
 )
 
-add_subdirectory(googletest)
+add_subdirectory(googletest EXCLUDE_FROM_ALL)
 
 
 target_include_directories(all_tests


### PR DESCRIPTION
This makes sure it is only built when needed and not
incorporated into the `install` target.

Fixes #183

Verified the build/install on Linux:

```bash
$ (rm -fr build && \
    mkdir -p build/dist && \
    cd build && \
    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(pwd)/dist .. && \
    cmake --build . --target install -- -j8)
...

$ tree build/dist -I '*.h|*.pump'
build/dist
├── include
│   ├── decNumber
│   └── ionc
└── lib
    ├── cmake
    │   └── IonC
    │       ├── IonCConfig.cmake
    │       ├── IonCConfigVersion.cmake
    │       ├── IonCTargets.cmake
    │       └── IonCTargets-release.cmake
    ├── libdecNumber.so
    ├── libdecNumber_static.a
    ├── libionc.so -> libionc.so.1.0.3
    ├── libionc.so.1.0.3
    └── libionc_static.a
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
