### PR TITLE
Increased cli max inputs count to 48 to fix ion-test-driver err message issue.

### DIFF
--- a/tools/cli/main.cpp
+++ b/tools/cli/main.cpp
@@ -84,7 +84,7 @@ static const char *const VERSION_GLOSSARY = "print the command's version number 
 //   - no errors
 //   - no input for multiple input options
 static const int ARG_MAX_ERRORS = 20;
-static const int MAX_NO_INPUTS = 24;
+static const int MAX_NO_INPUTS = 48;
 
 // Common args shared by subcommands
 static const char *const OUTPUT_SHORT_OPT = "o";


### PR DESCRIPTION
When running ion-test-driver, there is a weird error message when we doing write-compare phase:
![Screen Shot 2020-10-24 at 12 42 33 PM](https://user-images.githubusercontent.com/67451029/97092157-670d6000-15f6-11eb-88d4-e83e2527fc90.png)

After few tests, I found the reason of this is because ion-c-cli  compare mode can accept at most 24 files while we have 2x^2 + 1 files (x is the number of implementations, here is 4 so totally 33 files). I doubled count to 48 to handle more files.