### PR TITLE
Align all memory used by the system symbol table

### DIFF
--- a/ionc/include/ionc/ion_platform_config.h
+++ b/ionc/include/ionc/ion_platform_config.h
@@ -56,4 +56,15 @@
 #error "Compiler does not support thread local storage"
 #endif
 
+// Support for type alignment specification (`alignas`) across compilers
+#if __STDC_VERSION__ >= 201112L
+#define ALIGN_AS(size) _Alignas(size)
+#elif __GNUC__
+#define ALIGN_AS(size) __attribute__((__aligned__(size)))
+#elif defined(_MSC_VER)
+#define ALIGN_AS(size) __declspec(align(size))
+#else
+#error "Compiler does not support type alignment specification"
+#endif
+
 #endif

--- a/ionc/ion_alloc.h
+++ b/ionc/ion_alloc.h
@@ -112,7 +112,7 @@ struct _ion_allocation_chain
     // user bytes follow this header, though there may be some unused bytes here for alignment purposes
 };
 
-#define ION_ALLOC_BLOCK_TO_USER_PTR(block) ((BYTE*)ALIGN_PTR(((BYTE*)(block)) + ALIGN_SIZE(sizeof(ION_ALLOCATION_CHAIN))))
+#define ION_ALLOC_BLOCK_TO_USER_PTR(block) ((BYTE*)(((BYTE*)(block)) + ALIGN_SIZE(sizeof(ION_ALLOCATION_CHAIN))))
 #define ION_ALLOC_USER_PTR_TO_BLOCK(ptr)   ((ION_ALLOCATION_CHAIN *)(((BYTE*)(ptr)) - ALIGN_SIZE(sizeof(ION_ALLOCATION_CHAIN))))
 
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Rarely, the compiler/linker will decide to put `gSystemSymbolMemory` on a smaller alignment boundary (e.g. 4 bytes) than what is required for the data it contains.  `gSystemSymbolMemory` is declared as a `char[]`, but is really being used as generic backing memory for the system symbol table and any other data structures associated with it.  Notably, the very first data structure placed in the `gSystemSymbolMemory` is an `ION_ALLOCATION_CHAIN`, which may need a wider alignment.

With the current behavior, an `ION_ALLOCATION_CHAIN` could be allocated at a smaller alignment than needed.  The `ION_ALLOC_BLOCK_TO_USER_PTR` macro then gets an aligned offset into the memory chunk associated with the `ION_ALLOCATION_CHAIN`.  When another allocation needs to be performed, the `ION_ALLOC_USER_PTR_TO_BLOCK` macro is used to convert the user data pointer into an `ION_ALLOCATION_CHAIN`, but this is where the problems start happening.  Because `ION_ALLOC_BLOCK_TO_USER_PTR` aligns the user data pointer, an unknown amount of padding exists between the end of the `ION_ALLOCATION_CHAIN` and the user data pointer (up to `ALLOC_ALIGNMENT` bytes). `ION_ALLOC_USER_PTR_TO_BLOCK` doesn't account for any alignment done to the user data pointer (and there's no way it can really), meaning it might produce a pointer that is offset from the actual `ION_ALLOCATION_CHAIN` by the amount of padding that exists. This usually leads to a crash, since the data being read is now scrambled.

This commit addresses this issue by introducing an `ALIGN_AS` macro that forces a data structure to be aligned to a wider alignment than the type requires.  This is applied to the `gSystemSymbolMemory` array, so that it is always located at a correctly aligned address.  This also adds a few debug assertions to the system symbol table allocation routines and gets rid of the pointer aligning behavior in the `ION_ALLOC` converter macros (an offset from a pointer should be aligned if you start with an aligned pointer and add an aligned offset to it; in the case that you start with a misaligned pointer, you'll at least get the right pointer back with a round trip conversion, rather than a misaligned one).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
