### PR TITLE
Fixed issue #200.

### DIFF
--- a/tools/events/ion_event_stream.cpp
+++ b/tools/events/ion_event_stream.cpp
@@ -1173,6 +1173,9 @@ iERR ion_event_stream_write_event(hWRITER writer, IonEvent *event, ION_EVENT_IND
     if (event->field_name) {
         IONCWRITE(ion_writer_write_field_name_symbol(writer, event->field_name));
     }
+    if (writer->_in_struct && !event->field_name && event->event_type != CONTAINER_END) {
+        IONFAILSTATE(IERR_INVALID_STATE, "Field name in struct cannot be null.");
+    }
     if (event->num_annotations) {
         IONCWRITE(ion_writer_write_annotation_symbols(writer, event->annotations, event->num_annotations));
     }


### PR DESCRIPTION
### Description:
Links https://github.com/amzn/ion-c/issues/200.

This issue only happens for 'event stream' that only used for cli tool. I added field_name check for it.
If an event is inside a struct but doesn't give a valid field_name, then ion-c-cli will throw an exception.

### Example:
After this change, it will detect invalid field_name within a struct.

**File:**
```
$ion_event_stream
{
  event_type: CONTAINER_START,
  ion_type: STRUCT,
  depth: 0
}
{
  event_type: SCALAR,
  ion_type: INT,
  field_name: {
	text: "test"
  },
  value_text: "1",
  value_binary: [
    224,
    1,
    0,
    234,
    33,
    1
  ],
  depth: 1
}
{
  event_type: SCALAR,
  ion_type: INT,
  //no field_name here
  value_text: "1",
  value_binary: [
    224,
    1,
    0,
    234,
    33,
    1
  ],
  depth: 1
}
{
  event_type: CONTAINER_END,
  ion_type: STRUCT,
  depth: 0
}
{
  event_type: STREAM_END,
  depth: 0
}
```
**Output:**
Error report: 
```
{
  error_type: STATE,
  message: "/Users/cheqianh/Desktop/ion-c/ion-c/tools/events/ion_event_stream.cpp:1177 : IERR_INVALID_STATE: Field name in struct cannot be null.",
  location: "c",
  event_index: 2
}
```
Event stream:
```
{
  test: 1
```

