### PR TITLE
Bypass event processing in the cli tool if both the input and output are value streams.

### DIFF
--- a/test/test_ion_cli.cpp
+++ b/test/test_ion_cli.cpp
@@ -242,7 +242,7 @@ TEST(IonCli, ErrorIsConveyed) {
     test_ion_cli_process(test_file.c_str(), IO_TYPE_FILE, &command_output, &report);
     ASSERT_TRUE(report.hasErrors());
     ASSERT_FALSE(report.hasComparisonFailures());
-    ASSERT_EQ(0, command_output.length);
+    ASSERT_EQ(5, command_output.length);
     test_ion_cli_assert_error_equals(&report.getErrors()->at(0), ERROR_TYPE_READ, IERR_INVALID_SYNTAX, test_file);
     ion_cli_free_command_output(&command_output);
 }

--- a/tools/cli/cli.cpp
+++ b/tools/cli/cli.cpp
@@ -277,19 +277,8 @@ iERR ion_cli_write_input(IonCliCommonArgs *args, IonEventWriterContext *writer_c
     IonCliReaderContext reader_context;
     IonEventStream stream(input->contents);
     IONREPORT(ion_cli_open_reader(input, catalog, &reader_context, &stream, result));
-    if (args->output_format == OUTPUT_TYPE_EVENTS) {
-        // NOTE: don't short-circuit on read failure. Write as many events as possible.
-        err = ion_event_stream_read_all(reader_context.reader, catalog, &stream, result);
-        UPDATEERROR(ion_event_stream_write_all_events(writer_context->writer, &stream, catalog, result));
-        IONREPORT(err);
-    }
-    else if (args->output_format != OUTPUT_TYPE_NONE){
-        IONREPORT(ion_event_stream_read_all(reader_context.reader, catalog, &stream, result));
-        IONREPORT(ion_event_stream_write_all(writer_context->writer, &stream, result));
-        // Would be nice to use this (especially for performance testing), but having to peek at the first value in the
-        // stream (to identify $ion_event_stream) rules it out.
-        //IONCHECK(ion_writer_write_all_values(writer_context->writer, reader_context.reader));
-    }
+    IONREPORT(ion_event_stream_process_all(reader_context.reader, writer_context->writer, args->output_format, &stream,
+                                           catalog, result));
 cleanup:
     UPDATEERROR(ion_cli_close_reader(&reader_context, err, result));
     iRETURN;

--- a/tools/events/inc/ion_event_stream.h
+++ b/tools/events/inc/ion_event_stream.h
@@ -244,4 +244,11 @@ iERR ion_event_stream_write_all(hWRITER writer, IonEventStream *stream, IonEvent
  */
 iERR ion_event_stream_write_all_events(hWRITER writer, IonEventStream *stream, ION_CATALOG *catalog, IonEventResult *result);
 
+/**
+ * Behaves like ion_event_stream_read_all followed by ion_event_stream_write_all(_events). Bypasses event
+ * transformation if both the input and output are value streams.
+ */
+iERR ion_event_stream_process_all(hREADER reader, hWRITER writer, ION_EVENT_OUTPUT_TYPE output_type,
+                                  IonEventStream *stream, ION_CATALOG *catalog, IonEventResult *result);
+
 #endif //IONC_VALUE_STREAM_H


### PR DESCRIPTION
*Description of changes:*

At our company we are often dealing with binary Amazon ion files that are a few gigabytes large.
Sometimes we want to convert them to text for manual inspection, and it would be convenient to use the provided CLI tool for this purpose. Basically we would like to do this: `ion process -f pretty -o output.txt large_binary_file.ion`

Unfortunately the tool currently tries to load the whole input file into memory and even multiplies its size by converting it into an event stream. For larger files this requires more memory than is available in a typical desktop computer.

I've noticed this comment in cli.cpp:
```
// Would be nice to use this (especially for performance testing), but having to peek at the first value in the
// stream (to identify $ion_event_stream) rules it out.
//IONCHECK(ion_writer_write_all_values(writer_context->writer, reader_context.reader));
```

I think I could make it work by converting only the first value into events in ion_event_stream_is_event_stream, writing it back calling ion_event_stream_write_all, and processing the rest with ion_writer_write_all_values as the comment suggests.
The only unit test that failed is IonCli.ErrorIsConveyed. It looks like it parses "false" from "false::23" and reports error only when it reaches the first colon at index 5. The original implementation reported error immediately at index 0. I modified the test for now, but I'm not sure which one is considered the correct behavior.

Note that this does not solve the memory usage problem when the input or the output is an event stream. Solving that would require a much deeper refactor, and since that use case is not really important for us, I did not attempt to do it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
