### PR TITLE
Fixes `static` buffer to use `THREAD_LOCAL_STORAGE`.

### DIFF
--- a/ionc/ion_helpers.c
+++ b/ionc/ion_helpers.c
@@ -194,7 +194,7 @@ void _ion_writer_text_write_blob_make_base64_image(int triple, char *output)
 
 char *_ion_writer_get_control_escape_string(int c)
 {
-    static char hex_buffer[5];
+    static THREAD_LOCAL_STORAGE char hex_buffer[5];
     char *image;
 
     switch (c) {


### PR DESCRIPTION
`_ion_writer_get_control_escape_string` uses a function scoped `static`
storage class variable.  If two threads write an escape string at the
same time there is a data race.

See amzn/ion-rust#238.

Using `ion-rs` Testing with `while cargo test lob -- --test 'loader*' --test-threads 32; do true; done` without this patch can get a failure for this path pretty quickly.  With this patch, I am testing to see if I can run this overnight without problem.  I grant that this is not enough to _prove_ that the bug is fixed, but it should at least give us some confidence.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
