### PR TITLE
Bugfix negative zero for decimal to int

### DIFF
--- a/ionc/ion_int.c
+++ b/ionc/ion_int.c
@@ -680,13 +680,14 @@ iERR ion_int_from_decimal(ION_INT *iint, const decQuad *p_value, decContext *con
         FAILWITH(IERR_INVALID_ARG);
     }
 
-    // special case since zero is so common (and quick to test and set)
-    if (decQuadIsZero(p_value)) {
+    is_neg = decQuadIsSigned(p_value);
+
+    // special case since positive zero is so common (and quick to test and set)
+    if (decQuadIsZero(p_value) && !is_neg) {
         IONCHECK(_ion_int_zero(iint));
         SUCCEED();
     }
 
-    is_neg = decQuadIsSigned(p_value);
     decQuadCopyAbs(&temp1, p_value);
 
     decimal_digits = decQuadDigits(&temp1);


### PR DESCRIPTION
*Issue #, if available:*

Related to https://github.com/amzn/ion-rust/issues/83.

*Description of changes:*

Before this commit, -0d0 to int would lose the sign. This is because the
special case for zero triggers (negative zero **is** zero) but writes
out the wrong integer (`_ion_int_zero` has a signum=0).

A note on testing: I couldn't find an obvious place to test this, but I did test it manually as part of my changes to ion-rust. Importantly, after this change I get back an IonInt that has a signum of -1. It looks like this:


```
IonIntPtr { value: 0x7fe6b9600330 }, sign -1
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.