### PR TITLE
Matches behavior between the text and binary readers after they're cr…

### DIFF
--- a/ionc/ion_reader_binary.c
+++ b/ionc/ion_reader_binary.c
@@ -486,7 +486,9 @@ iERR _ion_reader_binary_get_type(ION_READER *preader, ION_TYPE *p_value_type)
         // the next value. All other values must be positioned before the contents of the current value.
         if (binary->_value_type != tid_SYMBOL)
         {
-            FAILWITH(IERR_INVALID_STATE);
+            // This matches the behavior of the text reader
+            *p_value_type = tid_none;
+            SUCCEED();
         }
     }
 

--- a/test/test_ion_binary.cpp
+++ b/test/test_ion_binary.cpp
@@ -337,6 +337,16 @@ TEST(IonBinarySymbol, ReaderReadsIVMInsideAnnotationWrapper) {
     ION_ASSERT_OK(ion_reader_close(reader));
 }
 
+TEST(IonBinaryReader, UnpositionedReaderHasTypeNone) {
+    hREADER reader;
+    BYTE *data = (BYTE *) "\xE0\x01\x00\xEA";
+    ION_TYPE type;
+
+    ION_ASSERT_OK(ion_reader_open_buffer(&reader, data, 4, NULL));
+    ION_ASSERT_OK(ion_reader_get_type(reader, &type));
+    ASSERT_EQ(tid_none, type);
+}
+
 TEST(IonBinarySymbol, ReaderReadsNullSymbol) {
     hREADER reader;
     BYTE *data = (BYTE *) "\xE0\x01\x00\xEA\x7F";

--- a/test/test_ion_text.cpp
+++ b/test/test_ion_text.cpp
@@ -674,6 +674,16 @@ TEST(IonTextStruct, AcceptsFieldNameWithKeywordPrefix) {
     ION_ASSERT_OK(ion_reader_close(reader));
 }
 
+TEST(IonTextReader, UnpositionedReaderHasTypeNone) {
+    const char *ion_text = "";
+    hREADER  reader;
+    ION_TYPE type;
+
+    ION_ASSERT_OK(ion_test_new_text_reader(ion_text, &reader));
+    ION_ASSERT_OK(ion_reader_get_type(reader, &type));
+    ASSERT_EQ(tid_none, type);
+}
+
 TEST(IonTextStruct, FailsOnFieldNameWithNoValueAtStructEnd) {
     const char *ion_text = "{a: }";
     hREADER  reader;


### PR DESCRIPTION
…eated, but before their position has been advanced.

This is just a parity gap between the text and binary ion readers, which in the normal case only impacts code with too-verbose diagnostics. In the worst case, it could be used by an SDK consumer to determine what kind of reader is currently being used, breaking encapsulation. Before the change, the unit test I added to the binary reader fails. After the change, it passes (without causing any other failures).

Now, the binary and text readers will both yield `type_none` in this situation.

https://issues.amazon.com/issues/ION-1226

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
