### PR TITLE
Fixes a memory leak issue in reader API.

### DIFF
--- a/ionc/ion_reader.c
+++ b/ionc/ion_reader.c
@@ -1917,7 +1917,12 @@ iERR _ion_reader_process_possible_symbol_table(ION_READER *preader, BOOL *is_sym
         preader->_local_symtab_pool = owner;
         preader->_current_symtab = local;
     }
-    iRETURN;
+    SUCCEED();
+fail:
+    if (owner != NULL) {
+        ion_free_owner(owner);
+    }
+    return err;
 }
 
 iERR ion_reader_get_position(hREADER hreader, int64_t *p_bytes, int32_t *p_line, int32_t *p_offset)

--- a/ionc/ion_reader.c
+++ b/ionc/ion_reader.c
@@ -1917,7 +1917,7 @@ iERR _ion_reader_process_possible_symbol_table(ION_READER *preader, BOOL *is_sym
         preader->_local_symtab_pool = owner;
         preader->_current_symtab = local;
     }
-    SUCCEED();
+    return IERR_OK;
 fail:
     if (owner != NULL) {
         ion_free_owner(owner);


### PR DESCRIPTION
This issue was mentioned in https://github.com/amzn/ion-python/pull/172#issuecomment-968407484

Owner should be released when method **fails**.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
