### PR TITLE
Respect indent_size and indent_with_tabs options in ion_writer_text

### DIFF
--- a/ionc/include/ionc/ion_writer.h
+++ b/ionc/include/ionc/ion_writer.h
@@ -43,7 +43,7 @@ typedef struct _ion_writer_options
      */
     BOOL indent_with_tabs;
 
-    /** Sets the default indent amount (default is 2)
+    /** Sets indent amount for pretty printing. Defaults to 2. Ignored if indent_with_tabs is true.
      *
      */
     SIZE indent_size;

--- a/ionc/ion_writer_text.c
+++ b/ionc/ion_writer_text.c
@@ -167,9 +167,15 @@ iERR _ion_writer_text_print_leading_white_space(ION_WRITER *pwriter)
     iENTER;
     int ii;
 
-    for (ii=0; ii<TEXTWRITER(pwriter)->_top; ii++) {
-        ION_TEXT_WRITER_APPEND_CHAR(' ');
-        ION_TEXT_WRITER_APPEND_CHAR(' ');
+    if (pwriter->options.indent_with_tabs) {
+        for (ii = 0; ii < TEXTWRITER(pwriter)->_top; ii++) {
+            ION_TEXT_WRITER_APPEND_CHAR('\t');
+        }
+    }
+    else {
+        for (ii = 0; ii < TEXTWRITER(pwriter)->_top * pwriter->options.indent_size; ii++) {
+            ION_TEXT_WRITER_APPEND_CHAR(' ');
+        }
     }
 
     iRETURN;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
ION_WRITER_OPTIONS defines indent_size and indent_with_tabs members, which I guess are supposed to control pretty printing in ion_writer_text. Previously these options were ignored by the text writer, my change aims to fix this.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
