### PR TITLE
Fixes a memory leak in binary writer.

### DIFF
--- a/ionc/ion_writer_binary.c
+++ b/ionc/ion_writer_binary.c
@@ -1229,6 +1229,7 @@ iERR _ion_writer_binary_close(ION_WRITER *pwriter)
     }
 
     IONCHECK(ion_stream_flush(pwriter->output));
+    IONCHECK(ion_stream_close(bwriter->_value_stream));
 
     iRETURN;
 }


### PR DESCRIPTION
While binary writer is freed, the underlying value_stream is not released which causes a memory leak issue.

My first reaction when I see the issue was if this is something should be released manually. After taking a look at the [field](https://github.com/amzn/ion-c/blob/master/ionc/ion_writer_impl.h#L125) and where it's [initialized](https://github.com/amzn/ion-c/blob/master/ionc/ion_writer_binary.c#L74). It's a temporary stream used by the ion_binary_writer and need to be released when writer is freed.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
