### PR TITLE
fix #221 - Ion binary floating point exception

### DIFF
--- a/tools/events/ion_event_util.cpp
+++ b/tools/events/ion_event_util.cpp
@@ -22,7 +22,7 @@ decContext g_IonEventDecimalContext = {
         DEC_MAX_MATH,                   // max exponent
         -DEC_MAX_MATH,                  // min exponent
         DEC_ROUND_HALF_EVEN,            // rounding mode
-        DEC_Errors,                     // trap conditions
+        0,                              // trap conditions
         0,                              // status flags
         0                               // apply exponent clamp?
 };


### PR DESCRIPTION
The global decContext `g_IonEventDecimalContext` has traps set to
DEC_Errors, which wouldn't be set if `decContextDefault()` would be
used with any `kind` but DEC_INIT_BASE.

*Issue #, if available:* #221

*Description of changes:*
Set  `g_IonEventDecimalContext.traps` to 0 (zero).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
