### PR TITLE
Refactor the ION_SYMBOL_TABLE type to make it opaque

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ message(STATUS "Setting DECNUMBER max digits to 34")
 
 set(CMAKE_INSTALL_RPATH "$ORIGIN")
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 add_subdirectory(decNumber)
 add_subdirectory(ionc)

--- a/ionc/ion_catalog.c
+++ b/ionc/ion_catalog.c
@@ -236,7 +236,7 @@ iERR _ion_catalog_find_symbol_table_helper(ION_CATALOG *pcatalog, ION_STRING *na
     iRETURN;
 }
 
-iERR ion_catalog_find_best_match(hCATALOG hcatalog, iSTRING name, long version, ION_SYMBOL_TABLE **p_psymtab)
+iERR ion_catalog_find_best_match(hCATALOG hcatalog, iSTRING name, long version, hSYMTAB *p_symtab)
 {
     iENTER;
     ION_CATALOG      *catalog;
@@ -244,16 +244,16 @@ iERR ion_catalog_find_best_match(hCATALOG hcatalog, iSTRING name, long version, 
 
     if (hcatalog == NULL) FAILWITH(IERR_INVALID_ARG);
     if (ION_STRING_IS_NULL(name)) FAILWITH(IERR_INVALID_ARG);
-    if (p_psymtab == NULL) FAILWITH(IERR_INVALID_ARG);
+    if (p_symtab == NULL) FAILWITH(IERR_INVALID_ARG);
 
     catalog = HANDLE_TO_PTR(hcatalog, ION_CATALOG);
 
     IONCHECK(_ion_catalog_find_best_match_helper(catalog, name, version, -1, &symtab));
     if (symtab != NULL) {
-        *p_psymtab = PTR_TO_HANDLE(symtab);
+        *p_symtab = PTR_TO_HANDLE(symtab);
     }
     else {
-        *p_psymtab = NULL;
+        *p_symtab = NULL;
     }
     iRETURN;
 }

--- a/ionc/ion_catalog.c
+++ b/ionc/ion_catalog.c
@@ -131,22 +131,31 @@ iERR ion_catalog_add_symbol_table(hCATALOG hcatalog, hSYMTAB hsymtab)
 iERR _ion_catalog_add_symbol_table_helper(ION_CATALOG *pcatalog, ION_SYMBOL_TABLE *psymtab)
 {
     iENTER;
-    ION_SYMBOL_TABLE **ppsymtab, *pclone, *ptest = NULL;
+    ION_SYMBOL_TABLE **ppsymtab, *psystem, *pclone, *ptest = NULL;
+    ION_STRING         name;
+    int32_t            version;
+    hOWNER             owner;
 
     ASSERT(pcatalog != NULL);
     ASSERT(psymtab != NULL);
 
+    IONCHECK(ion_symbol_table_get_name(psymtab, &name));
+    IONCHECK(ion_symbol_table_get_version(psymtab, &version));
+
     // see if we already have it
-    IONCHECK(_ion_catalog_find_symbol_table_helper(pcatalog, &psymtab->name, psymtab->version, &ptest));
+    IONCHECK(_ion_catalog_find_symbol_table_helper(pcatalog, &name, version, &ptest));
     if (ptest != NULL) {
         SUCCEED();
     }
 
     // otherwise ...
 
+    IONCHECK(_ion_symbol_table_get_owner(psymtab, &owner));
+
     // if this catalog doesn't own it - we have to clone it
-    if (pcatalog->owner != psymtab->owner) {
-        IONCHECK(_ion_symbol_table_clone_with_owner_helper(&pclone, psymtab, pcatalog->owner, psymtab->system_symbol_table));
+    if (pcatalog->owner != owner) {
+        IONCHECK(_ion_symbol_table_get_system_symbol_table(psymtab, &psystem));
+        IONCHECK(_ion_symbol_table_clone_with_owner_and_system_table(psymtab, &pclone, pcatalog->owner, psystem));
         psymtab = pclone;
     }
 
@@ -182,18 +191,23 @@ iERR ion_catalog_find_symbol_table(hCATALOG hcatalog, iSTRING name, long version
     iRETURN;
 }
 
-iERR _ion_catalog_find_symbol_table_helper(ION_CATALOG *pcatalog, ION_STRING *name, int32_t version, ION_SYMBOL_TABLE **p_psymtab)
+iERR _ion_catalog_find_symbol_table_helper(ION_CATALOG *pcatalog, ION_STRING *name, int32_t version, hSYMTAB *p_symtab)
 {
     iENTER;
     ION_SYMBOL_TABLE        **ppsymtab, *psymtab, *found = NULL;
     ION_COLLECTION_CURSOR    symtab_cursor;
+    ION_STRING               symtab_name, system_symtab_name;
+    int32_t                  symtab_version, system_symtab_version;
 
     ASSERT(pcatalog != NULL);
     ASSERT(!ION_STRING_IS_NULL(name));
-    ASSERT(p_psymtab != NULL);
+    ASSERT(p_symtab != NULL);
 
-    if (version == pcatalog->system_symbol_table->version
-    && ION_STRING_EQUALS(name, &pcatalog->system_symbol_table->name)
+    IONCHECK(_ion_symbol_table_get_name_helper(pcatalog->system_symbol_table, &system_symtab_name));
+    IONCHECK(_ion_symbol_table_get_version_helper(pcatalog->system_symbol_table, &system_symtab_version));
+
+    if (version == system_symtab_version
+    && ION_STRING_EQUALS(name, &system_symtab_name)
     ) {
         found = pcatalog->system_symbol_table;
     }
@@ -203,8 +217,12 @@ iERR _ion_catalog_find_symbol_table_helper(ION_CATALOG *pcatalog, ION_STRING *na
             ION_COLLECTION_NEXT(symtab_cursor, ppsymtab);
             if (!ppsymtab) break;
             psymtab = *ppsymtab;
-            if (psymtab->version != version) continue;
-            if (ION_STRING_EQUALS(name, &psymtab->name)) {
+
+            IONCHECK(_ion_symbol_table_get_name_helper(psymtab, &symtab_name));
+            IONCHECK(_ion_symbol_table_get_version_helper(psymtab, &symtab_version));
+
+            if (symtab_version != version) continue;
+            if (ION_STRING_EQUALS(name, &symtab_name)) {
                 found = psymtab;
                 break;
             }
@@ -212,13 +230,13 @@ iERR _ion_catalog_find_symbol_table_helper(ION_CATALOG *pcatalog, ION_STRING *na
         ION_COLLECTION_CLOSE(symtab_cursor);
     }
 
-    *p_psymtab = found;
+    *p_symtab = PTR_TO_HANDLE(found);
     SUCCEED();
 
     iRETURN;
 }
 
-iERR ion_catalog_find_best_match(hCATALOG hcatalog, iSTRING name, long version, hSYMTAB *p_symtab)
+iERR ion_catalog_find_best_match(hCATALOG hcatalog, iSTRING name, long version, ION_SYMBOL_TABLE **p_psymtab)
 {
     iENTER;
     ION_CATALOG      *catalog;
@@ -226,16 +244,16 @@ iERR ion_catalog_find_best_match(hCATALOG hcatalog, iSTRING name, long version, 
 
     if (hcatalog == NULL) FAILWITH(IERR_INVALID_ARG);
     if (ION_STRING_IS_NULL(name)) FAILWITH(IERR_INVALID_ARG);
-    if (p_symtab == NULL) FAILWITH(IERR_INVALID_ARG);
+    if (p_psymtab == NULL) FAILWITH(IERR_INVALID_ARG);
 
     catalog = HANDLE_TO_PTR(hcatalog, ION_CATALOG);
 
     IONCHECK(_ion_catalog_find_best_match_helper(catalog, name, version, -1, &symtab));
     if (symtab != NULL) {
-        *p_symtab = PTR_TO_HANDLE(symtab);
+        *p_psymtab = PTR_TO_HANDLE(symtab);
     }
     else {
-        *p_symtab = NULL;
+        *p_psymtab = NULL;
     }
     iRETURN;
 }
@@ -243,7 +261,9 @@ iERR ion_catalog_find_best_match(hCATALOG hcatalog, iSTRING name, long version, 
 iERR _ion_catalog_find_best_match_helper(ION_CATALOG *pcatalog, ION_STRING *name, int32_t version, int32_t max_id, ION_SYMBOL_TABLE **p_psymtab)
 {
     iENTER;
-    ION_SYMBOL_TABLE      **ppsymtab, *psymtab, *best = NULL;
+    ION_SYMBOL_TABLE       **ppsymtab, *psymtab, *best = NULL;
+    ION_STRING               symtab_name, best_name, system_name;
+    int32_t                  symtab_version, best_version, system_version;
     ION_COLLECTION_CURSOR    symtab_cursor;
 
     ASSERT(pcatalog != NULL);
@@ -251,9 +271,9 @@ iERR _ion_catalog_find_best_match_helper(ION_CATALOG *pcatalog, ION_STRING *name
 
     // check for the system table first (mostly because it's not
     // really in the list of symbol tables in the catalog)
-    if (version == pcatalog->system_symbol_table->version
-    && ION_STRING_EQUALS(name, &pcatalog->system_symbol_table->name)
-    ) {
+    IONCHECK(_ion_symbol_table_get_name_helper(pcatalog->system_symbol_table, &system_name));
+    IONCHECK(_ion_symbol_table_get_version_helper(pcatalog->system_symbol_table, &system_version));
+    if (version == system_version && ION_STRING_EQUALS(name, &system_name)) {
         best = pcatalog->system_symbol_table;
     }
     else {
@@ -262,30 +282,37 @@ iERR _ion_catalog_find_best_match_helper(ION_CATALOG *pcatalog, ION_STRING *name
             ION_COLLECTION_NEXT(symtab_cursor, ppsymtab);
             if (!ppsymtab) break;
             psymtab = *ppsymtab;
-            if (!ION_STRING_EQUALS(name, &psymtab->name)) continue;
+            IONCHECK(_ion_symbol_table_get_name_helper(psymtab, &symtab_name));
+            if (!ION_STRING_EQUALS(name, &symtab_name)) continue;
             if (!best) {
                 best = psymtab;
             }
             else {
-                if (version > 0 && psymtab->version >= version) {
-                    if (psymtab->version <= best->version) {
+                IONCHECK(_ion_symbol_table_get_version_helper(psymtab, &symtab_version));
+                IONCHECK(_ion_symbol_table_get_version_helper(best, &best_version));
+                if (version > 0 && symtab_version >= version) {
+                    if (symtab_version <= best_version) {
                         best = psymtab;
                     }
                 }
-                else if (psymtab->version > best->version) {
+                else if (symtab_version > best_version) {
                     best = psymtab;
                 }
             }
-            if (best->version == version) break;
+            IONCHECK(_ion_symbol_table_get_version_helper(best, &best_version));
+            if (best_version == version) break;
         }
         ION_COLLECTION_CLOSE(symtab_cursor);
     }
-    if ((version > 0 && max_id <= ION_SYS_SYMBOL_MAX_ID_UNDEFINED) && (!best || best->version != version)) {
+
+    if (version > 0 && max_id <= ION_SYS_SYMBOL_MAX_ID_UNDEFINED) {
         // This isn't an exact match, and the max_id of the import is undefined.
         // NOTE: the ionizer APIs treat version == 0 as a special case where the user is requesting the latest
         // version. When called from other locations where version <= 1 means the version is undefined, the caller
         // should manually validate that the max_id isn't also undefined.
-        FAILWITHMSG(IERR_INVALID_SYMBOL_TABLE, "Invalid symbol table import: found undefined max_id without exact match.")
+        if (!best) FAILWITHMSG(IERR_INVALID_SYMBOL_TABLE, "Invalid symbol table import: found undefined max_id without exact match.");
+        IONCHECK(_ion_symbol_table_get_version_helper(best, &best_version));
+        if (best_version != version) FAILWITHMSG(IERR_INVALID_SYMBOL_TABLE, "Invalid symbol table import: found undefined max_id without exact match.");
     }
     if (p_psymtab) *p_psymtab = best;
     SUCCEED();
@@ -314,13 +341,20 @@ iERR _ion_catalog_release_symbol_table_helper(ION_CATALOG *pcatalog, ION_SYMBOL_
 {
     iENTER;
     ION_SYMBOL_TABLE *test;
+    ION_STRING        name;
+    int32_t           version;
+    hOWNER            owner;
 
     ASSERT(pcatalog != NULL);
     ASSERT(psymtab != NULL);
 
+    IONCHECK(_ion_symbol_table_get_owner(psymtab, &owner));
+
     // if this symbol table is "foreign" get "our copy" of the table
-    if (psymtab->owner != pcatalog->owner) {
-        IONCHECK(_ion_catalog_find_symbol_table_helper(pcatalog, &psymtab->name, psymtab->version, &test));
+    if (owner != pcatalog->owner) {
+        IONCHECK(ion_symbol_table_get_name(psymtab, &name));
+        IONCHECK(ion_symbol_table_get_version(psymtab, &version));
+        IONCHECK(_ion_catalog_find_symbol_table_helper(pcatalog, &name, version, &test));
         if (!test) {
             // TODO: again - is this just fine (the table's already released)
             //       or is this a problem to report

--- a/ionc/ion_reader_binary.c
+++ b/ionc/ion_reader_binary.c
@@ -565,13 +565,16 @@ iERR _ion_reader_binary_validate_symbol_token(ION_READER *preader, SID sid)
 {
     iENTER;
     ION_SYMBOL_TABLE *symbol_table;
+    SID max_id;
+
     ASSERT(preader);
 
     symbol_table = preader->_current_symtab;
     if (!symbol_table) {
         IONCHECK(ion_symbol_table_get_system_table(&symbol_table, ION_SYSTEM_VERSION));
     }
-    if (sid <= UNKNOWN_SID || sid > symbol_table->max_id) {
+    IONCHECK(_ion_symbol_table_get_max_sid_helper(symbol_table, &max_id));
+    if (sid <= UNKNOWN_SID || sid > max_id) {
         FAILWITH(IERR_INVALID_SYMBOL);
     }
     iRETURN;

--- a/ionc/ion_reader_text.c
+++ b/ionc/ion_reader_text.c
@@ -895,13 +895,16 @@ iERR _ion_reader_text_has_any_annotations(ION_READER *preader, BOOL *p_has_annot
 iERR _ion_reader_text_validate_symbol_token(ION_READER *preader, ION_SYMBOL *p_symbol) {
     iENTER;
     ION_SYMBOL_TABLE *symbol_table;
+    SID               max_id;
+
     ASSERT(preader);
     ASSERT(p_symbol);
 
     IONCHECK(_ion_reader_text_get_symbol_table(preader, &symbol_table));
     ASSERT(symbol_table);
 
-    if (p_symbol->sid > symbol_table->max_id) {
+    IONCHECK(_ion_symbol_table_get_max_sid_helper(symbol_table, &max_id));
+    if (p_symbol->sid > max_id) {
         FAILWITH(IERR_INVALID_SYMBOL);
     }
 

--- a/ionc/ion_symbol_table.c
+++ b/ionc/ion_symbol_table.c
@@ -35,9 +35,9 @@ struct _ion_symbol_table
     BOOL                has_local_symbols;
     ION_STRING          name;
     int32_t             version;
-    int32_t             max_id;         // the max SID of this symbol tables symbols, including shared symbols.
-    int32_t             min_local_id;   // the lowest local SID. Only valid if has_local_symbols is TRUE. by_id[0] holds this symbol.
-    int32_t             flushed_max_id; // the max SID already serialized. If symbols are appended, only the ones after this need to be serialized.
+    SID                 max_id;         // the max SID of this symbol tables symbols, including shared symbols.
+    SID                 min_local_id;   // the lowest local SID. Only valid if has_local_symbols is TRUE. by_id[0] holds this symbol.
+    SID                 flushed_max_id; // the max SID already serialized. If symbols are appended, only the ones after this need to be serialized.
     ION_COLLECTION      import_list;    // collection of ION_SYMBOL_TABLE_IMPORT
     ION_COLLECTION      symbols;        // collection of ION_SYMBOL
     ION_SYMBOL_TABLE   *system_symbol_table;
@@ -652,6 +652,7 @@ iERR _ion_symbol_table_load_helper(ION_READER *preader, hOWNER owner, ION_SYMBOL
             ION_COLLECTION_NEXT(symbol_cursor, symbol);
             if (!symbol) break;
             if (symbol->sid == UNKNOWN_SID) {
+                if (sid == INT32_MAX) FAILWITH(IERR_INVALID_SYMBOL);
                 sid++;
                 symbol->sid = sid;
             }

--- a/ionc/ion_symbol_table.c
+++ b/ionc/ion_symbol_table.c
@@ -22,6 +22,32 @@
 #include <string.h>
 //#include "hashfn.h"
 
+// strings are commonly used pointer length values
+// the referenced data is (should be) immutable
+// and is often shared or owned by others
+// the character encoding is utf-8 and both comparisons
+// and collation is only done as memcmp
+
+struct _ion_symbol_table
+{
+    void               *owner;          // this may be a reader, writer, catalog or itself
+    BOOL                is_locked;
+    BOOL                has_local_symbols;
+    ION_STRING          name;
+    int32_t             version;
+    int32_t             max_id;         // the max SID of this symbol tables symbols, including shared symbols.
+    int32_t             min_local_id;   // the lowest local SID. Only valid if has_local_symbols is TRUE. by_id[0] holds this symbol.
+    int32_t             flushed_max_id; // the max SID already serialized. If symbols are appended, only the ones after this need to be serialized.
+    ION_COLLECTION      import_list;    // collection of ION_SYMBOL_TABLE_IMPORT
+    ION_COLLECTION      symbols;        // collection of ION_SYMBOL
+    ION_SYMBOL_TABLE   *system_symbol_table;
+
+    int32_t             by_id_max;      // current size of by_id, which holds the local symbols, but NOT necessarily the number of declared local symbols.
+    ION_SYMBOL        **by_id;          // the local symbols. Accessing shared symbols requires delegate lookups to the imports.
+    ION_INDEX           by_name;        // the local symbols (by name).
+
+};
+
 iERR _ion_symbol_table_local_find_by_sid(ION_SYMBOL_TABLE *symtab, SID sid, ION_SYMBOL **p_sym);
 
 iERR ion_symbol_table_open(hSYMTAB *p_hsymtab, hOWNER owner)

--- a/ionc/ion_symbol_table.c
+++ b/ionc/ion_symbol_table.c
@@ -124,6 +124,24 @@ iERR ion_symbol_table_clone_with_owner(hSYMTAB hsymtab, hSYMTAB *p_hclone, hOWNE
     iRETURN;
 }
 
+iERR _ion_symbol_table_clone_with_owner_and_system_table(hSYMTAB hsymtab, hSYMTAB *p_hclone, hOWNER owner, hSYMTAB hsystem)
+{
+    iENTER;
+    ION_SYMBOL_TABLE *orig, *clone, *system;
+
+    if (hsymtab == NULL) FAILWITH(IERR_INVALID_ARG);
+    if (p_hclone == NULL) FAILWITH(IERR_INVALID_ARG);
+
+    orig = HANDLE_TO_PTR(hsymtab, ION_SYMBOL_TABLE);
+    system = HANDLE_TO_PTR(hsystem, ION_SYMBOL_TABLE);
+
+    IONCHECK(_ion_symbol_table_clone_with_owner_helper(&clone, orig, owner, system));
+
+    *p_hclone = PTR_TO_HANDLE(clone);
+
+    iRETURN;
+}
+
 iERR _ion_symbol_table_clone_with_owner_helper(ION_SYMBOL_TABLE **p_pclone, ION_SYMBOL_TABLE *orig, hOWNER owner, ION_SYMBOL_TABLE *system)
 {
     iENTER;
@@ -844,6 +862,20 @@ iERR _ion_symbol_table_get_type_helper(ION_SYMBOL_TABLE *symtab, ION_SYMBOL_TABL
     return IERR_OK;
 }
 
+iERR _ion_symbol_table_get_owner(hSYMTAB hsymtab, hOWNER *howner) {
+    iENTER;
+    ION_SYMBOL_TABLE *symtab;
+
+    if (hsymtab == NULL) FAILWITH(IERR_INVALID_ARG);
+    if (howner == NULL)  FAILWITH(IERR_INVALID_ARG);
+
+    symtab = HANDLE_TO_PTR(hsymtab, ION_SYMBOL_TABLE);
+
+    *howner = symtab->owner;
+
+    iRETURN;
+}
+
 iERR ion_symbol_table_get_name(hSYMTAB hsymtab, iSTRING p_name)
 {
     iENTER;
@@ -880,6 +912,21 @@ iERR ion_symbol_table_get_version(hSYMTAB hsymtab, int32_t *p_version)
     symtab = HANDLE_TO_PTR(hsymtab, ION_SYMBOL_TABLE);
 
     IONCHECK(_ion_symbol_table_get_version_helper(symtab, p_version));
+
+    iRETURN;
+}
+
+iERR _ion_symbol_table_get_system_symbol_table(hSYMTAB hsymtab, hSYMTAB *p_hsymtab_system)
+{
+    iENTER;
+    ION_SYMBOL_TABLE *symtab;
+
+    if (hsymtab == NULL) FAILWITH(IERR_INVALID_ARG);
+    if (p_hsymtab_system == NULL)  FAILWITH(IERR_INVALID_ARG);
+
+    symtab = HANDLE_TO_PTR(hsymtab, ION_SYMBOL_TABLE);
+
+    *p_hsymtab_system = symtab->system_symbol_table;
 
     iRETURN;
 }
@@ -924,6 +971,25 @@ iERR _ion_symbol_table_get_max_sid_helper(ION_SYMBOL_TABLE *symtab, SID *p_max_i
     }
 
     *p_max_id = max_id;
+
+    return IERR_OK;
+}
+
+iERR _ion_symbol_table_get_flushed_max_sid_helper(ION_SYMBOL_TABLE *symtab, SID *p_flushed_max_id)
+{
+    ASSERT(symtab != NULL);
+    ASSERT(p_flushed_max_id != NULL);
+
+    *p_flushed_max_id = symtab->flushed_max_id;
+
+    return IERR_OK;
+}
+
+iERR _ion_symbol_table_set_flushed_max_sid_helper(ION_SYMBOL_TABLE *symtab, SID flushed_max_id)
+{
+    ASSERT(symtab != NULL);
+
+    symtab->flushed_max_id = flushed_max_id;
 
     return IERR_OK;
 }
@@ -1038,6 +1104,16 @@ iERR _ion_symbol_table_get_imports_helper(ION_SYMBOL_TABLE *symtab, ION_COLLECTI
     ASSERT(p_imports != NULL);
 
     *p_imports = &symtab->import_list;
+
+    return IERR_OK;
+}
+
+iERR _ion_symbol_table_get_symbols_helper(ION_SYMBOL_TABLE *symtab, ION_COLLECTION **p_symbols)
+{
+    ASSERT(symtab != NULL);
+    ASSERT(p_symbols != NULL);
+
+    *p_symbols = &symtab->symbols;
 
     return IERR_OK;
 }

--- a/ionc/ion_symbol_table_impl.h
+++ b/ionc/ion_symbol_table_impl.h
@@ -19,32 +19,6 @@
 extern "C" {
 #endif
 
-// strings are commonly used pointer length values
-// the referenced data is (should be) immutable
-// and is often shared or owned by others
-// the character encoding is utf-8 and both comparisons
-// and collation is only done as memcmp
-
-struct _ion_symbol_table
-{
-    void               *owner;          // this may be a reader, writer, catalog or itself
-    BOOL                is_locked;
-    BOOL                has_local_symbols;
-    ION_STRING          name;
-    int32_t             version;
-    int32_t             max_id;         // the max SID of this symbol tables symbols, including shared symbols.
-    int32_t             min_local_id;   // the lowest local SID. Only valid if has_local_symbols is TRUE. by_id[0] holds this symbol.
-    int32_t             flushed_max_id; // the max SID already serialized. If symbols are appended, only the ones after this need to be serialized.
-    ION_COLLECTION      import_list;    // collection of ION_SYMBOL_TABLE_IMPORT
-    ION_COLLECTION      symbols;        // collection of ION_SYMBOL
-    ION_SYMBOL_TABLE   *system_symbol_table;
-
-    int32_t             by_id_max;      // current size of by_id, which holds the local symbols, but NOT necessarily the number of declared local symbols.
-    ION_SYMBOL        **by_id;          // the local symbols. Accessing shared symbols requires delegate lookups to the imports.
-    ION_INDEX           by_name;        // the local symbols (by name).
-
-};
-
 struct _ion_symbol_table_import_descriptor
 {
     ION_STRING name;

--- a/ionc/ion_symbol_table_impl.h
+++ b/ionc/ion_symbol_table_impl.h
@@ -70,6 +70,7 @@ BOOL _ion_symbol_needs_quotes(ION_STRING *p_str, BOOL symbol_identifiers_need_qu
 // internal (pointer based helpers) functions for symbol tables (in ion_symbol_table.c)
 iERR _ion_symbol_table_open_helper(ION_SYMBOL_TABLE **p_psymtab, hOWNER owner, ION_SYMBOL_TABLE *psystem);
 iERR _ion_symbol_table_clone_with_owner_helper(ION_SYMBOL_TABLE **p_pclone, ION_SYMBOL_TABLE *orig, hOWNER owner, ION_SYMBOL_TABLE *system_symtab);
+iERR _ion_symbol_table_clone_with_owner_and_system_table(hSYMTAB hsymtab, hSYMTAB *p_hclone, hOWNER owner, hSYMTAB hsystem);
 iERR _ion_symbol_table_get_system_symbol_helper(ION_SYMBOL_TABLE **pp_system_table, int32_t version);
 //iERR _ion_symbol_table_load_import_list_helper(ION_READER *preader, hOWNER owner, ION_SYMBOL_TABLE_IMPORT **p_head);
 iERR _ion_symbol_table_load_symbol_list_helper(ION_READER *preader, hOWNER owner, ION_SYMBOL **p_listhead);
@@ -78,13 +79,18 @@ iERR _ion_symbol_table_unload_helper(ION_SYMBOL_TABLE *symtab, ION_WRITER *pwrit
 iERR _ion_symbol_table_lock_helper(ION_SYMBOL_TABLE *symtab);
 iERR _ion_symbol_table_is_locked_helper(ION_SYMBOL_TABLE *symtab, BOOL *p_is_locked);
 iERR _ion_symbol_table_get_type_helper(ION_SYMBOL_TABLE *symtab, ION_SYMBOL_TABLE_TYPE *p_type);
+iERR _ion_symbol_table_get_owner(hSYMTAB hsymtab, hOWNER *howner);
+iERR _ion_symbol_table_get_system_symbol_table(hSYMTAB hsymtab, hSYMTAB *p_hsymtab_system);
 iERR _ion_symbol_table_get_name_helper(ION_SYMBOL_TABLE *symtab, ION_STRING *p_name);
 iERR _ion_symbol_table_get_version_helper(ION_SYMBOL_TABLE *symtab, int32_t *p_version);
 iERR _ion_symbol_table_get_max_sid_helper(ION_SYMBOL_TABLE *symtab, SID *p_max_id);
+iERR _ion_symbol_table_get_flushed_max_sid_helper(ION_SYMBOL_TABLE *symtab, SID *p_flushed_max_id);
 iERR _ion_symbol_table_set_name_helper(ION_SYMBOL_TABLE *symtab, ION_STRING *name);
 iERR _ion_symbol_table_set_version_helper(ION_SYMBOL_TABLE *symtab, int32_t version);
 iERR _ion_symbol_table_set_max_sid_helper(ION_SYMBOL_TABLE *symtab, SID max_id);
+iERR _ion_symbol_table_set_flushed_max_sid_helper(ION_SYMBOL_TABLE *symtab, SID flushed_max_id);
 iERR _ion_symbol_table_get_imports_helper(ION_SYMBOL_TABLE *symtab, ION_COLLECTION **p_imports);
+iERR _ion_symbol_table_get_symbols_helper(ION_SYMBOL_TABLE *symtab, ION_COLLECTION **p_symbols);
 iERR _ion_symbol_table_parse_possible_symbol_identifier(ION_SYMBOL_TABLE *symtab, ION_STRING *name, SID *p_sid, ION_SYMBOL **p_sym, BOOL *p_is_symbol_identifier);
 iERR _ion_symbol_table_find_by_name_helper(ION_SYMBOL_TABLE *symtab, ION_STRING *name, SID *p_sid, ION_SYMBOL **p_sym, BOOL symbol_identifiers_as_sids);
 iERR _ion_symbol_table_find_by_sid_helper(ION_SYMBOL_TABLE *symtab, SID sid, ION_STRING **p_name);

--- a/ionc/ion_writer.c
+++ b/ionc/ion_writer.c
@@ -2876,7 +2876,7 @@ iERR _ion_writer_make_symbol_helper(ION_WRITER *pwriter, ION_STRING *pstr, SID *
     iENTER;
     SID               sid = UNKNOWN_SID, max_id;
     ION_SYMBOL_TABLE *psymtab, *system;
-    BOOL symtab_is_locked;
+    BOOL              symtab_is_locked;
 
     ASSERT(pwriter);
     ASSERT(pstr);
@@ -2888,11 +2888,12 @@ iERR _ion_writer_make_symbol_helper(ION_WRITER *pwriter, ION_STRING *pstr, SID *
     if (!psymtab) {
         IONCHECK(_ion_writer_initialize_local_symbol_table(pwriter));
         psymtab = pwriter->symbol_table;
-    }
-    IONCHECK(_ion_symbol_table_is_locked_helper(psymtab, &symtab_is_locked));
-    if (symtab_is_locked) {
-        IONCHECK(_ion_writer_initialize_local_symbol_table(pwriter));
-        psymtab = pwriter->symbol_table;
+    } else {
+        IONCHECK(_ion_symbol_table_is_locked_helper(psymtab, &symtab_is_locked));
+        if (symtab_is_locked) {
+            IONCHECK(_ion_writer_initialize_local_symbol_table(pwriter));
+            psymtab = pwriter->symbol_table;
+        }
     }
 
     // we'll remember what the top symbol is to see if add_symbol changes it

--- a/ionc/ion_writer_text.c
+++ b/ionc/ion_writer_text.c
@@ -196,11 +196,13 @@ iERR _ion_writer_text_close_collection(ION_WRITER *pwriter, BYTE close_char)
 
 BOOL _ion_writer_text_has_symbol_table(ION_WRITER *pwriter)
 {
+    ION_COLLECTION *import_list;
     // Text writers only need to serialize a symbol table when the current symbol table contains shared imports and
     // the stream contains at least one value.
     ASSERT(pwriter);
-    return pwriter->symbol_table != NULL && !TEXTWRITER(pwriter)->_no_output
-           && !ION_COLLECTION_IS_EMPTY(&pwriter->symbol_table->import_list);
+    if (!pwriter->symbol_table) return FALSE;
+    _ion_symbol_table_get_imports_helper(pwriter->symbol_table, &import_list);
+    return !TEXTWRITER(pwriter)->_no_output && !ION_COLLECTION_IS_EMPTY(import_list);
 }
 
 iERR _ion_writer_text_write_stream_start(ION_WRITER *pwriter)

--- a/test/test_ion_symbol.cpp
+++ b/test/test_ion_symbol.cpp
@@ -1392,6 +1392,7 @@ TEST_P(BinaryAndTextTest, WriterAcceptsImportsAfterConstruction) {
     ION_SYMBOL_TABLE_IMPORT *foo_import, *bar_import, import1_import, import2_import;
     ION_COLLECTION new_imports_1, new_imports_2;
     ION_SYMBOL_TABLE *writer_table;
+    ION_COLLECTION *writer_table_import_list;
     BOOL contains_import;
 
     ion_string_from_cstr("foo", &foo);
@@ -1416,23 +1417,24 @@ TEST_P(BinaryAndTextTest, WriterAcceptsImportsAfterConstruction) {
 
     ION_ASSERT_OK(ion_writer_get_symbol_table(writer, &writer_table));
 
-    ION_ASSERT_OK(_ion_collection_contains(&writer_table->import_list, foo_import, &_ion_symbol_table_import_compare_fn, &contains_import));
+    ION_ASSERT_OK(ion_symbol_table_get_imports(writer_table, &writer_table_import_list));
+    ION_ASSERT_OK(_ion_collection_contains(writer_table_import_list, foo_import, &_ion_symbol_table_import_compare_fn, &contains_import));
     ASSERT_TRUE(contains_import);
 
-    ION_ASSERT_OK(_ion_collection_contains(&writer_table->import_list, bar_import, &_ion_symbol_table_import_compare_fn, &contains_import));
+    ION_ASSERT_OK(_ion_collection_contains(writer_table_import_list, bar_import, &_ion_symbol_table_import_compare_fn, &contains_import));
     ASSERT_TRUE(contains_import);
 
     ION_STRING_ASSIGN(&import1_import.descriptor.name, &import1_name);
     ION_STRING_ASSIGN(&import2_import.descriptor.name, &import2_name);
-    import1_import.descriptor.max_id = import1->max_id;
-    import2_import.descriptor.max_id = import2->max_id;
-    import1_import.descriptor.version = import1->version;
-    import2_import.descriptor.version = import2->version;
+    ION_ASSERT_OK(ion_symbol_table_get_max_sid(import1, &import1_import.descriptor.max_id));
+    ION_ASSERT_OK(ion_symbol_table_get_max_sid(import2, &import2_import.descriptor.max_id));
+    ION_ASSERT_OK(ion_symbol_table_get_version(import1, &import1_import.descriptor.version));
+    ION_ASSERT_OK(ion_symbol_table_get_version(import2, &import2_import.descriptor.version));
 
-    ION_ASSERT_OK(_ion_collection_contains(&writer_table->import_list, &import1_import, &_ion_symbol_table_import_compare_fn, &contains_import));
+    ION_ASSERT_OK(_ion_collection_contains(writer_table_import_list, &import1_import, &_ion_symbol_table_import_compare_fn, &contains_import));
     ASSERT_TRUE(contains_import);
 
-    ION_ASSERT_OK(_ion_collection_contains(&writer_table->import_list, &import2_import, &_ion_symbol_table_import_compare_fn, &contains_import));
+    ION_ASSERT_OK(_ion_collection_contains(writer_table_import_list, &import2_import, &_ion_symbol_table_import_compare_fn, &contains_import));
     ASSERT_TRUE(contains_import);
 
     ION_ASSERT_OK(ion_writer_close(writer));


### PR DESCRIPTION
*Description of changes:*
Internally, ion-c pokes at the ION_SYMBOL_TABLE type quite a bit, which violates encapsulation and makes it hard to make changes to the data structure without breakage across the library.  This cleans up direct usages of the symbol table type, replaces them with API calls, and makes the ION_SYMBOL_TABLE type opaque to avoid depending on the internal details outside of ion_symbol_table.c.

This is needed in preparation to fix #264, as we need to make some changes to the representation of the ION_SYMBOL_TABLE type to fix it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
