### PR TITLE
Fixed issue #204.

### DIFF
--- a/ionc/ion_scanner.c
+++ b/ionc/ion_scanner.c
@@ -2379,7 +2379,7 @@ past_exponent:
     iRETURN;
 }
 
-iERR _ion_scanner_read_timestamp(ION_SCANNER *scanner, int c, BYTE **p_dst, SIZE *p_remaining, int *p_char, ION_SUB_TYPE *p_ist )
+iERR _ion_scanner_read_timestamp(ION_SCANNER *scanner, int c, BYTE **p_dst, SIZE *p_remaining, int *p_end_char, ION_SUB_TYPE *p_ist )
 {
     iENTER;
     ION_SUB_TYPE t                      = IST_TIMESTAMP_YEAR;
@@ -2515,7 +2515,7 @@ check_timestamp_terminator:
     *p_dst       = dst;
     *p_remaining = remaining;
     *p_ist       = t;
-    *p_char = c;
+    *p_end_char = c;
 
     iRETURN;
 }

--- a/ionc/ion_scanner.c
+++ b/ionc/ion_scanner.c
@@ -2300,22 +2300,22 @@ iERR _ion_scanner_read_radix_int(ION_SCANNER *scanner, BYTE **p_dst, SIZE *p_rem
     iRETURN;
 }
 
-iERR _ion_scanner_read_hex_int(ION_SCANNER *scanner, BYTE **p_dst, SIZE *p_remaining, int *p_char)
+iERR _ion_scanner_read_hex_int(ION_SCANNER *scanner, BYTE **p_dst, SIZE *p_remaining, int *p_end_char)
 {
     iENTER;
     int c;
     IONCHECK(_ion_scanner_read_radix_int(scanner, p_dst, p_remaining, &c, ION_INT_HEX, FALSE));
-    *p_char = c;
+    *p_end_char = c;
     IONCHECK(_ion_scanner_unread_char(scanner, c));
     iRETURN;
 }
 
-iERR _ion_scanner_read_binary_int(ION_SCANNER *scanner, BYTE **p_dst, SIZE *p_remaining, int *p_char)
+iERR _ion_scanner_read_binary_int(ION_SCANNER *scanner, BYTE **p_dst, SIZE *p_remaining, int *p_end_char)
 {
     iENTER;
     int c;
     IONCHECK(_ion_scanner_read_radix_int(scanner, p_dst, p_remaining, &c, ION_INT_BINARY, FALSE));
-    *p_char = c;
+    *p_end_char = c;
     IONCHECK(_ion_scanner_unread_char(scanner, c));
     iRETURN;
 }

--- a/ionc/ion_scanner.c
+++ b/ionc/ion_scanner.c
@@ -2161,10 +2161,6 @@ iERR _ion_scanner_read_possible_number(ION_SCANNER *scanner, int c, int sign, IO
 
     IONCHECK(_ion_scanner_read_char(scanner, &c));
 
-    if (c > 0 && c != 'x' && c != 'X' && c != 'b' && c != 'B' && !isdigit(c) && c != '_' && c != '-' && c != 'T'
-        && c != 'e' && c != 'E' && c != 'd' && c != 'D' && c != '.' && strchr(NUMERIC_STOP_CHARACTERS, c) == NULL ) {
-        FAILWITH(IERR_INVALID_SYNTAX);
-    }
     // if we have an x we have a hexadecimal int
     if (c == 'x' || c == 'X') {
         PUSH_VALUE_BYTE(c);

--- a/ionc/ion_scanner.c
+++ b/ionc/ion_scanner.c
@@ -2379,7 +2379,7 @@ past_exponent:
     iRETURN;
 }
 
-iERR _ion_scanner_read_timestamp(ION_SCANNER *scanner, int c, BYTE **p_dst, SIZE *p_remaining, int *p_end_char, ION_SUB_TYPE *p_ist )
+iERR _ion_scanner_read_timestamp(ION_SCANNER *scanner, int c, BYTE **p_dst, SIZE *p_remaining, int *p_end_char, ION_SUB_TYPE *p_ist)
 {
     iENTER;
     ION_SUB_TYPE t                      = IST_TIMESTAMP_YEAR;

--- a/ionc/ion_scanner.h
+++ b/ionc/ion_scanner.h
@@ -457,8 +457,8 @@ iERR _ion_scanner_read_as_base64                    (ION_SCANNER *scanner, BYTE 
 
 iERR _ion_scanner_read_possible_number              (ION_SCANNER *scanner, int c, int sign, ION_SUB_TYPE *p_ist);
 iERR _ion_scanner_read_radix_int                    (ION_SCANNER *scanner, BYTE **p_dst, SIZE *p_remaining, int *p_char, ION_INT_RADIX radix, BOOL underscore_allowed);
-iERR _ion_scanner_read_hex_int                      (ION_SCANNER *scanner, BYTE **p_dst, SIZE *p_remaining, int *p_char);
-iERR _ion_scanner_read_binary_int                   (ION_SCANNER *scanner, BYTE **p_dst, SIZE *p_remaining, int *p_char);
+iERR _ion_scanner_read_hex_int                      (ION_SCANNER *scanner, BYTE **p_dst, SIZE *p_remaining, int *p_end_char);
+iERR _ion_scanner_read_binary_int                   (ION_SCANNER *scanner, BYTE **p_dst, SIZE *p_remaining, int *p_end_char);
 iERR _ion_scanner_read_digits                       (ION_SCANNER *scanner, BYTE **p_dst, SIZE *p_remaining, int *p_char);
 iERR _ion_scanner_read_digits_with_underscores      (ION_SCANNER *scanner, BYTE **p_dst, SIZE *p_remaining, int *p_char, BOOL underscore_allowed);
 iERR _ion_scanner_read_exponent                     (ION_SCANNER *scanner, BYTE **p_dst, SIZE *p_remaining, int *p_char);

--- a/ionc/ion_scanner.h
+++ b/ionc/ion_scanner.h
@@ -462,7 +462,7 @@ iERR _ion_scanner_read_binary_int                   (ION_SCANNER *scanner, BYTE 
 iERR _ion_scanner_read_digits                       (ION_SCANNER *scanner, BYTE **p_dst, SIZE *p_remaining, int *p_char);
 iERR _ion_scanner_read_digits_with_underscores      (ION_SCANNER *scanner, BYTE **p_dst, SIZE *p_remaining, int *p_char, BOOL underscore_allowed);
 iERR _ion_scanner_read_exponent                     (ION_SCANNER *scanner, BYTE **p_dst, SIZE *p_remaining, int *p_char);
-iERR _ion_scanner_read_timestamp                    (ION_SCANNER *scanner, int c, BYTE **p_dst, SIZE *p_remaining, int *p_end_char, ION_SUB_TYPE *p_ist );
+iERR _ion_scanner_read_timestamp                    (ION_SCANNER *scanner, int c, BYTE **p_dst, SIZE *p_remaining, int *p_end_char, ION_SUB_TYPE *p_ist);
 
 #ifdef __cplusplus
 }

--- a/ionc/ion_scanner.h
+++ b/ionc/ion_scanner.h
@@ -462,7 +462,7 @@ iERR _ion_scanner_read_binary_int                   (ION_SCANNER *scanner, BYTE 
 iERR _ion_scanner_read_digits                       (ION_SCANNER *scanner, BYTE **p_dst, SIZE *p_remaining, int *p_char);
 iERR _ion_scanner_read_digits_with_underscores      (ION_SCANNER *scanner, BYTE **p_dst, SIZE *p_remaining, int *p_char, BOOL underscore_allowed);
 iERR _ion_scanner_read_exponent                     (ION_SCANNER *scanner, BYTE **p_dst, SIZE *p_remaining, int *p_char);
-iERR _ion_scanner_read_timestamp                    (ION_SCANNER *scanner, int c, BYTE **p_dst, SIZE *p_remaining, int *p_char, ION_SUB_TYPE *p_ist );
+iERR _ion_scanner_read_timestamp                    (ION_SCANNER *scanner, int c, BYTE **p_dst, SIZE *p_remaining, int *p_end_char, ION_SUB_TYPE *p_ist );
 
 #ifdef __cplusplus
 }

--- a/ionc/ion_scanner.h
+++ b/ionc/ion_scanner.h
@@ -457,12 +457,12 @@ iERR _ion_scanner_read_as_base64                    (ION_SCANNER *scanner, BYTE 
 
 iERR _ion_scanner_read_possible_number              (ION_SCANNER *scanner, int c, int sign, ION_SUB_TYPE *p_ist);
 iERR _ion_scanner_read_radix_int                    (ION_SCANNER *scanner, BYTE **p_dst, SIZE *p_remaining, int *p_char, ION_INT_RADIX radix, BOOL underscore_allowed);
-iERR _ion_scanner_read_hex_int                      (ION_SCANNER *scanner, BYTE **p_dst, SIZE *p_remaining);
-iERR _ion_scanner_read_binary_int                   (ION_SCANNER *scanner, BYTE **p_dst, SIZE *p_remaining);
+iERR _ion_scanner_read_hex_int                      (ION_SCANNER *scanner, BYTE **p_dst, SIZE *p_remaining, int *p_char);
+iERR _ion_scanner_read_binary_int                   (ION_SCANNER *scanner, BYTE **p_dst, SIZE *p_remaining, int *p_char);
 iERR _ion_scanner_read_digits                       (ION_SCANNER *scanner, BYTE **p_dst, SIZE *p_remaining, int *p_char);
 iERR _ion_scanner_read_digits_with_underscores      (ION_SCANNER *scanner, BYTE **p_dst, SIZE *p_remaining, int *p_char, BOOL underscore_allowed);
 iERR _ion_scanner_read_exponent                     (ION_SCANNER *scanner, BYTE **p_dst, SIZE *p_remaining, int *p_char);
-iERR _ion_scanner_read_timestamp                    (ION_SCANNER *scanner, int c, BYTE **p_dst, SIZE *p_remaining, ION_SUB_TYPE *p_ist );
+iERR _ion_scanner_read_timestamp                    (ION_SCANNER *scanner, int c, BYTE **p_dst, SIZE *p_remaining, int *p_char, ION_SUB_TYPE *p_ist );
 
 #ifdef __cplusplus
 }

--- a/test/test_ion_text.cpp
+++ b/test/test_ion_text.cpp
@@ -572,9 +572,7 @@ TEST(IonTextDecimal, FailsEarlyOnInvalidDecimal) {
     ION_TYPE type;
     ION_DECIMAL decimal;
     ION_ASSERT_OK(ion_test_new_text_reader(invalid_text, &reader));
-    ION_ASSERT_OK(ion_reader_next(reader, &type));
-    ASSERT_EQ(tid_DECIMAL, type);
-    ION_ASSERT_FAIL(ion_reader_read_ion_decimal(reader, &decimal));
+    ION_ASSERT_FAIL(ion_reader_next(reader, &type));
     ION_ASSERT_OK(ion_reader_close(reader));
 }
 


### PR DESCRIPTION
### Over description:
This PR links https://github.com/amzn/ion-c/issues/204.

Our logic parsing a numeric value includes three steps:
1. Check the first char, if it's a digit go to step 2,
2. Check the second char,
3. Check the rest chars 

Logic in `ion_scanner.c  line 2164-2167` checks if the second char is valid, if not raise an error before it returns values.

For step 3 above, we have already passed a pointer `c` to each functions so we can track the last char that makes the parser stop. If the c is invalid after parser stop, then raise an error before it returns incomplete numeric value (ion_scanner.c  2257 - 2259).