### PR TITLE
Fixes an issue where offset capture of a multi-field struct was incor…

### DIFF
--- a/ionc/ion_reader.c
+++ b/ionc/ion_reader.c
@@ -1986,6 +1986,11 @@ iERR _ion_reader_get_position_helper(ION_READER *preader, int64_t *p_bytes, int3
  *  ion version marker and the initial local symbol table (if one
  *  is present).  At that point the symbol table will be current
  *  and later seek's will have an appropriate symbol table to use.
+ *
+ *  Note that when seeking directly into a struct, the offsets
+ *  provided by calls to ion_reader_get_value_offset point to the
+ *  beginning of the value, not the field, and therefore the field
+ *  name will not be accessible via ion_reader_get_field_name.
  */
 iERR ion_reader_seek(hREADER hreader, POSITION offset, SIZE length)
 {

--- a/ionc/ion_reader_text.c
+++ b/ionc/ion_reader_text.c
@@ -282,7 +282,7 @@ iERR _ion_reader_text_next(ION_READER *preader, ION_TYPE *p_value_type)
         text->_value_start = text->_scanner._value_start;
     }
     else if (text->_state == IPS_BEFORE_FIELDNAME) {
-        // In a struct, value_start will be positive, but positioned at the field name, not the value
+        // In latter fields in a struct, value_start will be positive, but positioned at the field name, not the value
         text->_value_start = text->_scanner._value_start;
     }
     else {

--- a/ionc/ion_reader_text.c
+++ b/ionc/ion_reader_text.c
@@ -281,6 +281,10 @@ iERR _ion_reader_text_next(ION_READER *preader, ION_TYPE *p_value_type)
         // The start position of the value was not known at the start of this function. At this point it must be known.
         text->_value_start = text->_scanner._value_start;
     }
+    else if (text->_state == IPS_BEFORE_FIELDNAME) {
+        // In a struct, value_start will be positive, but positioned at the field name, not the value
+        text->_value_start = text->_scanner._value_start;
+    }
     else {
         text->_value_start = value_start;
     }

--- a/test/test_ion_reader_seek.cpp
+++ b/test/test_ion_reader_seek.cpp
@@ -721,16 +721,10 @@ TEST_P(TextAndBinary, ReaderPopulatesStructFieldsOnSeek) {
 
     ION_ASSERT_OK(ion_reader_next(reader, &type));
     ASSERT_EQ(tid_SYMBOL, type);
-
-    // Real code would probably capture these, but it doesn't affect the issue
-    //ION_ASSERT_OK(ion_reader_get_field_name(reader, &read_field1));
     ION_ASSERT_OK(ion_reader_get_value_offset(reader, &pos_field1));
 
     ION_ASSERT_OK(ion_reader_next(reader, &type));
     ASSERT_EQ(tid_SYMBOL, type);
-
-    // Real code would probably capture these, but it doesn't affect the issue
-    //ION_ASSERT_OK(ion_reader_get_field_name(reader, &read_field2));
     ION_ASSERT_OK(ion_reader_get_value_offset(reader, &pos_field2));
 
     ION_ASSERT_OK(ion_reader_step_out(reader));

--- a/test/test_ion_reader_seek.cpp
+++ b/test/test_ion_reader_seek.cpp
@@ -686,20 +686,21 @@ TEST_P(TextAndBinary, ReaderPopulatesStructFieldsOnSeek) {
 
     hWRITER writer = NULL;
     ION_STREAM *ion_stream = NULL;
-    ION_STRING field1, field2, value;
+    ION_STRING field1, field2, value1, value2;
     BYTE *data;
     SIZE data_length;
 
     // {field1:val1,field2:val2}
     ion_string_from_cstr("field1", &field1);
-    ion_string_from_cstr("value", &value);
+    ion_string_from_cstr("value1", &value1);
     ion_string_from_cstr("field2", &field2);
+    ion_string_from_cstr("value2", &value2);
     ION_ASSERT_OK(ion_test_new_writer(&writer, &ion_stream, is_binary));
     ION_ASSERT_OK(ion_writer_start_container(writer, tid_STRUCT));
     ION_ASSERT_OK(ion_writer_write_field_name(writer, &field1));
-    ION_ASSERT_OK(ion_writer_write_symbol(writer, &value));
+    ION_ASSERT_OK(ion_writer_write_symbol(writer, &value1));
     ION_ASSERT_OK(ion_writer_write_field_name(writer, &field2));
-    ION_ASSERT_OK(ion_writer_write_symbol(writer, &value));
+    ION_ASSERT_OK(ion_writer_write_symbol(writer, &value2));
     ION_ASSERT_OK(ion_writer_finish_container(writer));
     ION_ASSERT_OK(ion_test_writer_get_bytes(writer, ion_stream, &data, &data_length));
 
@@ -754,6 +755,6 @@ TEST_P(TextAndBinary, ReaderPopulatesStructFieldsOnSeek) {
     // Assert:
 
     // Easy assertions: there's only one value, "value," and we should have read it both times
-    assertStringsEqual((char *)value.value, cread_val1, strlen(cread_val1));
-    assertStringsEqual((char *)value.value, cread_val2, strlen(cread_val2));
+    assertStringsEqual((char *)value1.value, cread_val1, strlen(cread_val1));
+    assertStringsEqual((char *)value2.value, cread_val2, strlen(cread_val2));
 }


### PR DESCRIPTION
Fixes an issue where offset capture of a multi-field struct was incorrectly returning field name positions instead of value positions

*Description of changes:*

This adds a condition to the resetting of the `value_start` position during the `_next` operation to bring the behavior of the text reader in line with the binary reader when doing offset capture.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
