### PR TITLE
Fix reader, stream, and import leaks in CLI 

### DIFF
--- a/tools/cli/cli.cpp
+++ b/tools/cli/cli.cpp
@@ -224,6 +224,7 @@ iERR ion_cli_open_writer(IonCliCommonArgs *common_args, ION_CATALOG *catalog, IO
     if (imports && !ION_COLLECTION_IS_EMPTY(imports)) {
         IONCWRITE(ion_writer_options_initialize_shared_imports(&writer_context->options));
         IONCWRITE(ion_writer_options_add_shared_imports(&writer_context->options, imports));
+        writer_context->has_imports = true;
     }
 
     IONCWRITE(ion_cli_open_writer_basic(&common_args->output, common_args->output_format, writer_context, result));

--- a/tools/cli/cli.cpp
+++ b/tools/cli/cli.cpp
@@ -425,9 +425,11 @@ cleanup:
     }
     if (reader_contexts) {
         for (size_t i = 0; i < num_inputs; i++) {
-            ion_reader_close(reader_contexts[i]->reader);
-            ion_stream_close(reader_contexts[i]->ion_stream);
-            delete reader_contexts[i];
+            if (reader_contexts[i] != NULL) {
+                ion_reader_close(reader_contexts[i]->reader);
+                ion_stream_close(reader_contexts[i]->ion_stream);
+                delete reader_contexts[i];
+            }
         }
         free(reader_contexts);
     }

--- a/tools/cli/cli.cpp
+++ b/tools/cli/cli.cpp
@@ -425,6 +425,8 @@ cleanup:
     }
     if (reader_contexts) {
         for (size_t i = 0; i < num_inputs; i++) {
+            ion_reader_close(reader_contexts[i]->reader);
+            ion_stream_close(reader_contexts[i]->ion_stream);
             delete reader_contexts[i];
         }
         free(reader_contexts);


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
Minor fixes to release memory in two spots within cli.cpp.

The first was when opening a writer via `ion_cli_open_writer` with imports, the `has_imports` flag would not be set on the writer context, resulting in leaked imports from `ion_event_writer_close` not closing the imports.

The second is a stream and reader leak when cleaning up the reader_contexts in `ion_cli_command_compare_standard`.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
