### PR TITLE
Fix g_ion_alloc_page_list initialization issue.

### DIFF
--- a/ionc/ion_alloc.h
+++ b/ionc/ion_alloc.h
@@ -77,7 +77,10 @@ ION_API_EXPORT void        ion_alloc_free      (void *ptr);
 //#ifndef ION_ALLOCATION_BLOCK_SIZE
 //#define ION_ALLOCATION_BLOCK_SIZE DEFAULT_BLOCK_SIZE
 //#endif
-    
+
+// DEFAULT_BLOCK_SIZE was defined in ion_internal.h, but needed for initializing g_ion_alloc_page_list.
+#define DEFAULT_BLOCK_SIZE (1024*64)
+
 // force aligned allocations
 #ifndef ALLOC_ALIGNMENT
 #define ALLOC_ALIGNMENT 4
@@ -157,7 +160,7 @@ struct _ion_alloc_page_list
 
 GLOBAL THREAD_LOCAL_STORAGE ION_ALLOC_PAGE_LIST g_ion_alloc_page_list
 #ifdef INIT_STATICS
-= { ION_ALLOC_PAGE_POOL_PAGE_SIZE_NONE, 0, 0, NULL }
+= { ION_ALLOC_PAGE_POOL_DEFAULT_PAGE_SIZE, 0, ION_ALLOC_PAGE_POOL_DEFAULT_LIMIT, NULL }
 #endif
 ;
 

--- a/ionc/ion_allocation.c
+++ b/ionc/ion_allocation.c
@@ -41,10 +41,6 @@ void *_ion_alloc_owner(SIZE len)
     void                 *owner;
     ION_ALLOCATION_CHAIN *new_chain;
 
-    if (g_ion_alloc_page_list.page_size == ION_ALLOC_PAGE_POOL_PAGE_SIZE_NONE) {
-        ion_initialize_page_pool(ION_ALLOC_PAGE_POOL_DEFAULT_PAGE_SIZE, ION_ALLOC_PAGE_POOL_DEFAULT_LIMIT);
-    }
-
     new_chain = _ion_alloc_block(len);
     if (!new_chain) return NULL;
 
@@ -224,7 +220,8 @@ void _ion_free_block(ION_ALLOCATION_CHAIN *pblock)
 void ion_initialize_page_pool(SIZE page_size, int free_page_limit)
 {
     // once the page list is in use, you can't change your mind
-    if (g_ion_alloc_page_list.page_size != ION_ALLOC_PAGE_POOL_PAGE_SIZE_NONE)
+    // This is changed, because g_ion_alloc_page_list.page_size is initialized to ION_ALLOC_PAGE_POOL_DEFAULT_PAGE_SIZE.
+    if (g_ion_alloc_page_list.page_size == ION_ALLOC_PAGE_POOL_DEFAULT_PAGE_SIZE)
     {
         return;
     }

--- a/ionc/ion_internal.h
+++ b/ionc/ion_internal.h
@@ -81,8 +81,9 @@ typedef struct _ion_header {
 #include "ion_index.h"
 #include "ion_stream_impl.h" 
 
+// DEFAULT_BLOCK_SIZE is moved to ion_alloc.h, included above.
 //#define DEFAULT_BLOCK_SIZE (256*1024) /* was 128*1024*1024 */
-#define DEFAULT_BLOCK_SIZE (1024*64)
+//#define DEFAULT_BLOCK_SIZE (1024*64)
 
 // TODO: static final boolean _debug_on = false;
 #define ASSERT( x ) while (!(x)) { ion_helper_breakpoint(), assert( x ); }


### PR DESCRIPTION
g_ion_alloc_page_list sometimes not initialized:
    - when symbol table is created first.
    - in multi-threaded use case, when ionc stream is initialized on one thread, and used from another one.
The initialization function is called with constant values, so the initialization list of g_ion_alloc_page_list is changed for using these constants.
Related to https://github.com/amzn/ion-c/issues/181

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
