### PR TITLE
Ionc compile '.c' issue 

### DIFF
--- a/ionc/include/ionc/ion_int.h
+++ b/ionc/include/ionc/ion_int.h
@@ -128,9 +128,9 @@ ION_INT_GLOBAL ION_INT         g_Int_Null
 #endif
 ;
 
-ION_INT_GLOBAL THREAD_LOCAL_STORAGE BOOL g_ion_int_globals_initialized; // NOTE: this is initialized to 0 according to C standard.
-ION_INT_GLOBAL THREAD_LOCAL_STORAGE ION_INT_GLOBAL decQuad     g_digit_base_quad;
-ION_INT_GLOBAL THREAD_LOCAL_STORAGE ION_INT_GLOBAL decNumber    g_digit_base_number;
+ION_INT_GLOBAL THREAD_LOCAL_STORAGE BOOL            g_ion_int_globals_initialized; // NOTE: this is initialized to 0 according to C standard.
+ION_INT_GLOBAL THREAD_LOCAL_STORAGE decQuad         g_digit_base_quad;
+ION_INT_GLOBAL THREAD_LOCAL_STORAGE decNumber       g_digit_base_number;
 
 
 //////////////////////////////////////////////////////////////

--- a/ionc/include/ionc/ion_int.h
+++ b/ionc/include/ionc/ion_int.h
@@ -128,9 +128,9 @@ ION_INT_GLOBAL ION_INT         g_Int_Null
 #endif
 ;
 
-THREAD_LOCAL_STORAGE ION_INT_GLOBAL BOOL            g_ion_int_globals_initialized; // NOTE: this is initialized to 0 according to C standard.
-THREAD_LOCAL_STORAGE ION_INT_GLOBAL decQuad         g_digit_base_quad;
-THREAD_LOCAL_STORAGE ION_INT_GLOBAL decNumber       g_digit_base_number;
+ION_INT_GLOBAL THREAD_LOCAL_STORAGE BOOL g_ion_int_globals_initialized; // NOTE: this is initialized to 0 according to C standard.
+ION_INT_GLOBAL THREAD_LOCAL_STORAGE ION_INT_GLOBAL decQuad     g_digit_base_quad;
+ION_INT_GLOBAL THREAD_LOCAL_STORAGE ION_INT_GLOBAL decNumber    g_digit_base_number;
 
 
 //////////////////////////////////////////////////////////////


### PR DESCRIPTION
A customer mentioned that the ion_int.h file can't compile successfully due to the below issue:
```.c
ion_int.h:131:1: error: ‘thread’ before ‘extern’
THREAD_LOCAL_STORAGE ION_INT_GLOBAL BOOL g_ion_int_globals_initialized; // NOTE: this is initialized to 0 according to C standard.
^
```
The customer mentioned that it works if the order of `THREAD_LOCAL_STORAGE` and `ION_INT_GLOBAL` are switched. 
However both orders worked on my laptop. I created this PR so reviewer can see where the code is. I think it may because of the different environment or platform etc. 