### PR TITLE
Fixes writer max annotation option doesn't work.

### DIFF
--- a/ionc/ion_writer.c
+++ b/ionc/ion_writer.c
@@ -1096,9 +1096,8 @@ iERR _ion_writer_add_annotation_helper(ION_WRITER *pwriter, ION_STRING *annotati
     ASSERT(annotation->length >= 0);
 
     if (!pwriter->annotations) {
-        int max_annotation_count = pwriter->options.max_annotation_count;
-        int final_max_annotation_count = (max_annotation_count > DEFAULT_ANNOTATION_LIMIT) ?
-                    max_annotation_count : DEFAULT_ANNOTATION_LIMIT;
+        int final_max_annotation_count = (pwriter->options.max_annotation_count > DEFAULT_ANNOTATION_LIMIT)
+                ? pwriter->options.max_annotation_count : DEFAULT_ANNOTATION_LIMIT;
         IONCHECK(_ion_writer_set_max_annotation_count_helper(pwriter, final_max_annotation_count));
     }
     else if (pwriter->annotation_curr >= pwriter->annotation_count) FAILWITH(IERR_TOO_MANY_ANNOTATIONS);

--- a/ionc/ion_writer.c
+++ b/ionc/ion_writer.c
@@ -274,7 +274,9 @@ iERR _ion_writer_open_helper(ION_WRITER **p_pwriter, ION_STREAM *stream, ION_WRI
         writer_type = ion_type_text_writer;
     }
 
-    IONCHECK(ion_temp_buffer_init(pwriter, &pwriter->temp_buffer, ION_WRITER_TEMP_BUFFER_DEFAULT));
+    // calculate annotations size by writer option's max_annotation_count field
+    SIZE temp_buffer_size = p_options->max_annotation_count * sizeof(ION_SYMBOL) + ION_WRITER_TEMP_BUFFER_DEFAULT;
+    IONCHECK(ion_temp_buffer_init(pwriter, &pwriter->temp_buffer, temp_buffer_size));
 
     // allocate a temp pool we can reset from time to time
     IONCHECK( _ion_writer_allocate_temp_pool( pwriter ));
@@ -1094,7 +1096,10 @@ iERR _ion_writer_add_annotation_helper(ION_WRITER *pwriter, ION_STRING *annotati
     ASSERT(annotation->length >= 0);
 
     if (!pwriter->annotations) {
-        IONCHECK(_ion_writer_set_max_annotation_count_helper(pwriter, DEFAULT_ANNOTATION_LIMIT));
+        int max_annotation_count = pwriter->options.max_annotation_count;
+        int final_max_annotation_count = (max_annotation_count > DEFAULT_ANNOTATION_LIMIT) ?
+                    max_annotation_count : DEFAULT_ANNOTATION_LIMIT;
+        IONCHECK(_ion_writer_set_max_annotation_count_helper(pwriter, final_max_annotation_count));
     }
     else if (pwriter->annotation_curr >= pwriter->annotation_count) FAILWITH(IERR_TOO_MANY_ANNOTATIONS);
 


### PR DESCRIPTION
### Description:

This PR is working on https://github.com/amzn/ion-python/issues/165 on ion-c layer and the fix of ion-python layer is [here](https://github.com/amzn/ion-python/pull/179).

### Step by step fix:

1.  The writer option's max annotation count is set when writer is initialized but never used. For example, I set max annotation count to 100 but it still writes at most 10 annotations. 
2. The root is because the writer always set annotations counts to default (10) when a writer writes the first annotation no matter how much we set for max_annotation_count. Code details is [here](https://github.com/amzn/ion-c/blob/master/ionc/ion_writer.c#L1096-L1098). Changed it to max_annotation_count as below (line 1099).
3. Then it raise an `IERR_NO_MEMORY` error when max_annotation_count is so large. The root is because we only allocate [default memory](https://github.com/amzn/ion-c/blob/master/ionc/ion_writer_impl.h#L48) (In this case, it's 1024 bytes) for [temp_buffer](https://github.com/amzn/ion-c/blob/master/ionc/ion_writer_impl.h#L144) where the annotation bytes is stored. The code details is [here](https://github.com/amzn/ion-c/blob/master/ionc/ion_writer.c#L277). So I calculated how much bytes we need for annotations: 
`p_options->max_annotation_count * sizeof(ION_SYMBOL)`
4. However, above three steps fix the ion-hash issue but fail some ion-c unit test. This is because the temp_buffer is not only used for annotation. For example, [ion_writer_text](https://github.com/amzn/ion-c/blob/master/ionc/ion_writer_text.c#L56-L63) reserved bytes from temp buffer twice. So, for example, if there are 100 bytes for annotations, we need to allocate more than 100 bytes for temp_buffer because it will be used somewhere else too.
5. So I separate the annotation calculation from the defaults bytes. I allocate `p_options->max_annotation_count * sizeof(ION_SYMBOL) + ION_WRITER_TEMP_BUFFER_DEFAULT` bytes for temp_buffer (see change below line 278) where it has `+ION_WRITER_TEMP_BUFFER_DEFAULT` at the end. So we calculate how many bytes annotations need first, then add `ION_WRITER_TEMP_BUFFER_DEFAULT` for other fields, which solves the issue and passes all tests.
6. Here might be a minor improvement. Before we allocate 1024 bytes for everything but now we separate annotations and other fields so it doesn't need default to 1024 bytes anymore. I think we can decrease the default value to 512 and add some comments explaining why. 

### Tests:

This change passes ion-c tests, ion-python tests and ion-hash-python tests.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
