### PR TITLE
Address issues with debug allocator, and utf-8 escape sequences

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
       # Amazon Linux needs a newer version of git installed for actions/checkout
       - name: Install Dependencies
         run: |
-          yum install which git make cmake3 -y
+          yum install which git make cmake3 libasan libubsan -y
           if [ ! -e '/usr/bin/cmake' ]; then ln -s "$(which cmake3)" /usr/bin/cmake; fi
       - name: Install ${{ matrix.compiler.cc }}
         run: yum install ${{ matrix.compiler.packages }} -y

--- a/ionc/ion_allocation.c
+++ b/ionc/ion_allocation.c
@@ -228,9 +228,18 @@ SIZE debug_pattern_size = sizeof(debug_pattern);
 void *debug_malloc(SIZE size, const char *file, int line) 
 {
     BYTE   *ptr, *psize, *head, *user, *tail;
-    SIZE  adjusted_size = size + 2*debug_pattern_size * 2 + sizeof(SIZE);
+    SIZE overhead = 2 * debug_pattern_size * 2 + sizeof(SIZE);
+    SIZE adjusted_size = 0;
 
     assert( debug_pattern_size == 8 ); // just to make sure we're getting the right value and know what's actually happening
+
+    // Check for integer overflow in the adjusted_size calculation
+    // SIZE is int32_t, so we need to ensure size + overhead doesn't exceed INT32_MAX
+    if (size < 0 || size > (MAX_SIZE - overhead)) {
+       return NULL; // Allocation request too large or invalid
+    }
+
+    adjusted_size = size + overhead;
 
     ptr = (BYTE *)malloc(adjusted_size);
 

--- a/ionc/ion_writer_text.c
+++ b/ionc/ion_writer_text.c
@@ -1275,6 +1275,10 @@ iERR _ion_writer_text_append_escape_sequence_string(ION_STREAM *poutput, BOOL do
     else {
         len = (SIZE)(limit - cp);
         if (len > 4) len = 4;
+
+        // Initialize the entire buffer to prevent memory disclosure
+        memset(unicode_buffer, 0, sizeof(unicode_buffer));
+
         for (ii=0; ii<len; ii++) {
             unicode_buffer[ii] = cp[ii];
         }
@@ -1305,6 +1309,10 @@ iERR _ion_writer_text_append_escape_sequence_cstr_limit(ION_STREAM *poutput, cha
     else {
         len = (SIZE)(limit - cp);
         if (len > 4) len = 4;
+
+        // Initialize the entire buffer to prevent memory disclosure
+        memset(temp_buffer, 0, sizeof(temp_buffer));
+
         strncpy(temp_buffer, cp, len);
         IONCHECK(_ion_writer_text_read_unicode_scalar(temp_buffer, &ilen, &unicode_scalar));
         len = ilen;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR addresses 2 issues:
* A potential integer overflow when using the debug allocator.
* Potential for uninitialized memory to be included as part of a UTF-8 escape sequence.
 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
