### PR TITLE
Fix undefined behavior when using CLI's process command.

### DIFF
--- a/tools/cli/cli.cpp
+++ b/tools/cli/cli.cpp
@@ -233,8 +233,9 @@ iERR ion_cli_open_writer(IonCliCommonArgs *common_args, ION_CATALOG *catalog, IO
 
 iERR ion_cli_close_writer(IonEventWriterContext *context, ION_CLI_IO_TYPE output_type, ION_STRING *output, iERR err,
                           IonEventResult *result) {
-    UPDATEERROR(ion_event_writer_close(context, result, err, output_type == IO_TYPE_MEMORY, &output->value,
-                                       &output->length));
+    UPDATEERROR(ion_event_writer_close(context, result, err, output_type == IO_TYPE_MEMORY,
+                                       (output == NULL) ? NULL : &output->value,
+                                       (output == NULL) ? NULL : &output->length));
     cRETURN;
 }
 


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
When using the `process` subcommand of the Ion-C CLI the `ion_cli_command_process` function is called using `NULL` for `output` ION_STRING parameter. At the end of `ion_cli_command_process` as part of the function's cleanup it calls `ion_cli_close_writer` supplying the NULL `output` string, which then gets used in a call to `ion_event_writer_close`, supplying the value and length fields of the ION_STRING to capture the writer's output.

Since the output string is NULL, the dereferences to obtain the value and length fields are undefined behavior. ub-san identifies the issue when running a debug build like so:

```
$ echo '{foo: bar}' | tools/cli/ion process -f pretty -
/home/ubuntu/ion-c/tools/cli/cli.cpp:236:5: runtime error: member access within null pointer of type 'ION_STRING' (aka '_ion_string')
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/ubuntu/ion-c/tools/cli/cli.cpp:236:5 in 
/home/ubuntu/ion-c/tools/cli/cli.cpp:236:5: runtime error: member access within null pointer of type 'ION_STRING' (aka '_ion_string')
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/ubuntu/ion-c/tools/cli/cli.cpp:236:5 in 
{
  foo: bar
}
```

This PR simply adjusts the call site to supply a NULL for each, if output is NULL. Since we're writing directly to stdout, the output type is IO_TYPE_CONSOLE, ensuring that nothing will be done with the output value pointer and length.

After the PR:
```
$ echo '{foo: bar}' | tools/cli/ion process -f pretty -
{
  foo: bar
}
```
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.