### PR TITLE
fix #269 and #270

### DIFF
--- a/ionc/include/ionc/ion_collection.h
+++ b/ionc/include/ionc/ion_collection.h
@@ -27,7 +27,12 @@ typedef struct _ion_collection_node  ION_COLLECTION_NODE;
 typedef struct _ion_collection_node *ION_COLLECTION_CURSOR;
 
 
-#define IPCN_DATA_SIZE sizeof(void *)
+#define IPCN_DATA_SIZE      sizeof(void *)
+#define IPCN_OVERHEAD_SIZE  (sizeof(ION_COLLECTION_NODE) - IPCN_DATA_SIZE)
+
+#define IPCN_pNODE_TO_pDATA(x) (&((x)->_data[0]))
+#define IPCN_pDATA_TO_pNODE(x) ((ION_COLLECTION_NODE *) (((uint8_t *)(x)) - IPCN_OVERHEAD_SIZE))
+
 
 /** The node allocation scheme depends on this layout !
  * currently that there are only 2 members so it uses

--- a/ionc/ion_collection.c
+++ b/ionc/ion_collection.c
@@ -372,12 +372,14 @@ void _ion_collection_remove_node_helper(ION_COLLECTION *collection, ION_COLLECTI
     next = node->_next;
 
     if (next) {
+        ASSERT(next->_prev == node);
         next->_prev = prev;
     }
     else {
         collection->_tail = prev;
     }
     if (prev) {
+        ASSERT(prev->_next == node);
         prev->_next = next;
     }
     else {

--- a/ionc/ion_collection_impl.h
+++ b/ionc/ion_collection_impl.h
@@ -19,11 +19,6 @@
 extern "C" {
 #endif
 
-#define IPCN_OVERHEAD_SIZE  (sizeof(ION_COLLECTION_NODE) - IPCN_DATA_SIZE)
-
-#define IPCN_pNODE_TO_pDATA(x)    (&((x)->_data[0]))
-#define IPCN_pDATA_TO_pNODE(x) ((ION_COLLECTION_NODE *)(((uint8_t *)(x)) - IPCN_OVERHEAD_SIZE))
-
 typedef iERR (*ION_COPY_FN)(void *context, void *dst, void *src, int32_t data_size);
 typedef iERR (*ION_COMPARE_FN)(void *lhs, void *rhs, BOOL *is_equal);
 

--- a/test/gather_vectors.cpp
+++ b/test/gather_vectors.cpp
@@ -87,20 +87,13 @@ std::string find_ion_tests_path() {
     if (directory_exists("ion-tests")) {
         return "ion-tests";
     }
-    std::string from_test_directory = join_path(/*ion-c*/"..", "ion-tests");
-    if (directory_exists(from_test_directory)) {
-        return from_test_directory;
+    for (std::string parent_dir = ".."; directory_exists(parent_dir); parent_dir = join_path(parent_dir, "..")) {
+        std::string ion_tests_dir = join_path(parent_dir, "ion-tests");
+        if (directory_exists(ion_tests_dir)) {
+            return ion_tests_dir;
+        }
     }
-    std::string from_build_directory;
-    test_concat_filenames(&from_build_directory, 5, /*test*/"..", /*release*/"..", /*build*/"..", /*ion-c*/"..", "ion-tests");
-    if (directory_exists(from_build_directory)) {
-        return from_build_directory;
-    }
-    std::string from_out_of_source_test_directory;
-    test_concat_filenames(&from_out_of_source_test_directory, 3, /*e.g., cmake-build-debug*/"..", /*..ion-c*/"..", "ion-tests");
-    if (directory_exists(from_out_of_source_test_directory)) {
-        return from_out_of_source_test_directory;
-    }
+    // giving up
     return "";
 }
 

--- a/test/test_ion_symbol.cpp
+++ b/test/test_ion_symbol.cpp
@@ -1715,3 +1715,23 @@ TEST_P(BinaryAndTextTest, ReaderSkipsOverIVMBoundary) {
     ION_ASSERT_OK(ion_reader_next(reader, &type));
     ASSERT_EQ(tid_EOF, type);
 }
+
+TEST(IonSymbolTable, CanBeRemovedFromCatalog) {
+    ION_SYMBOL_TEST_POPULATE_CATALOG;
+    int32_t cnt;
+
+    ION_ASSERT_OK(ion_catalog_get_symbol_table_count(catalog, &cnt));
+    ASSERT_EQ(2, cnt);
+    ION_ASSERT_OK(ion_catalog_release_symbol_table(catalog, import1));
+    ION_ASSERT_OK(ion_catalog_get_symbol_table_count(catalog, &cnt));
+    ASSERT_EQ(1, cnt);
+    ION_ASSERT_OK(ion_catalog_release_symbol_table(catalog, import1));
+    ION_ASSERT_OK(ion_catalog_get_symbol_table_count(catalog, &cnt));
+    ASSERT_EQ(1, cnt);
+    ION_ASSERT_OK(ion_catalog_release_symbol_table(catalog, import2));
+    ION_ASSERT_OK(ion_catalog_get_symbol_table_count(catalog, &cnt));
+    ASSERT_EQ(0, cnt);
+    ION_ASSERT_OK(ion_catalog_release_symbol_table(catalog, import2));
+    ION_ASSERT_OK(ion_catalog_get_symbol_table_count(catalog, &cnt));
+    ASSERT_EQ(0, cnt);
+}


### PR DESCRIPTION
*Issue #, if available:* #269 and #270

*Description of changes:*
- Make macros used in ion_collection.h accessible.
- Fix ion_catalog's usage of `_ion_collection_remove`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
