### PR TITLE
adds changes for correctly setting stream position when error occurs while reading binary int64

### DIFF
--- a/ionc/ion_reader_binary.c
+++ b/ionc/ion_reader_binary.c
@@ -969,7 +969,7 @@ iERR _ion_reader_binary_read_int64(ION_READER *preader, int64_t *p_value)
 {
     iENTER;
     ION_BINARY_READER *binary;
-    int                tid, len;
+    int                tid, len, i;
     uint64_t           unsignedInt64 = 0;
     BOOL               is_negative;
     BOOL               is_null;
@@ -1006,7 +1006,17 @@ iERR _ion_reader_binary_read_int64(ION_READER *preader, int64_t *p_value)
     IONCHECK(ion_binary_read_uint_64(preader->istream, len, &unsignedInt64));
 
     is_negative = (tid == TID_NEG_INT)? TRUE: FALSE;
-    IONCHECK(cast_to_int64(unsignedInt64, is_negative, p_value));
+    iERR result = cast_to_int64(unsignedInt64, is_negative, p_value);
+
+    // if an error is thrown reset reader stream's current pointer to the beginning of current value again
+    if(result) {
+        i = len;
+        while(i--) {
+            preader->istream->_curr--;
+        }
+        FAILWITH(result);
+    }
+
     if (is_negative && *p_value == 0) {
         FAILWITH(IERR_INVALID_BINARY);
     }

--- a/ionc/ion_reader_binary.c
+++ b/ionc/ion_reader_binary.c
@@ -969,7 +969,7 @@ iERR _ion_reader_binary_read_int64(ION_READER *preader, int64_t *p_value)
 {
     iENTER;
     ION_BINARY_READER *binary;
-    int                tid, len, i;
+    int                tid, len;
     uint64_t           unsignedInt64 = 0;
     BOOL               is_negative;
     BOOL               is_null;
@@ -1006,15 +1006,15 @@ iERR _ion_reader_binary_read_int64(ION_READER *preader, int64_t *p_value)
     IONCHECK(ion_binary_read_uint_64(preader->istream, len, &unsignedInt64));
 
     is_negative = (tid == TID_NEG_INT)? TRUE: FALSE;
-    iERR result = cast_to_int64(unsignedInt64, is_negative, p_value);
 
-    // if an error is thrown reset reader stream's current pointer to the beginning of current value again
-    if(result) {
-        i = len;
-        while(i--) {
-            preader->istream->_curr--;
+    {
+        iERR cast_result = cast_to_int64(unsignedInt64, is_negative, p_value);
+
+        // if an error is thrown reset reader stream's current pointer to the beginning of current value again
+        if (cast_result :!= IERR_OK) {
+            preader->istream->_curr -= len;
+            FAILWITH(cast_result);
         }
-        FAILWITH(result);
     }
 
     if (is_negative && *p_value == 0) {

--- a/ionc/ion_reader_binary.c
+++ b/ionc/ion_reader_binary.c
@@ -1011,7 +1011,7 @@ iERR _ion_reader_binary_read_int64(ION_READER *preader, int64_t *p_value)
         iERR cast_result = cast_to_int64(unsignedInt64, is_negative, p_value);
 
         // if an error is thrown reset reader stream's current pointer to the beginning of current value again
-        if (cast_result :!= IERR_OK) {
+        if (cast_result != IERR_OK) {
             preader->istream->_curr -= len;
             FAILWITH(cast_result);
         }

--- a/test/test_ion_binary.cpp
+++ b/test/test_ion_binary.cpp
@@ -429,9 +429,12 @@ void test_ion_binary_reader_threshold_for_int64(BYTE *data, size_t len, char *ac
     ASSERT_STREQ(actual_value, int_str);
 }
 
-TEST(IonBinaryReader, ReaderThresholdForInt64) {
+TEST(IonBinaryReader, ReaderPositiveThresholdForInt64) {
     test_ion_binary_reader_threshold_for_int64((BYTE *)"\xE0\x01\x00\xEA\x28\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF", 13, "18446744073709551615");
-    test_ion_binary_reader_threshold_for_int64((BYTE *)"\xE0\x01\x00\xEA\x39\x00\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF", 14, "-18446744073709551615");
+}
+
+TEST(IonBinaryReader, ReaderNegativeThresholdForInt64) {
+    test_ion_binary_reader_threshold_for_int64((BYTE *)"\xE0\x01\x00\xEA\x38\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF", 13, "-18446744073709551615");
 }
 
 void test_ion_binary_reader_requires_timestamp_fraction_less_than_one(BYTE *data, size_t len) {


### PR DESCRIPTION
*Description of changes:*
This PR works on setting stream position correctly when error occurs in reading binary int64 value.

*Changes:*
- Changed reader method for binary int64 value to set the position of stream back to the start of value in order to not consume it in error cases.

*Test:*
- Added tests for checking the edge case(integer of size 8 bytes) that doesn't fit in int64 throwing overflow error and then reading it as big integer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
