### PR TITLE
Fix issue #235 (Negative Binary Literals are Positive)

### DIFF
--- a/ionc/ion_reader_text.c
+++ b/ionc/ion_reader_text.c
@@ -1373,7 +1373,9 @@ iERR _ion_reader_text_read_int64(ION_READER *preader, int64_t *p_value)
         FAILWITH(IERR_NULL_VALUE);
     }
 
-    if (text->_value_sub_type == IST_INT_NEG_DECIMAL || text->_value_sub_type == IST_INT_NEG_HEX) {
+    if (text->_value_sub_type == IST_INT_NEG_DECIMAL
+     || text->_value_sub_type == IST_INT_NEG_HEX
+     || text->_value_sub_type == IST_INT_NEG_BINARY) {
         sign = TRUE;
     }
 

--- a/test/test_ion_text.cpp
+++ b/test/test_ion_text.cpp
@@ -706,3 +706,17 @@ TEST(IonTextStruct, FailsOnFieldNameWithNoValueInMiddle) {
     ION_ASSERT_OK(ion_reader_next(reader, &type));
     ASSERT_EQ(IERR_INVALID_SYNTAX, ion_reader_next(reader, &type));
 }
+
+// reproduction for amzn/ion-c#235
+TEST(IonTextInt, BinaryLiterals) {
+    const char *ion_text = "-0b100";
+    hREADER  reader;
+    ION_TYPE type;
+    int64_t value;
+
+    ION_ASSERT_OK(ion_test_new_text_reader(ion_text, &reader));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_INT, type);
+    ION_ASSERT_OK(ion_reader_read_int64(reader, &value));
+    ASSERT_EQ(-4, value);
+}


### PR DESCRIPTION
**Issue summary:** 

Issue #235: Negative binary literals are read as its positive magnitude, e.g. -0b100 read as 4 instead of -4.

The root of the issue is because we didn't change 'sign' when we detects negative binary number.


**Test:**
<img width="537" alt="Screen Shot 2021-04-27 at 5 47 21 PM" src="https://user-images.githubusercontent.com/67451029/116329633-a3c23b80-a780-11eb-95d0-48f7835e93d2.png">

Also worked for below two files: 
```
"ion-tests/iontestdata/good/equivs/binaryInts.ion",
"ion-tests/iontestdata/good/equivs/intsWithUnderscores.ion",
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
