### PR TITLE
chore: enable ubsan and asan in debug build script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,13 +15,16 @@ jobs:
       matrix:
         container-image: ['amazonlinux:1', 'amazonlinux:2']
         compiler:
-          - { cc: 'gcc', cxx: 'g++'}
-          - { cc: 'clang', cxx: 'clang++' }
+          - { cc: 'gcc', cxx: 'g++', debug_cflags: '', debug_cxxflags: '', debug_ldflags: '' }
+          - { cc: 'clang', cxx: 'clang++', debug_cflags: '', debug_cxxflags: '', debug_ldflags: '' }
     runs-on: ubuntu-latest
     container: ${{ format('docker://{0}', matrix.container-image) }}
     env:
       CC: ${{ matrix.compiler.cc }}
       CXX: ${{ matrix.compiler.cxx }}
+      DEBUG_CFLAGS: ${{ matrix.compiler.debug_cflags }}
+      DEBUG_CXXFLAGS: ${{ matrix.compiler.debug_cxxflags }}
+      DEBUG_LDFLAGS: ${{ matrix.compiler.debug_ldflags }}
     steps:
       - name: Install `which`
         run: yum install which -y
@@ -63,19 +66,24 @@ jobs:
       matrix:
         os: ['macos-latest', 'ubuntu-latest']
         compiler:
-          - { cc: 'gcc', cxx: 'g++'}
-          - { cc: 'clang', cxx: 'clang++' }
+          - { cc: 'gcc', cxx: 'g++', debug_cflags: '-fsanitize=address,undefined -fsanitize-recover=address -fno-omit-frame-pointer -fno-optimize-sibling-calls', debug_cxxflags: '-fsanitize=address,undefined -fsanitize-recover=address -fno-omit-frame-pointer -fno-optimize-sibling-calls', debug_ldflags: '-fsanitize=address,undefined' }
+          - { cc: 'clang', cxx: 'clang++', debug_cflags: '-fsanitize=address,undefined -fsanitize-recover=address -fno-omit-frame-pointer -fno-optimize-sibling-calls', debug_cxxflags: '-fsanitize=address,undefined -fsanitize-recover=address -fno-omit-frame-pointer -fno-optimize-sibling-calls', debug_ldflags: ''  }
         # gcc just redirects to clang on the macos vm; replace with a specific gcc alias
         exclude:
           - os: 'macos-latest'
             compiler: { cc: 'gcc', cxx: 'g++'}
         include:
           - os: 'macos-latest'
-            compiler: { cc: 'gcc-11', cxx: 'g++-11'}
+            compiler: { cc: 'gcc-11', cxx: 'g++-11', debug_cflags: '-fsanitize=address,undefined -fsanitize-recover=address -fno-omit-frame-pointer -fno-optimize-sibling-calls', debug_cxxflags: '-fsanitize=address,undefined -fsanitize-recover=address -fno-omit-frame-pointer -fno-optimize-sibling-calls', debug_ldflags: '-fsanitize=address,undefined' }
     runs-on: ${{ matrix.os }}
     env:
       CC: ${{ matrix.compiler.cc }}
       CXX: ${{ matrix.compiler.cxx }}
+      DEBUG_CFLAGS: ${{ matrix.compiler.debug_cflags }}
+      DEBUG_CXXFLAGS: ${{ matrix.compiler.debug_cxxflags }}
+      DEBUG_LDFLAGS: ${{ matrix.compiler.debug_ldflags }}
+      UBSAN_OPTIONS: "print_stacktrace=1"
+      ASAN_OPTIONS: "halt_on_error=0"
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2

--- a/build-debug.sh
+++ b/build-debug.sh
@@ -1,6 +1,17 @@
 #!/bin/sh --
 
-mkdir -p build/debug
-cd build/debug
-cmake -DCMAKE_BUILD_TYPE=Debug ../..
-make clean && make
+set -x
+
+DEFAULT_CFLAGS="-fsanitize=address,undefined -fsanitize-recover=address -fno-omit-frame-pointer -fno-optimize-sibling-calls"
+DEFAULT_CXXFLAGS="${DEFAULT_CFLAGS}"
+DEFAULT_LDFLAGS="-fsanitize=address,undefined"
+
+export LD="$CXX"
+
+mkdir -p build/debug && cd build/debug
+cmake \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DCMAKE_C_FLAGS_DEBUG="${DEBUG_CFLAGS-${DEFAULT_CFLAGS}}" \
+  -DCMAKE_CXX_FLAGS_DEBUG="${DEBUG_CXXFLAGS-${DEFAULT_CXXFLAGS}}" \
+  ../..
+make clean && make LDFLAGS="${DEBUG_LDFLAGS-${DEFAULT_LDFLAGS}}" -j"$(nproc || sysctl -n hw.ncpu)"


### PR DESCRIPTION
*Issue #, if available:* #283

*Description of changes:*
This turns on the ubsan and asan sanitizers for debug builds on macos and ubuntu in the CI pipeline.  This doesn't cause any build failures currently, but it does spit out stack traces for places where undefined behavior and memory safety issues are present.

This also makes debug builds slightly faster by tuning the number of jobs make uses to the number of cpu cores available.

Work still needs to be done to enable these on AL1/2 and windows.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
