### PR TITLE
Adds a buffer bound check for timestamp parsing

### DIFF
--- a/ionc/ion_timestamp.c
+++ b/ionc/ion_timestamp.c
@@ -596,7 +596,7 @@ iERR ion_timestamp_parse(ION_TIMESTAMP *ptime, char *buffer, SIZE buf_length, SI
         if (fractional_digits_read == 0) {
             FAILWITH(IERR_INVALID_TIMESTAMP);
         }
-        if (cp > end_of_buffer) FAILWITH(IERR_INVALID_TIMESTAMP);
+        if (cp > end_of_buffer || dst >= end_of_temp) FAILWITH(IERR_INVALID_TIMESTAMP);
 
         *dst = 0; // null terminate the string (it's why we copied it after all)
         // TODO timestamp fraction as ION_DECIMAL to support full precision?

--- a/test/test_ion_text.cpp
+++ b/test/test_ion_text.cpp
@@ -720,3 +720,15 @@ TEST(IonTextInt, BinaryLiterals) {
     ION_ASSERT_OK(ion_reader_read_int64(reader, &value));
     ASSERT_EQ(-4, value);
 }
+
+TEST(IonTextInt, ) {
+    const char *ion_text = "2007-02-23T12:14:32.13371337133713371337844674407370955551616Z";
+    hREADER  reader;
+    ION_TYPE type;
+    ION_TIMESTAMP value;
+
+    ION_ASSERT_OK(ion_test_new_text_reader(ion_text, &reader));
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(tid_TIMESTAMP, type);
+    ASSERT_EQ( IERR_INVALID_TIMESTAMP, ion_reader_read_timestamp(reader, &value));
+}


### PR DESCRIPTION
*Issue #286*

*Description of changes:*
This PR works on adding a safety check for buffer bounds while parsing timestamp.

*Test:*
Added reproduction test from #286.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
