### PR TITLE
Fix a couple leaks around event and symbol cleanup

### DIFF
--- a/tools/events/ion_event_stream.cpp
+++ b/tools/events/ion_event_stream.cpp
@@ -1092,6 +1092,7 @@ iERR ion_event_stream_is_event_stream(hREADER reader, IonEventStream *stream, bo
                 && ION_STRING_EQUALS(&ion_event_stream_marker, &symbol_value->value)) {
                 *is_event_stream = TRUE;
                 stream->remove(i); // Toss this event -- it's not part of the user data.
+                delete event;
             }
         }
         else if (event->event_type == STREAM_END) {

--- a/tools/events/ion_event_stream.cpp
+++ b/tools/events/ion_event_stream.cpp
@@ -1027,6 +1027,19 @@ cleanup:
     if (value_imports) {
         ion_free_owner(value_imports);
     }
+
+    // Free string data for the current value_field_name.
+    if (p_value_field_name) {
+        free(value_field_name.import_location.name.value);
+        free(value_field_name.value.value);
+    }
+
+    // Free string data associated with the annotation symbols.
+    for (std::vector<ION_SYMBOL>::iterator it = value_annotations.begin(); it != value_annotations.end(); it++) {
+       free(it->value.value);
+       free(it->import_location.name.value);
+    }
+
     iRETURN;
 }
 


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
This PR addresses two instances in ion_event_stream where leaks were occurring.

The first is when cleaning up the annotation symbols, and field name, at the end of `ion_event_stream_read_event`. The string data for `value_field_name`, as well as each of the symbols stored in `value_annotations` was not freed.

The second was when removing an event from the event stream in `ion_event_stream_is_event_stream`. Once the pointer to the event is removed from the vector, the object itself needed to be freed.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.