### PR TITLE
Stream fetch position over the limit raises error (amzn#185)

### DIFF
--- a/ionc/ion_stream.c
+++ b/ionc/ion_stream.c
@@ -1447,7 +1447,7 @@ iERR _ion_stream_fetch_position( ION_STREAM *stream, POSITION target_position )
     if (!_ion_stream_is_paged(stream) && _ion_stream_is_fully_buffered(stream)) {
         // if we have a user buffer, this is one large page and thus we can position within it
         page_end = IH_POSITION_OF(stream->_limit);
-        if (target_position > page_end) {
+        if (target_position >= page_end) {
             FAILWITH(IERR_EOF);
         }
         goto done;

--- a/test/test_ion_binary.cpp
+++ b/test/test_ion_binary.cpp
@@ -537,3 +537,17 @@ TEST(IonBinaryBlob, CanFullyReadBlobUsingPartialReads) {
             29, tid_BLOB, 23, "This is a BLOB of text.");
 }
 
+TEST(IonBinaryWriterBuffer, SmallBuffer) {
+    iENTER;
+    hWRITER writer = NULL;
+    uint8_t buf[2];
+    ION_WRITER_OPTIONS options = { 0 };
+    options.output_as_binary = TRUE;
+    ION_ASSERT_OK(ion_writer_open_buffer(&writer, buf, sizeof(buf), &options));
+    ION_ASSERT_OK(ion_writer_write_int32(writer, 1));
+
+    SIZE len;
+    ION_ASSERT_FAIL(ion_writer_finish(writer, &len));
+    ION_ASSERT_FAIL(ion_writer_close(writer));
+}
+


### PR DESCRIPTION
*Issue #, if available: (amzn#185)*

*Description of changes: In case of non-paged buffered streams with smaller buffer than needed for write the while loop in ion_stream_write function became infinite because _ion_stream_position returns stream limit and ion_stream_fetch_position checked for the condition over the limit but not for at the limit. So it successfully wrote exactly zero bytes and continued...*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
