### PR TITLE
issue#196 Updating comparison report for non-equivalent struct

### DIFF
--- a/tools/events/ion_event_equivalence.cpp
+++ b/tools/events/ion_event_equivalence.cpp
@@ -118,7 +118,7 @@ BOOL ion_compare_struct_subset(ION_EVENT_EQUIVALENCE_PARAMS) {
                 ION_SET_ACTUAL;
                 ION_EXPECT_TRUE_WITH_INDEX(!(ION_ACTUAL_ARG->event_type == CONTAINER_END && ION_ACTUAL_ARG->depth == target_depth),
                                            "Did not find matching field for " + ion_event_symbol_to_string(expected_field_name),
-                                           index_expected_container_start,index_actual_container_start);
+                                           index_expected_container_start, index_actual_container_start);
                 ION_ASSERT(IERR_OK == ion_symbol_is_equal(expected_field_name,
                                                           ION_ACTUAL_ARG->field_name, &field_names_equal),
                            "Failed to compare field names.");

--- a/tools/events/ion_event_equivalence.cpp
+++ b/tools/events/ion_event_equivalence.cpp
@@ -99,6 +99,8 @@ BOOL ion_compare_scalars(ION_EVENT_EQUIVALENCE_PARAMS) {
  */
 BOOL ion_compare_struct_subset(ION_EVENT_EQUIVALENCE_PARAMS) {
     const int target_depth = ION_GET_EXPECTED->depth;
+    const int index_expected_container_start = ION_INDEX_ACTUAL_ARG;
+    const int index_actual_container_start = ION_INDEX_EXPECTED_ARG;
     ION_NEXT_INDICES; // Move past the CONTAINER_START events
     const size_t index_actual_start = ION_INDEX_ACTUAL_ARG;
     std::set<size_t> skips;
@@ -114,8 +116,9 @@ BOOL ion_compare_struct_subset(ION_EVENT_EQUIVALENCE_PARAMS) {
         while (ION_INDEX_ACTUAL_ARG < ION_STREAM_ACTUAL_ARG->size()) {
             if (skips.count(ION_INDEX_ACTUAL_ARG) == 0) {
                 ION_SET_ACTUAL;
-                ION_EXPECT_TRUE(!(ION_ACTUAL_ARG->event_type == CONTAINER_END && ION_ACTUAL_ARG->depth == target_depth),
-                                "Did not find matching field for " + ion_event_symbol_to_string(expected_field_name));
+                ION_EXPECT_TRUE_WITH_INDEX(!(ION_ACTUAL_ARG->event_type == CONTAINER_END && ION_ACTUAL_ARG->depth == target_depth),
+                                           "Did not find matching field for " + ion_event_symbol_to_string(expected_field_name),
+                                           index_expected_container_start,index_actual_container_start);
                 ION_ASSERT(IERR_OK == ion_symbol_is_equal(expected_field_name,
                                                           ION_ACTUAL_ARG->field_name, &field_names_equal),
                            "Failed to compare field names.");

--- a/tools/events/ion_event_equivalence_impl.h
+++ b/tools/events/ion_event_equivalence_impl.h
@@ -37,6 +37,15 @@
     return FALSE;
 
 /**
+ * Sets the desired index of event for IonEventResult's comparison_result context.
+ */
+#define ION_FAIL_COMPARISON_WITH_INDEX(message, index_expected, index_actual) \
+    _ion_event_set_comparison_result(ION_RESULT_ARG, ION_COMPARISON_TYPE_ARG, stream_expected->at(index_expected), \
+        stream_actual->at(index_actual), index_expected, index_actual, ION_STREAM_EXPECTED_ARG->location, \
+        ION_STREAM_ACTUAL_ARG->location, message); \
+    return FALSE;
+
+/**
  * Sets the current IonEventResult's error_description with context about the error and returns.
  */
 #define ION_FAIL_ASSERTION(message, loc) \
@@ -70,6 +79,7 @@
 
 // Equivalence assertions. Each sets the comparison_result and returns in the event of inequality.
 #define ION_EXPECT_TRUE(x, m) if (!(x)) { ION_FAIL_COMPARISON(m); }
+#define ION_EXPECT_TRUE_WITH_INDEX(x, m, e, a) if (!(x)) { ION_FAIL_COMPARISON_WITH_INDEX(m, e, a); }
 #define ION_EXPECT_FALSE(x, m) if (x) { ION_FAIL_COMPARISON(m); }
 #define ION_EXPECT_EQ(x, y, m) if((x) != (y)) { ION_FAIL_COMPARISON(m); }
 #define ION_EXPECT_EVENT_TYPE_EQ(x, y) ION_EXPECT_EQ(x, y, "Event types did not match.")


### PR DESCRIPTION
### Description
Worked on issue https://github.com/amzn/ion-c/issues/196. 

For comparing struct, we write CONTAINER_START event for lhs/rhs in comparison report if we can't find a key-value pair of the first struct in the second struct.

### What I did

Added a helper function that sets comparison report's context to desire event's index (ION_EXPECT_TRUE_WITH_INDEX). When two structs are different, we use this new function to write the CONTAINER_START event on comparison report.
