### PR TITLE
fixup #260 i.e. f7d33b0

### DIFF
--- a/ionc/ion_writer.c
+++ b/ionc/ion_writer.c
@@ -275,7 +275,7 @@ iERR _ion_writer_open_helper(ION_WRITER **p_pwriter, ION_STREAM *stream, ION_WRI
     }
 
     // calculate annotations size by writer option's max_annotation_count field
-    SIZE temp_buffer_size = p_options->max_annotation_count * sizeof(ION_SYMBOL) + ION_WRITER_TEMP_BUFFER_DEFAULT;
+    SIZE temp_buffer_size = pwriter->options.max_annotation_count * sizeof(ION_SYMBOL) + ION_WRITER_TEMP_BUFFER_DEFAULT;
     IONCHECK(ion_temp_buffer_init(pwriter, &pwriter->temp_buffer, temp_buffer_size));
 
     // allocate a temp pool we can reset from time to time


### PR DESCRIPTION
*Issue #, if available:* #260

*Description of changes:*

The fix for #260 uses `p_options`, which might be `NULL`. 
Using `pwriter->options`, configured by any `p_options` instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
