### PR TITLE
Fix leak of resources when unable to flush binary writer

### DIFF
--- a/ionc/ion_writer.c
+++ b/ionc/ion_writer.c
@@ -2829,9 +2829,12 @@ iERR _ion_writer_close_helper(ION_WRITER *pwriter)
 
     ASSERT(pwriter);
 
+    BOOL flush = TRUE;
+
     if (pwriter->depth != 0) {
-        UPDATEERROR(_ion_writer_free(pwriter));
-        FAILWITHMSG(IERR_UNEXPECTED_EOF, "Writer freed; cannot flush a writer that is not at the top level.");
+        flush = FALSE;
+        err = IERR_UNEXPECTED_EOF;
+        DEBUG_ERRMSG(err, "Writer freed; cannot flush a writer that is not at the top level.");
     }
 
     // all the local resources are allocated in the parent
@@ -2844,17 +2847,19 @@ iERR _ion_writer_close_helper(ION_WRITER *pwriter)
         break;
     case ion_type_text_writer:
         if (pwriter->_typed_writer.text._top > 0) {
-            UPDATEERROR(_ion_writer_free(pwriter));
-            FAILWITHMSG(IERR_UNEXPECTED_EOF, "Cannot flush a text writer with a value in progress.");
+            flush = FALSE;
+            err = IERR_UNEXPECTED_EOF;
+            DEBUG_ERRMSG(err, "Cannot flush a text writer with a value in progress.");
         }
-        UPDATEERROR(_ion_writer_text_close(pwriter));
+        UPDATEERROR(_ion_writer_text_close(pwriter, flush));
         break;
     case ion_type_binary_writer:
         if (pwriter->_typed_writer.binary._lob_in_progress != tid_none) {
-            UPDATEERROR(_ion_writer_free(pwriter));
-            FAILWITHMSG(IERR_UNEXPECTED_EOF, "Cannot flush a binary writer with a lob in progress.");
+            flush = FALSE;
+            err = IERR_UNEXPECTED_EOF;
+            DEBUG_ERRMSG(err, "Cannot flush a binary writer with a lob in progress.");
         }
-        UPDATEERROR(_ion_writer_binary_close(pwriter));
+        UPDATEERROR(_ion_writer_binary_close(pwriter, flush));
         break;
     default:
         UPDATEERROR(IERR_INVALID_ARG);

--- a/ionc/ion_writer_binary.c
+++ b/ionc/ion_writer_binary.c
@@ -1219,7 +1219,7 @@ iERR _ion_writer_binary_write_all_values(ION_WRITER *pwriter, ION_READER *preade
     iRETURN;
 }
 
-iERR _ion_writer_binary_close(ION_WRITER *pwriter)
+iERR _ion_writer_binary_close(ION_WRITER *pwriter, BOOL flush)
 {
     iENTER;
     ION_BINARY_WRITER *bwriter;
@@ -1231,11 +1231,14 @@ iERR _ion_writer_binary_close(ION_WRITER *pwriter)
 
     patches = !ION_COLLECTION_IS_EMPTY(&bwriter->_patch_list);
     values  = ion_stream_get_position(bwriter->_value_stream) != 0;
-    if (patches || values) {
-        UPDATEERROR(_ion_writer_binary_flush_to_output(pwriter));
+
+    if (flush) {
+        if (patches || values) {
+            UPDATEERROR(_ion_writer_binary_flush_to_output(pwriter));
+        }
+        UPDATEERROR(ion_stream_flush(pwriter->output));
     }
 
-    UPDATEERROR(ion_stream_flush(pwriter->output));
     UPDATEERROR(ion_stream_close(bwriter->_value_stream));
 
     iRETURN;

--- a/ionc/ion_writer_impl.h
+++ b/ionc/ion_writer_impl.h
@@ -321,7 +321,7 @@ iERR _ion_writer_text_append_lob(ION_WRITER *pwriter, BYTE *p_buf, SIZE length);
 iERR _ion_writer_text_finish_lob(ION_WRITER *pwriter);
 iERR _ion_writer_text_start_container(ION_WRITER *pwriter, ION_TYPE container_type);
 iERR _ion_writer_text_finish_container(ION_WRITER *pwriter);
-iERR _ion_writer_text_close(ION_WRITER *pwriter);
+iERR _ion_writer_text_close(ION_WRITER *pwriter, BOOL flush);
 
 //
 // internal binary impl's of public api's
@@ -346,7 +346,7 @@ iERR _ion_writer_binary_append_lob(ION_WRITER *pwriter, BYTE *p_buf, SIZE length
 iERR _ion_writer_binary_finish_lob(ION_WRITER *pwriter);
 iERR _ion_writer_binary_start_container(ION_WRITER *pwriter, ION_TYPE container_type);
 iERR _ion_writer_binary_finish_container(ION_WRITER *pwriter);
-iERR _ion_writer_binary_close(ION_WRITER *pwriter);
+iERR _ion_writer_binary_close(ION_WRITER *pwriter, BOOL flush);
 
 iERR _ion_writer_binary_output_stream_handler(ION_STREAM *pstream);
 iERR _ion_writer_binary_input_stream_handler(ION_STREAM *pstream);

--- a/ionc/ion_writer_text.c
+++ b/ionc/ion_writer_text.c
@@ -1112,17 +1112,18 @@ iERR _ion_writer_text_finish_container(ION_WRITER *pwriter)
     iRETURN;
 }
 
-iERR _ion_writer_text_close(ION_WRITER *pwriter)
+iERR _ion_writer_text_close(ION_WRITER *pwriter, BOOL flush)
 {
     iENTER;
 
     if (!pwriter) FAILWITH(IERR_BAD_HANDLE);
 
-    if (pwriter->options.pretty_print) {
-        ION_PUT(pwriter->output, '\n');
+    if (flush) {
+        if (pwriter->options.pretty_print) {
+            ION_PUT(pwriter->output, '\n');
+        }
+        IONCHECK(ion_stream_flush(pwriter->output));
     }
-
-    IONCHECK(ion_stream_flush(pwriter->output));
 
     iRETURN;
 }


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
Prior to this commit when a binary writer was closed,
but could not be flushed, the `_ion_writer_close_helper`
function would skip `_ion_writer_binary_close`, which
resulted in the binary writer's `_value_stream` being
leaked.

This commit updates the close functions for both binary
and text formats to include a BOOL to communicate if
we want to flush or not. `_ion_writer_close_helper` was then
updated to track if we are able to flush and provide
that info to the format writer's close, so we can ensure
all resources are cleaned up.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
