### PR TITLE
Resets the scanner state after stepping into a container in the text …

### DIFF
--- a/ionc/ion_reader_text.c
+++ b/ionc/ion_reader_text.c
@@ -745,6 +745,8 @@ iERR _ion_reader_text_step_in(ION_READER *preader)
         text->_state = IPS_BEFORE_UTA;
     }
 
+    IONCHECK(_ion_scanner_reset(&text->_scanner));
+
     iRETURN;
 }
 


### PR DESCRIPTION
This resolves an issue where, when using the Ion text reader, the first element of a container in the initial position of a stream would yield an offset value equal to the offset value of the container, so later seeks would end up positioned on the container, rather than the value. This is different than the behavior of the Ion binary reader, which returns offsets as expected.

After this change, the text and binary readers behave identically in this situation.

There are two (really, four) tests in this commit. `ReaderHandlesInitialUnannotatedContainerValueOffsetSeek` fails when executed with a text reader before this change, but all 4 of the tests pass after the change is applied).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.