### PR TITLE
Ensures that text floats are written using '.' for decimal points regardless of locale.

### DIFF
--- a/test/test_ion_writer.cpp
+++ b/test/test_ion_writer.cpp
@@ -18,6 +18,7 @@
 #include "ion_event_stream.h"
 #include "ion_helpers.h"
 #include "ion_test_util.h"
+#include <locale.h>
 
 class WriterTest : public ::testing::Test {
 protected:
@@ -105,4 +106,92 @@ TEST_F(WriterTest, TextWriterCloseMustFlushStream) {
     file_size = ftell(out);
 
     ASSERT_EQ(file_size, 4);
+}
+
+TEST_F(WriterTest, TextWriterUsesCorrectDecimalPointRegardlessOfLocale) {
+    hWRITER writer = NULL;
+    ION_WRITER_OPTIONS options;
+    BYTE buffer[1024];
+    SIZE bytes_written;
+    iERR err = IERR_OK;
+    std::string output; // Declare early to avoid C++ goto issues
+    char original_locale_copy[256] = {0};
+    char locale_before_writer_copy[256] = {0};
+    const char* test_locale = nullptr;
+    char *original_locale = nullptr;
+    char *locale_before_writer = nullptr;
+    char *locale_after_writer = nullptr;
+
+    // Save original locale
+    original_locale = setlocale(LC_ALL, NULL);
+    if (original_locale && strlen(original_locale) < sizeof(original_locale_copy)) {
+        strcpy(original_locale_copy, original_locale);
+    }
+
+    // Try multiple common locales that use comma as decimal separator
+    const char* comma_locales[] = {
+        "uk_UA.UTF-8",    // Ukrainian
+        "de_DE.UTF-8",    // German
+        "fr_FR.UTF-8",    // French
+        "es_ES.UTF-8",    // Spanish
+        "it_IT.UTF-8",    // Italian
+        "ru_RU.UTF-8",    // Russian
+        nullptr
+    };
+
+    test_locale = nullptr;
+    for (int i = 0; comma_locales[i] != nullptr; i++) {
+        test_locale = setlocale(LC_ALL, comma_locales[i]);
+        if (test_locale) {
+            break; // Successfully set a locale with comma as decimal separator
+        }
+    }
+
+    // If no locale with comma as decimal separator is available, skip this test
+    if (!test_locale) {
+        GTEST_SKIP() << "No locale with comma as decimal separator available - cannot test locale independence";
+    }
+
+    // Store locale to verify later that the writer does not change it
+    locale_before_writer = setlocale(LC_ALL, NULL);
+    if (locale_before_writer && strlen(locale_before_writer) < sizeof(locale_before_writer_copy)) {
+        strcpy(locale_before_writer_copy, locale_before_writer);
+    }
+
+    memset(&options, 0, sizeof(ION_WRITER_OPTIONS));
+    options.output_as_binary = FALSE;
+    options.pretty_print = FALSE;
+
+    memset(buffer, 0, sizeof(buffer));
+    IONCHECK(ion_writer_open_buffer(&writer, buffer, sizeof(buffer), &options));
+    IONCHECK(ion_writer_write_float(writer, 1.5f));
+    IONCHECK(ion_writer_finish(writer, &bytes_written));
+    IONCHECK(ion_writer_close(writer));
+
+    // Verify global locale is unchanged after writer operations
+    locale_after_writer = setlocale(LC_ALL, NULL);
+    EXPECT_STREQ(locale_before_writer_copy, locale_after_writer)
+        << "Global locale changed during writer operation - before: " << locale_before_writer_copy
+        << ", after: " << locale_after_writer;
+
+    // Convert to string for verification
+    output.assign((char*)buffer, bytes_written);
+
+    // Should contain "1.5" and NOT contain any commas as decimal separators
+    EXPECT_NE(std::string::npos, output.find("1.5"))
+        << "Expected '1.5' in output, got: " << output;
+    EXPECT_EQ(std::string::npos, output.find("1,5"))
+        << "Found incorrect comma decimal separator in output: " << output;
+
+    writer = NULL;
+
+fail:
+    // Restore original locale
+    if (original_locale_copy[0]) {
+        setlocale(LC_ALL, original_locale_copy);
+    }
+    if (writer) {
+        ion_writer_close(writer);
+    }
+    ASSERT_EQ(IERR_OK, err);
 }


### PR DESCRIPTION
*Issue #, if available:*
Fixes #364

*Description of changes:*
Previous iterations of this fix attempted to pass in a custom locale (platform-specific functions required) or temporarily modify the global locale (thread-safety issues). Instead, we use a simple solution substitutes any `,` in formatted floats with `.`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
