### PR TITLE
Fixed issue#198

### DIFF
--- a/tools/events/ion_event_equivalence.cpp
+++ b/tools/events/ion_event_equivalence.cpp
@@ -264,7 +264,7 @@ BOOL ion_compare_sets_nonequivs(ION_EVENT_EQUIVALENCE_PARAMS) {
     // The corresponding indices are assumed to be equivalent.
     if (ION_INDEX_EXPECTED_ARG != ION_INDEX_ACTUAL_ARG) {
         ION_PREPARE_COMPARISON;
-        ION_EXPECT_FALSE(ion_compare_events(ION_EVENT_EQUIVALENCE_ARGS), "Equivalent values in a non-equivs set.");
+        ION_EXPECT_FALSE_FOR_NON_EQUIVS(ion_compare_events(ION_EVENT_EQUIVALENCE_ARGS), "Equivalent values in a non-equivs set.");
     }
     ION_PASS_ASSERTIONS;
 }
@@ -340,11 +340,11 @@ BOOL ion_compare_sets_embedded(ION_EVENT_EQUIVALENCE_PARAMS, size_t *expected_le
                     ION_ASSERT(ION_COMPARISON_TYPE_ARG == COMPARISON_TYPE_NONEQUIVS,
                                "Invalid embedded documents comparison type.");
                     if (step_expected == 1 && step_actual == 1) {
-                        ION_EXPECT_FALSE(step_expected == 1 && step_actual == 1,
+                        ION_EXPECT_FALSE_FOR_NON_EQUIVS(step_expected == 1 && step_actual == 1,
                                          "Both embedded streams are empty stream in a non-equivs set.")
                     }
                     else if (step_expected > 1 && step_actual > 1) {
-                        ION_EXPECT_FALSE(
+                        ION_EXPECT_FALSE_FOR_NON_EQUIVS(
                                 ion_compare_substreams(ION_STREAM_EXPECTED_ARG, ION_INDEX_EXPECTED_ARG,
                                                        ION_STREAM_ACTUAL_ARG, ION_INDEX_ACTUAL_ARG,
                                                        COMPARISON_TYPE_BASIC, /*result=*/NULL, // Result not needed.

--- a/tools/events/ion_event_equivalence.cpp
+++ b/tools/events/ion_event_equivalence.cpp
@@ -340,8 +340,9 @@ BOOL ion_compare_sets_embedded(ION_EVENT_EQUIVALENCE_PARAMS, size_t *expected_le
                     ION_ASSERT(ION_COMPARISON_TYPE_ARG == COMPARISON_TYPE_NONEQUIVS,
                                "Invalid embedded documents comparison type.");
                     if (step_expected == 1 && step_actual == 1) {
-                        ION_EXPECT_FALSE_FOR_NON_EQUIVS(step_expected == 1 && step_actual == 1,
-                                         "Both embedded streams are empty stream in a non-equivs set.")
+                        ION_EXPECT_FALSE_FOR_NON_EQUIVS(
+                                step_expected == 1 && step_actual == 1,
+                                "Both embedded streams are empty stream in a non-equivs set.")
                     }
                     else if (step_expected > 1 && step_actual > 1) {
                         ION_EXPECT_FALSE_FOR_NON_EQUIVS(

--- a/tools/events/ion_event_equivalence_impl.h
+++ b/tools/events/ion_event_equivalence_impl.h
@@ -29,8 +29,21 @@
 
 /**
  * Sets the current IonEventResult's comparison_result with context about the comparison failure and returns.
+ *
+ * Note: We don't write comparison report for non-equivs mode here.
  */
 #define ION_FAIL_COMPARISON(message) \
+    if (ION_COMPARISON_TYPE_ARG != COMPARISON_TYPE_NONEQUIVS) { \
+        _ion_event_set_comparison_result(ION_RESULT_ARG, ION_COMPARISON_TYPE_ARG, ION_EXPECTED_ARG, ION_ACTUAL_ARG, \
+            ION_INDEX_EXPECTED_ARG, ION_INDEX_ACTUAL_ARG, ION_STREAM_EXPECTED_ARG->location, \
+            ION_STREAM_ACTUAL_ARG->location, message); \
+    } \
+    return FALSE;
+
+/**
+ * Sets the current IonEventResult's comparison_result with context about the comparison failure and returns.
+ */
+#define ION_FAIL_COMPARISON_FOR_NON_EQUIVS(message) \
     _ion_event_set_comparison_result(ION_RESULT_ARG, ION_COMPARISON_TYPE_ARG, ION_EXPECTED_ARG, ION_ACTUAL_ARG, \
         ION_INDEX_EXPECTED_ARG, ION_INDEX_ACTUAL_ARG, ION_STREAM_EXPECTED_ARG->location, \
         ION_STREAM_ACTUAL_ARG->location, message); \
@@ -71,6 +84,7 @@
 // Equivalence assertions. Each sets the comparison_result and returns in the event of inequality.
 #define ION_EXPECT_TRUE(x, m) if (!(x)) { ION_FAIL_COMPARISON(m); }
 #define ION_EXPECT_FALSE(x, m) if (x) { ION_FAIL_COMPARISON(m); }
+#define ION_EXPECT_FALSE_FOR_NON_EQUIVS(x, m) if (x) { ION_FAIL_COMPARISON_FOR_NON_EQUIVS(m); } //for non-equivs mode only
 #define ION_EXPECT_EQ(x, y, m) if((x) != (y)) { ION_FAIL_COMPARISON(m); }
 #define ION_EXPECT_EVENT_TYPE_EQ(x, y) ION_EXPECT_EQ(x, y, "Event types did not match.")
 #define ION_EXPECT_BOOL_EQ(x, y) _ION_IS_VALUE_EQ(x, y, ion_equals_bool)


### PR DESCRIPTION
This commit fixed issue #198 .

The reason for this issue is because that equivs mode and non-equivs mode share the same compare_event function. When we compare non-equiv set, it will write the report for equivalent value before we write the non-equivs values into the report since it uses the same compare_event function as equiv mode.

To solver this, I separated equivs mode and non-equivs mode by give them two different functions to write the report:
**ION_EXPECT_FALSE_FOR_NON_EQUIVS** is for non-equivs mode only, it will write the report when set has equivalent values.
**ION_EXPECT_FALSE** is for equivs mode to write report, it won't do anything if the current mode is non-equivs.
