### PR TITLE
Fix leak of reader during path extraction

### DIFF
--- a/ionc/ion_extractor.c
+++ b/ionc/ion_extractor.c
@@ -280,7 +280,11 @@ iERR ion_extractor_path_create_from_ion(ION_EXTRACTOR *extractor, ION_EXTRACTOR_
     }
 
     *p_path = path;
-    iRETURN;
+
+fail:
+    UPDATEERROR(ion_reader_close(reader));
+
+    RETURN(__location_name__, __line__, __count__++, err);
 }
 
 bool _ion_extractor_string_equals_nocase(ION_STRING *lhs, ION_STRING *rhs) {


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
During the execution of `ion_extractor_path_create_from_ion`, a reader is created that does not get freed.

I added the freeing of the reader, but also removed the use of `iRETURN` and manually defined the fail label, so that I could ensure all paths lead to the reader being closed.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
