### PR TITLE
Fixed async main branch change issue for ion-test-driver GitHub Actions.

### DIFF
--- a/.github/workflows/ion-test-driver.yml
+++ b/.github/workflows/ion-test-driver.yml
@@ -13,9 +13,6 @@ jobs:
           ref: master
           path: ion-c
 
-      - name: Get main branch HEAD sha
-        run: cd ion-c && echo "sha=`git rev-parse --short HEAD`" >> $GITHUB_ENV
-
       - name: Checkout ion-test-driver
         uses: actions/checkout@master
         with:
@@ -28,6 +25,9 @@ jobs:
 
       - name: Pip install
         run: pip3 install -r ion-test-driver/requirements.txt && pip3 install -e ion-test-driver
+
+      - name: Get main branch HEAD sha
+        run: cd ion-c && echo `git rev-parse --short HEAD` && echo "sha=`git rev-parse --short HEAD`" >> $GITHUB_ENV
 
       - name: Run ion-test-driver
         run: python3 ion-test-driver/amazon/iontest/ion_test_driver.py -o output


### PR DESCRIPTION
Before we get main branch sha too early which will cause an async issue. Now I move this step right before ion-test-driver run.