### PR TITLE
Fix memleak when writer is closed prior to closing containers

### DIFF
--- a/ionc/ion_writer.c
+++ b/ionc/ion_writer.c
@@ -2812,6 +2812,7 @@ iERR _ion_writer_free(ION_WRITER *pwriter)
     // Free the writer's members.
     UPDATEERROR(_ion_writer_free_local_symbol_table( pwriter ));
     UPDATEERROR( _ion_writer_free_temp_pool( pwriter ));
+    UPDATEERROR(_ion_writer_free_pending_pool(pwriter));
 
     // If the writer allocated the stream, free it.
     if (pwriter->writer_owns_stream) {
@@ -3280,4 +3281,15 @@ iERR _ion_writer_free_temp_pool( ION_WRITER *pwriter )
     SUCCEED();
 
     iRETURN;
+}
+
+iERR _ion_writer_free_pending_pool(ION_WRITER *writer) {
+    iENTER;
+
+    if (writer->_pending_temp_entity_pool != NULL) {
+        ion_free_owner(writer->_pending_temp_entity_pool);
+        writer->_pending_temp_entity_pool = NULL;
+    }
+
+    RETURN(__location_name__, __line__, __count__++, err);
 }

--- a/ionc/ion_writer_impl.h
+++ b/ionc/ion_writer_impl.h
@@ -279,6 +279,7 @@ iERR ion_temp_buffer_reset(ION_TEMP_BUFFER *temp_buffer);
 iERR _ion_writer_allocate_temp_pool( ION_WRITER *pwriter );
 iERR _ion_writer_reset_temp_pool( ION_WRITER *pwriter );
 iERR _ion_writer_free_temp_pool( ION_WRITER *pwriter );
+iERR _ion_writer_free_pending_pool( ION_WRITER *pwriter );
 
 
 


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
ION_WRITER's `_pending_temp_entity_pool` is moved over to `_temp_entity_pool` while transitioning from the symtab intercept state, when depth is zero.

If the writer was closed prior to that transition, the data pointed to by `_pending_temp_entity_pool` would be leaked. This PR adds a function to free the data, and checks during `_ion_writer_free` to ensure the pending temp entity pool is freed if needed, similar to how the temp entity pool is freed.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
