### PR TITLE
Fixed issue #202.

### DIFF
--- a/tools/events/ion_event_equivalence.cpp
+++ b/tools/events/ion_event_equivalence.cpp
@@ -162,6 +162,12 @@ BOOL ion_compare_sequences(ION_EVENT_EQUIVALENCE_PARAMS) {
             // The streams are incomplete, but they are the same length and all their values are equivalent.
             break;
         }
+        if (ION_STREAM_ACTUAL_ARG->size() == ION_INDEX_ACTUAL_ARG) {
+            if (ION_STREAM_EXPECTED_ARG->size() != ION_INDEX_EXPECTED_ARG) {
+                ION_EXPECT_TRUE(FALSE, "Streams have different lengths");
+            }
+            break;
+        }
         ION_EXPECTED_ARG = ION_GET_EXPECTED;
         ION_ACTUAL_ARG = ION_GET_ACTUAL;
         // NOTE: symbol tables are only allowed within embedded stream sequences. Logic could be added to verify this.


### PR DESCRIPTION
This PR fixed https://github.com/amzn/ion-c/issues/202.

The reason of this issue is that we only did edge check for the first file.

For example, `file1` has 2 events and `file2` has 1 event and both indexes are 1 now.
We only checked that `1` is less than the first file's size `2` but ignored that `1` is reach the end of the second file's end.
So an error is raised before we write it into report.

So we need to check if the index reach the end of the both files rather than only the first one. I added the boundary check for the second file (ION_STREAM_ACTUAL_ARG).