### PR TITLE
Runtime Sanitizer Issues: Uninitialized structs in tests, and stack buffer read overflow

### DIFF
--- a/decNumber/decBasic.c
+++ b/decNumber/decBasic.c
@@ -2242,7 +2242,7 @@ decFloat * decFloatFMA(decFloat *result, const decFloat *dfl,
       // all done except for the special IEEE 754 exact-zero-result
       // rule (see above); while testing for zero, strip leading
       // zeros (which will save decFinalize doing it)
-      for (; UBTOUI(lo->msd)==0 && lo->msd+3<lo->lsd;) lo->msd+=4;
+      for (; lo->msd+3<lo->lsd && UBTOUI(lo->msd)==0;) lo->msd+=4;
       for (; *lo->msd==0 && lo->msd<lo->lsd;) lo->msd++;
       if (*lo->msd==0) {           // must be true zero (and diffsign)
         lo->sign=0;                // assume +

--- a/test/test_ion_extractor.cpp
+++ b/test/test_ion_extractor.cpp
@@ -43,7 +43,7 @@
  * Initializes an extractor test with the default options.
  */
 #define ION_EXTRACTOR_TEST_INIT \
-    ION_EXTRACTOR_OPTIONS options; \
+    ION_EXTRACTOR_OPTIONS options = {0}; \
     options.max_path_length = ION_EXTRACTOR_TEST_PATH_LENGTH; \
     options.max_num_paths = ION_EXTRACTOR_TEST_MAX_PATHS; \
     options.match_relative_paths = false; \
@@ -548,7 +548,7 @@ TEST(IonExtractorSucceedsWhen, NoPathMatchesFromIon) {
 }
 
 TEST(IonExtractorSucceedsWhen, ARelativePathMatches) {
-    ION_EXTRACTOR_OPTIONS options;
+    ION_EXTRACTOR_OPTIONS options = {0};
     options.max_path_length = ION_EXTRACTOR_TEST_PATH_LENGTH;
     options.max_num_paths = ION_EXTRACTOR_TEST_MAX_PATHS;
     options.match_relative_paths = true;
@@ -591,7 +591,7 @@ TEST(IonExtractorSucceedsWhen, StepOutControlIsReceivedAfterMatch) {
 }
 
 TEST(IonExtractorSucceedsWhen, StepOutControlIsReceivedAfterMatchOnRelativePath) {
-    ION_EXTRACTOR_OPTIONS options;
+    ION_EXTRACTOR_OPTIONS options = {0};
     options.max_path_length = ION_EXTRACTOR_TEST_PATH_LENGTH;
     options.max_num_paths = ION_EXTRACTOR_TEST_MAX_PATHS;
     options.match_relative_paths = true;
@@ -633,7 +633,7 @@ TEST(IonExtractorSucceedsWhen, StepOutControlIsReceivedAfterMatchOnWildcard) {
 }
 
 TEST(IonExtractorSucceedsWhen, NumPathsAtMaximum) {
-    ION_EXTRACTOR_OPTIONS options;
+    ION_EXTRACTOR_OPTIONS options = {0};
     options.max_path_length = ION_EXTRACTOR_TEST_PATH_LENGTH;
     options.max_num_paths = ION_EXTRACTOR_MAX_NUM_PATHS;
     hREADER reader;
@@ -676,7 +676,7 @@ TEST(IonExtractorSucceedsWhen, TopLevelWildcardHasZeroMatches) {
 }
 
 TEST(IonExtractorSucceedsWhen, DepthOneWildcardIsRegistered) {
-    ION_EXTRACTOR_OPTIONS options;
+    ION_EXTRACTOR_OPTIONS options = {0};
     options.max_path_length = ION_EXTRACTOR_TEST_PATH_LENGTH;
     options.max_num_paths = ION_EXTRACTOR_TEST_MAX_PATHS;
     options.match_relative_paths = true;
@@ -693,7 +693,7 @@ TEST(IonExtractorSucceedsWhen, DepthOneWildcardIsRegistered) {
 }
 
 TEST(IonExtractorSucceedsWhen, DepthTwoWildcardIsRegisteredTwice) {
-    ION_EXTRACTOR_OPTIONS options;
+    ION_EXTRACTOR_OPTIONS options = {0};
     options.max_path_length = ION_EXTRACTOR_TEST_PATH_LENGTH;
     options.max_num_paths = ION_EXTRACTOR_TEST_MAX_PATHS;
     options.match_relative_paths = true;
@@ -724,7 +724,7 @@ TEST(IonExtractorSucceedsWhen, BothTopLevelWildcardAndLengthOnePathAreRegistered
 }
 
 TEST(IonExtractorSucceedsWhen, CaseInsensitiveMatches) {
-    ION_EXTRACTOR_OPTIONS options;
+    ION_EXTRACTOR_OPTIONS options = {0};
     options.max_path_length = ION_EXTRACTOR_TEST_PATH_LENGTH;
     options.max_num_paths = ION_EXTRACTOR_TEST_MAX_PATHS;
     options.match_case_insensitive = true;
@@ -793,7 +793,7 @@ TEST(IonExtractorSucceedsWhen, SkippingNestedSexps) {
 
 TEST(IonExtractorFailsWhen, MaxPathLengthExceedsLimit) {
     hEXTRACTOR extractor;
-    ION_EXTRACTOR_OPTIONS options;
+    ION_EXTRACTOR_OPTIONS options = {0};
     options.max_path_length = ION_EXTRACTOR_MAX_PATH_LENGTH + 1;
     options.max_num_paths = ION_EXTRACTOR_MAX_NUM_PATHS;
     ION_ASSERT_FAIL(ion_extractor_open(&extractor, &options));
@@ -801,7 +801,7 @@ TEST(IonExtractorFailsWhen, MaxPathLengthExceedsLimit) {
 
 TEST(IonExtractorFailsWhen, MaxNumPathsExceedsLimit) {
     hEXTRACTOR extractor;
-    ION_EXTRACTOR_OPTIONS options;
+    ION_EXTRACTOR_OPTIONS options = {0};
     options.max_path_length = ION_EXTRACTOR_MAX_PATH_LENGTH;
     options.max_num_paths = ION_EXTRACTOR_MAX_NUM_PATHS + 1;
     ION_ASSERT_FAIL(ion_extractor_open(&extractor, &options));
@@ -809,7 +809,7 @@ TEST(IonExtractorFailsWhen, MaxNumPathsExceedsLimit) {
 
 TEST(IonExtractorFailsWhen, MaxPathLengthIsBelowMinimum) {
     hEXTRACTOR extractor;
-    ION_EXTRACTOR_OPTIONS options;
+    ION_EXTRACTOR_OPTIONS options = {0};
     options.max_path_length = 0;
     options.max_num_paths = ION_EXTRACTOR_MAX_NUM_PATHS;
     ION_ASSERT_FAIL(ion_extractor_open(&extractor, &options));
@@ -817,7 +817,7 @@ TEST(IonExtractorFailsWhen, MaxPathLengthIsBelowMinimum) {
 
 TEST(IonExtractorFailsWhen, MaxNumPathsIsBelowMinimum) {
     hEXTRACTOR extractor;
-    ION_EXTRACTOR_OPTIONS options;
+    ION_EXTRACTOR_OPTIONS options = {0};
     options.max_path_length = ION_EXTRACTOR_MAX_PATH_LENGTH;
     options.max_num_paths = 0;
     ION_ASSERT_FAIL(ion_extractor_open(&extractor, &options));
@@ -836,7 +836,7 @@ TEST(IonExtractorFailsWhen, PathExceedsDeclaredLength) {
 TEST(IonExtractorFailsWhen, PathExceedsMaxLength) {
     hEXTRACTOR extractor;
     hPATH path;
-    ION_EXTRACTOR_OPTIONS options;
+    ION_EXTRACTOR_OPTIONS options = {0};
     options.max_path_length = 1;
     options.max_num_paths = ION_EXTRACTOR_MAX_NUM_PATHS;
     ION_ASSERT_OK(ion_extractor_open(&extractor, &options));
@@ -847,7 +847,7 @@ TEST(IonExtractorFailsWhen, PathExceedsMaxLength) {
 TEST(IonExtractorFailsWhen, PathFromIonExceedsMaxLength) {
     hEXTRACTOR extractor;
     hPATH path;
-    ION_EXTRACTOR_OPTIONS options;
+    ION_EXTRACTOR_OPTIONS options = {0};
     options.max_path_length = 1;
     options.max_num_paths = ION_EXTRACTOR_MAX_NUM_PATHS;
     const char *ion_text = "(foo bar)"; // Length: 2, max_length: 1.
@@ -872,7 +872,7 @@ TEST(IonExtractorFailsWhen, PathIsIncomplete) {
 TEST(IonExtractorFailsWhen, TooManyPathsAreRegistered) {
     hEXTRACTOR extractor;
     hPATH path;
-    ION_EXTRACTOR_OPTIONS options;
+    ION_EXTRACTOR_OPTIONS options = {0};
     options.max_path_length = ION_EXTRACTOR_MAX_PATH_LENGTH;
     options.max_num_paths = 1;
     ION_ASSERT_OK(ion_extractor_open(&extractor, &options));
@@ -916,7 +916,7 @@ TEST(IonExtractorFailsWhen, PathIsCreatedFromIonThatExceedsMaxLength) {
     hEXTRACTOR extractor;
     hPATH path;
     const char *data = "(foo bar)";
-    ION_EXTRACTOR_OPTIONS options;
+    ION_EXTRACTOR_OPTIONS options = {0};
     options.max_path_length = 1;
     options.max_num_paths = ION_EXTRACTOR_MAX_NUM_PATHS;
     ION_ASSERT_OK(ion_extractor_open(&extractor, &options));
@@ -991,7 +991,7 @@ TEST(IonExtractorFailsWhen, ControlStepsOutBeyondReaderDepth) {
 }
 
 TEST(IonExtractorFailsWhen, ControlStepsOutBeyondRelativePathDepth) {
-    ION_EXTRACTOR_OPTIONS options;
+    ION_EXTRACTOR_OPTIONS options = {0};
     options.max_path_length = ION_EXTRACTOR_TEST_PATH_LENGTH;
     options.max_num_paths = ION_EXTRACTOR_TEST_MAX_PATHS;
     options.match_relative_paths = true;


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
This PR is part of efforts to eliminate the runtime sanitizer errors reported when running in debug mode. Most of the issues were either related to uninitialized data in tests, or non-breaking issues with how the decNumber library is implemented. Specifically, this PR addresses uninitialized test data, and an off-by-one error in a loop that resulted in memory reads from beyond the boundaries of a buffer.

The memory access issue is identified by Clang's AddressSanitizer like so:
```
==3361==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7ffeffb60030 at pc 0x0000004e5f87 bp 0x7ffeffb5ff90 sp 0x7ffeffb5f758
READ of size 4 at 0x7ffeffb60030 thread T0
    #0 0x4e5f86 in __asan_memcpy (/home/runner/work/ion-c/ion-c/build/debug/test/all_tests+0x4e5f86)
    #1 0x7f08145fe426 in decQuadFMA /home/runner/work/ion-c/ion-c/decNumber/decBasic.c:2245:14
...
Address 0x7ffeffb60030 is located in stack of thread T0 at offset 144 in frame
    #0 0x7f08145f2ccf in decQuadFMA /home/runner/work/ion-c/ion-c/decNumber/decBasic.c:1998
  This frame has 6 object(s):
    [32, 144) 'acc' (line 2004) <== Memory access at offset 144 overflows this variable
    [176, 200) 'mul' (line 2006)
    [240, 264) 'fin' (line 2007)
    [304, 340) 'coe' (line 2008)
    [384, 388) 'uiwork' (line 2015)
    [400, 416) 'proxy' (line 2020)
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow (/home/runner/work/ion-c/ion-c/build/debug/test/all_tests+0x4e5f86) in __asan_memcpy
```
The original code consisted of a for loop that: 
* walks over a buffer in 32bit increments
* `memcpy`s every 32bit span into a 32bit int before checking to make sure the value is zero and stops if not.
* checks the boundary conditions for the loop to make sure the pointer is 4 or more bytes from the end and stops if not.
* increments the read pointer by 4bytes.

Because the boundary check is done after the memcpy, the memcpy ends up reaching beyond the size of the buffer. The data copied is only used as another stopping condition for the loop, and does not corrupt the digit data. It does however trigger the AddressSanitizer during debug build execution and could potentially cause issue with other dynamic analysis tools.

The change in this PR simply swaps the order of the bounds check and memcpy so the evaluation short circuits when memcpy would reach beyond the buffer. The already existing for-loop immediately after the change handles finishing the remainder of the pointer increments to account for non-multiple of 4 buffer sizes, in the same way it did pre-PR.

With this PR, the AddressSanitizer is no longer triggered:
```
~/Code/ion-c/build/debug rgiliam/tests_sanitizers ≡
❯ ./test/all_tests 2>&1 1>/dev/null | fgrep AddressSanitizer

~/Code/ion-c/build/debug rgiliam/tests_sanitizers ≡
❯
```
and unit tests still pass as expected:
```
[----------] Global test environment tear-down
[==========] 2957 tests from 41 test cases ran. (2655 ms total)
[  PASSED  ] 2957 tests.
```

The uninitialized options in tests triggered the UndefinedBehavior sanitizer, which presented with these:
```
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/runner/work/ion-c/ion-c/ionc/ion_extractor.c:70:72 in 
/home/runner/work/ion-c/ion-c/ionc/ion_extractor.c:69:70: runtime error: load of value 16, which is not a valid value for type 'bool'
```
These were being triggered by two uninitialized structs, but I've added initialization for all structs that were not already initialized at declaration, or memset prior to use since it is pretty dependent on what is in memory at the time of the test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
