### PR TITLE
Fix an issue where writer-owned resources were not being freed...

### DIFF
--- a/ionc/ion_writer_binary.c
+++ b/ionc/ion_writer_binary.c
@@ -1225,11 +1225,11 @@ iERR _ion_writer_binary_close(ION_WRITER *pwriter)
     patches = !ION_COLLECTION_IS_EMPTY(&bwriter->_patch_list);
     values  = ion_stream_get_position(bwriter->_value_stream) != 0;
     if (patches || values) {
-        IONCHECK(_ion_writer_binary_flush_to_output(pwriter));
+        UPDATEERROR(_ion_writer_binary_flush_to_output(pwriter));
     }
 
-    IONCHECK(ion_stream_flush(pwriter->output));
-    IONCHECK(ion_stream_close(bwriter->_value_stream));
+    UPDATEERROR(ion_stream_flush(pwriter->output));
+    UPDATEERROR(ion_stream_close(bwriter->_value_stream));
 
     iRETURN;
 }

--- a/test/test_ion_writer.cpp
+++ b/test/test_ion_writer.cpp
@@ -46,7 +46,7 @@ iERR ion_test_open_file_writer(hWRITER *writer, FILE *out, BOOL is_binary) {
     iRETURN;
 }
 
-TEST(WriterTest, ResourcesLeakedOnWriteToTooSmallBuffer)
+TEST_F(WriterTest, ResourcesNotLeakedOnWriteToTooSmallBuffer)
 {
     hWRITER writer = NULL;
     ION_WRITER_OPTIONS options = {

--- a/test/test_ion_writer.cpp
+++ b/test/test_ion_writer.cpp
@@ -49,9 +49,9 @@ iERR ion_test_open_file_writer(hWRITER *writer, FILE *out, BOOL is_binary) {
 TEST_F(WriterTest, ResourcesNotLeakedOnWriteToTooSmallBuffer)
 {
     hWRITER writer = NULL;
-    ION_WRITER_OPTIONS options = {
-        .output_as_binary = true
-    };
+    ION_WRITER_OPTIONS options;
+    ion_event_initialize_writer_options(&options);
+    options.output_as_binary = true;
 
     uint8_t buf[1];
     SIZE len;

--- a/test/test_ion_writer.cpp
+++ b/test/test_ion_writer.cpp
@@ -46,6 +46,23 @@ iERR ion_test_open_file_writer(hWRITER *writer, FILE *out, BOOL is_binary) {
     iRETURN;
 }
 
+TEST(WriterTest, ResourcesLeakedOnWriteToTooSmallBuffer)
+{
+    hWRITER writer = NULL;
+    ION_WRITER_OPTIONS options = {
+        .output_as_binary = true
+    };
+
+    uint8_t buf[1];
+    SIZE len;
+
+    ion_writer_open_buffer(&writer, buf, sizeof(buf), &options);
+    ion_writer_write_int32(writer, 1);
+    ion_writer_finish(writer, &len);
+
+    ASSERT_EQ(IERR_BUFFER_TOO_SMALL, ion_writer_close(writer));
+}
+
 TEST_F(WriterTest, BinaryWriterCloseMustFlushStream) {
     hWRITER writer = NULL;
 


### PR DESCRIPTION
... When encountering errors while closing the writer

*Issue #, if available:* N/A

*Description of changes:* Use `UPDATEERROR` instead of `IONCHECK` so that the error encountered while flushing a too-small output buffer is propagated without preventing the subsequent cleanup work.

Note: running this test under `valgrind` before the change is applied shows one 64 KiB page definitely lost. After the change, it's freed properly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.