### PR TITLE
fix broken clob parsing when scanning unknown lobs

### DIFF
--- a/ionc/ion_scanner.c
+++ b/ionc/ion_scanner.c
@@ -1184,30 +1184,21 @@ iERR _ion_scanner_skip_unknown_lob(ION_SCANNER *scanner)
     iENTER;
     int c;
 
-    for (;;) {
-        // we should see a double closing curly brace next
-        IONCHECK(_ion_scanner_read_past_lob_whitespace(scanner, &c));
-        switch (c) {
-        case '\'':
-            // note that a valid triple quoted string looks like an empty
-            // single quoted string, followed by a single quoted string,
-            // followed by another empty single quoted string
-            IONCHECK(_ion_scanner_skip_single_quoted_string(scanner));
-            break;
-        case '\"':
-            IONCHECK(_ion_scanner_skip_plain_clob(scanner));
-            break;
-        case '}':
-            IONCHECK(_ion_scanner_read_char(scanner, &c));
-            if (c == '}') {
-                SUCCEED();
-            }
-            break;
-        case EOF:
-            FAILWITH(IERR_UNEXPECTED_EOF);
-        default:
-            break;
-        }
+    IONCHECK(_ion_scanner_read_past_lob_whitespace(scanner, &c));
+    switch (c) {
+    case '\'':
+        // if we see a single quote, try to skip a long clob (one with a 
+        // triple-quoted string)
+        IONCHECK(_ion_scanner_skip_long_clob(scanner));
+        break;
+    case '\"':
+        // if we see a double quote, try to skip a plain clob
+        IONCHECK(_ion_scanner_skip_plain_clob(scanner));
+        break;
+    default:
+        // else try to skip a regular blob
+        IONCHECK(_ion_scanner_skip_blob(scanner));
+        break;
     }
 
     iRETURN;

--- a/test/test_ion_text.cpp
+++ b/test/test_ion_text.cpp
@@ -619,6 +619,44 @@ TEST(IonTextBlob, CanReadBlob) {
                        tid_BLOB, 23, "This is a BLOB of text.");
 }
 
+void test_text_list(const char *ion_text) {
+    ION_TYPE expected_tid = tid_LIST;
+
+    hREADER reader;
+    ION_ASSERT_OK(ion_test_new_text_reader(ion_text, &reader));
+
+    ION_TYPE type;
+    ION_ASSERT_OK(ion_reader_next(reader, &type));
+    ASSERT_EQ(expected_tid, type);
+
+    // Attempting to read another element should return EOF.
+    int result = ion_reader_next(reader, &type);
+    ION_ASSERT_OK(result);
+    ASSERT_EQ(tid_EOF, type);
+
+    ION_ASSERT_OK(ion_reader_close(reader));
+}
+
+TEST(IonTextList, CanReadListClob1) {
+    test_text_list("[{{\"foo\"}},{{\"bar\"}}]");
+}
+
+TEST(IonTextList, CanReadListClob2) {
+    test_text_list("[1,{{\"foo\"}},2]");
+}
+
+TEST(IonTextList, CanReadInt) {
+    test_text_list("[1,2]");
+}
+
+TEST(IonTextList, CanReadSymbol) {
+    test_text_list("[foo,bar]");
+}
+
+TEST(IonTextList, CanReadBlob) {
+    test_text_list("[{{ Zm9v }}, {{ YmFy }}]");
+}
+
 /** Tests the ability to read BLOB or CLOB using multiple calls to ion_reader_read_lob_partial_bytes. */
 void test_partial_lob_read(const char *ion_text, ION_TYPE expected_tid, SIZE expected_size, const char *expected_value) {
     hREADER reader;


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Skip-scanning through `[{{"foo"}},{{"bar"}}]` in text mode currently (erroneously) fails with `IERR_UNEXPECTED_EOF`.

`_ion_scanner_skip_unknown_lob` (which handles skipping clobs and blobs when skip-scanning through a data structure) expects to parse the closing `}}` of a clob or blob.  However, when it tries to skip a "plain clob" (a clob with a double-quoted string), it calls `_ion_scanner_skip_plain_clob`, which consumes the closing `}}`.  So it erroneously continues reading and skipping input, even though it's already skipped the entire clob, leading to the `IERR_UNEXPECTED_EOF` result.

This change identifies the unknown lob by the matching against the first non-whitespace character it sees and reuses the helper functions for skipping the particular lob type of the unknown lob (clob with long strings, plain clob, or blob) instead of duplicating the skipping logic from these functions into `_ion_scanner_skip_unknown_lob`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
