### PR TITLE
Fix pointer alignment issues

### DIFF
--- a/ionc/ion_allocation.c
+++ b/ionc/ion_allocation.c
@@ -176,7 +176,7 @@ void *_ion_alloc_with_owner_helper(ION_ALLOCATION_CHAIN *powner, SIZE request_le
 ION_ALLOCATION_CHAIN *_ion_alloc_block(SIZE min_needed)
 {
     ION_ALLOCATION_CHAIN *new_block;
-    SIZE                  alloc_size = min_needed + sizeof(ION_ALLOCATION_CHAIN); // subtract out the block[1]
+    SIZE                  alloc_size = min_needed + ALIGN_SIZE(sizeof(ION_ALLOCATION_CHAIN)); // subtract out the block[1]
 
     if (alloc_size > g_ion_alloc_page_list.page_size) {
         // it's an oversize block - we'll ask the system for this one
@@ -200,7 +200,7 @@ ION_ALLOCATION_CHAIN *_ion_alloc_block(SIZE min_needed)
     new_block->position = ION_ALLOC_BLOCK_TO_USER_PTR(new_block);
     new_block->limit    = ((BYTE*)new_block) + new_block->size;
 
-    assert(new_block->position == ((BYTE *)(&new_block->limit) + sizeof(new_block->limit)));
+    assert(new_block->position == ((BYTE *)(&new_block->limit) + ALIGN_SIZE(sizeof(new_block->limit))));
 
     return new_block;
 }


### PR DESCRIPTION

*Issue #, if available:* #273

*Description of changes:*
Pointers are now aligned to 16 bytes (instead of 4) by default.  If C11 is detected, it tries to use the alignment of `max_align_t` instead.  Users can specify a different alignment by setting `-DCMAKE_C_FLAGS="-DALLOC_ALIGNMENT=<x>"` when configuring via cmake.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
