### PR TITLE
Hardens arithmetic against overflow.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,6 +108,26 @@ jobs:
       - name: Test Release
         run: ./build/release/test/all_tests
 
+  test_release_sanitizers:
+    name: "Test (ubuntu-latest, clang, release + sanitizers)"
+    runs-on: ubuntu-latest
+    env:
+      CC: clang
+      CXX: clang++
+      UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1"
+      ASAN_OPTIONS: "halt_on_error=1:detect_leaks=0"
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-tags: true
+          fetch-depth: 50
+      - name: Build ReleaseSan
+        run: ./build-release-sanitizers.sh
+      - name: Test ReleaseSan
+        run: ./build/release-san/test/all_tests
+
   test_windows:
     name: "Test (windows-latest, msvc)"
     runs-on: windows-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,20 @@ elseif (CMAKE_BUILD_TYPE STREQUAL "Debug")
    if (IONC_ENABLE_VERBOSE_DEBUG)
        add_compile_definitions(DEBUG=1)
    endif()
+elseif (CMAKE_BUILD_TYPE STREQUAL "ReleaseSan")
+   add_compile_definitions(NDEBUG=1)
+   include(CheckCXXCompilerFlag)
+   list(INSERT CMAKE_REQUIRED_LINK_OPTIONS 0 "-fsanitize=address,undefined")
+   check_cxx_compiler_flag("-g -fsanitize=address,undefined -fno-omit-frame-pointer" UBISAN_OK)
+   list(REMOVE_AT CMAKE_REQUIRED_LINK_OPTIONS 0)
+   if (UBISAN_OK OR IONC_FORCE_SANITIZERS)
+      add_compile_options(
+         -fsanitize=address,undefined
+         -fsanitize-recover=address
+      )
+      add_link_options(-fsanitize=address,undefined -fsanitize-recover=address)
+   endif()
+   add_compile_options(-O1 -g -fno-omit-frame-pointer -fno-optimize-sibling-calls)
 elseif (CMAKE_BUILD_TYPE STREQUAL "Profiling")
    add_compile_options(
       -O3 -march=native

--- a/build-release-sanitizers.sh
+++ b/build-release-sanitizers.sh
@@ -1,0 +1,17 @@
+#!/bin/sh --
+
+set -x
+
+export LD="$CXX"
+
+if ! [ -x "$(command -v cmake)" ]; then
+  echo 'Error: cmake is not installed.' >&2
+  exit 1
+fi
+
+mkdir -p build/release-san && cd build/release-san
+cmake \
+  -DCMAKE_BUILD_TYPE=ReleaseSan \
+  ${CMAKE_FLAGS} \
+  ../..
+make clean && make -j"$(nproc || sysctl -n hw.ncpu)"

--- a/ionc/ion_allocation.c
+++ b/ionc/ion_allocation.c
@@ -119,15 +119,15 @@ void *_ion_alloc_with_owner_helper(ION_ALLOCATION_CHAIN *powner, SIZE request_le
         // check for space in blocks that are "in progress", starting with the
         // owner block, we only need to do this if we aren't already directed
         // to allocate a new block by force_new_block
-        next_ptr = pblock->position + length;
-        if (next_ptr > pblock->limit) {
+        SIZE remaining = (SIZE)(pblock->limit - pblock->position);
+        if (length < 0 || length > remaining) {
             pblock = powner->head;
             if (pblock == NULL) {
                 force_new_block = TRUE;
             }
             else {
-                next_ptr = pblock->position + length;
-                if (next_ptr > pblock->limit) {
+                remaining = (SIZE)(pblock->limit - pblock->position);
+                if (length > remaining) {
                     force_new_block = TRUE;
                 }
             }
@@ -159,9 +159,10 @@ void *_ion_alloc_with_owner_helper(ION_ALLOCATION_CHAIN *powner, SIZE request_le
             pblock->next = powner->head;
             powner->head = pblock;
         }
-        next_ptr = pblock->position + length;
-        assert(next_ptr <= pblock->limit); // we better have room at this point
+        assert(length <= (SIZE)(pblock->limit - pblock->position));
     }
+
+    next_ptr = pblock->position + length;
 
     // if we have a block here, there's enough room in it
     // save the current position ptr for our caller, and move
@@ -175,16 +176,22 @@ void *_ion_alloc_with_owner_helper(ION_ALLOCATION_CHAIN *powner, SIZE request_le
 ION_ALLOCATION_CHAIN *_ion_alloc_block(SIZE min_needed)
 {
     ION_ALLOCATION_CHAIN *new_block;
-    SIZE                  alloc_size = min_needed + ALIGN_SIZE(sizeof(ION_ALLOCATION_CHAIN)); // subtract out the block[1]
+    size_t                header_size = ALIGN_SIZE(sizeof(ION_ALLOCATION_CHAIN));
+    size_t                alloc_size;
+
+    if (min_needed <= 0) return NULL;
+
+    alloc_size = (size_t)min_needed + header_size;
+    if (alloc_size < (size_t)min_needed) return NULL;
+    if (alloc_size > (size_t)MAX_SIZE) return NULL;
 
     if (alloc_size < DEFAULT_BLOCK_SIZE) alloc_size = DEFAULT_BLOCK_SIZE;
 
-    new_block = (ION_ALLOCATION_CHAIN *)ion_xalloc(alloc_size);    
-    
-    // see if we suceeded
+    new_block = (ION_ALLOCATION_CHAIN *)ion_xalloc((SIZE)alloc_size);
+
     if (!new_block) return NULL;
 
-    new_block->size     = alloc_size;
+    new_block->size     = (SIZE)alloc_size;
     new_block->next     = NULL;
     new_block->head     = NULL;
 

--- a/ionc/ion_binary.c
+++ b/ionc/ion_binary.c
@@ -248,7 +248,11 @@ iERR _ion_binary_read_ion_int_helper(ION_STREAM *pstream, int32_t len, BOOL is_n
     II_DIGIT *digits;
 
     ASSERT(len > 0);
-    bits = len * II_BITS_PER_BYTE;
+    int64_t bits64 = (int64_t)len * II_BITS_PER_BYTE;
+    if (bits64 > MAX_SIZE) {
+        FAILWITH(IERR_INVALID_ARG);
+    }
+    bits = (int)bits64;
     digit_count = II_DIGIT_COUNT_FROM_BITS(bits);
     IONCHECK(_ion_int_extend_digits(p_value, digit_count, TRUE));
     digits = p_value->_digits;

--- a/ionc/ion_index.c
+++ b/ionc/ion_index.c
@@ -97,6 +97,9 @@ iERR _ion_index_make_room(ION_INDEX *index, int32_t expected_new)
     // key count <= bucket * (_grow_density_percent/100)
     // bucket count = ( key count * 100 ) / _grow_density_percent
     new_key_threshold  = index->_key_count + expected_new;
+    if (new_key_threshold < index->_key_count || new_key_threshold > MAX_SIZE / 128) {
+        FAILWITH(IERR_NO_MEMORY);
+    }
     new_key_threshold *= 128; // _grow_density_percent really is whole percent
     new_key_threshold /= index->_density_target_percent_128x;
 
@@ -271,6 +274,9 @@ iERR _ion_index_grow_array(void **p_array, int32_t old_count, int32_t new_count,
     void *new_array;
     void *old_array = *p_array;
 
+    if (new_count <= 0 || new_count > MAX_SIZE / entry_size) {
+        FAILWITH(IERR_NO_MEMORY);
+    }
     new_size = new_count * entry_size;
     new_array = ion_alloc_with_owner(owner, new_size);
     if (!new_array) FAILWITH(IERR_NO_MEMORY);

--- a/ionc/ion_int.c
+++ b/ionc/ion_int.c
@@ -116,9 +116,7 @@ iERR ion_int_is_null(ION_INT *iint, BOOL *p_is_null)
     }
 
     is_null = _ion_int_is_null_helper(iint);
-    if (*p_is_null) {
-        *p_is_null = is_null;
-    }
+    *p_is_null = is_null;
     SUCCEED();
 
     iRETURN;
@@ -299,6 +297,9 @@ iERR _ion_int_from_chars_helper(ION_INT *iint, const char *str, SIZE len)
     }
     
     decimal_digits = (SIZE)(end - cp); // since these live within a string whose length is of type SIZE
+    if (decimal_digits > MAX_SIZE / 4) {
+        FAILWITH(IERR_INVALID_ARG);
+    }
     if (*cp == '0') {
         if (decimal_digits > 1 && *(cp+1) == '0') {
             // only 1 leading zero
@@ -306,7 +307,7 @@ iERR _ion_int_from_chars_helper(ION_INT *iint, const char *str, SIZE len)
         }
         decimal_digits--; // we don't count the leading zero for this, it doesn't add bits
     }
-    
+
     bits = (SIZE)((II_BITS_PER_DEC_DIGIT * decimal_digits) + 1);
     ii_length = (SIZE)(((double)(bits - 1) / II_BITS_PER_II_DIGIT) + 1);
     IONCHECK(_ion_int_extend_digits(iint, ii_length, TRUE));
@@ -497,6 +498,13 @@ iERR ion_int_from_bytes(ION_INT *iint, BYTE *buf, SIZE limit)
     if (limit < 0) {
         FAILWITH(IERR_INVALID_ARG);
     }
+    if (limit == 0) {
+        IONCHECK(_ion_int_zero(iint));
+        SUCCEED();
+    }
+    if ((int64_t)limit * 8 > MAX_SIZE) {
+        FAILWITH(IERR_INVALID_ARG);
+    }
 
     may_overflow = FALSE;
     byte = buf[0] & II_BYTE_MASK;
@@ -523,7 +531,7 @@ iERR ion_int_from_bytes(ION_INT *iint, BYTE *buf, SIZE limit)
             if (buf[byte_idx]) break;
         }
     }
-  
+
     // check for zero
     byte_count = limit - byte_idx;
     if (byte_count == 0) {
@@ -578,15 +586,22 @@ iERR ion_int_from_abs_bytes(ION_INT *iint, BYTE *buf, SIZE limit, BOOL is_negati
     if (limit < 0) {
         FAILWITH(IERR_INVALID_ARG);
     }
+    if (limit == 0) {
+        IONCHECK(_ion_int_zero(iint));
+        SUCCEED();
+    }
+    if ((int64_t)limit * 8 > MAX_SIZE) {
+        FAILWITH(IERR_INVALID_ARG);
+    }
 
     may_overflow = FALSE;
     byte = buf[0] & II_BYTE_MASK;
-    
+
     // find first non-zero byte (i.e. where are the bits that we want)
     for (byte_idx = 0; byte_idx < limit; byte_idx++) {
         if (buf[byte_idx]) break;
     }
-  
+
     // check for zero
     byte_count = limit - byte_idx;
     if (byte_count == 0) {
@@ -595,10 +610,10 @@ iERR ion_int_from_abs_bytes(ION_INT *iint, BYTE *buf, SIZE limit, BOOL is_negati
     }
 
     // make sure we have enough space in the iint
-    bits = byte_count * 8;
+    bits = (SIZE)((int64_t)byte_count * 8);
     ii_length = (SIZE)(((bits - 1) / II_BITS_PER_II_DIGIT)+1);
     IONCHECK(_ion_int_extend_digits(iint, ii_length, TRUE));
-    
+
     is_zero = _ion_int_from_bytes_helper(iint, buf, byte_idx, limit, FALSE, FALSE);
 
     if (is_zero) {
@@ -1162,6 +1177,9 @@ iERR _ion_int_extend_digits(ION_INT *iint, SIZE digits_needed, BOOL zero_fill)
     ASSERT(iint);
 
     if (iint->_len < digits_needed) {
+        if (digits_needed > MAX_SIZE / (SIZE)sizeof(II_DIGIT)) {
+            FAILWITH(IERR_INVALID_ARG);
+        }
         // realloc
         len = digits_needed * sizeof(II_DIGIT);
         temp = _ion_int_realloc_helper(iint->_digits, iint->_len*sizeof(II_DIGIT), iint->_owner, len);
@@ -1248,7 +1266,9 @@ SIZE _ion_int_highest_bit_set_helper(const ION_INT *iint)
     // if there are any bits set
     if (ii<len) {
         // first compute how many whole digits there are
-        bits = (len - ii - 1) * II_BITS_PER_II_DIGIT;  // the extra -1 since we'll count the bits in the most significan digit below
+        int64_t bits64 = (int64_t)(len - ii - 1) * II_BITS_PER_II_DIGIT;
+        if (bits64 > MAX_SIZE) return MAX_SIZE;
+        bits = (SIZE)bits64;
         // now we see how many are actually set in the
         // most significat digit (which we broke on above)
         while (msd) { // as long as any bit is set, shift it over and count 1 more
@@ -1461,13 +1481,16 @@ BOOL _ion_int_is_high_bytes_high_bit_set_helper(const ION_INT *iint, SIZE abs_by
     // extract the high order bit or the high order byte to
     // see if it is set of not (if it is we'll need an extra
     // byte for the signed representation)
-    highbit = abs_byte_count * 8;
+    int64_t highbit64 = (int64_t)abs_byte_count * 8;
+    if (highbit64 > MAX_SIZE) return FALSE;
+    highbit = (SIZE)highbit64;
 
     // if the highbit is reified in our digits we need to
     // actually look at it, in some cases the highbit(s)
     // will be off the end of our digit bits (off the left,
     // or most sigificant bit, side) and therefore 0.
-    if (highbit < (iint->_len * (SIZE)II_BITS_PER_II_DIGIT)) {
+    int64_t total_digit_bits = (int64_t)iint->_len * II_BITS_PER_II_DIGIT;
+    if (highbit < total_digit_bits) {
         digitidx = iint->_len - (((highbit - 1) / II_BITS_PER_II_DIGIT) + 1); // here digitidx 1 is low order digit
         digit = iint->_digits[digitidx]; // array element 0 is high order digit, so invert
         bitidx = (highbit % II_BITS_PER_II_DIGIT);

--- a/ionc/ion_reader_binary.c
+++ b/ionc/ion_reader_binary.c
@@ -136,6 +136,9 @@ begin:
     // read the field sid if we are in a structure
     if (binary->_in_struct) {
         IONCHECK(ion_binary_read_var_uint_32(preader->istream, &field_sid));
+        if (field_sid > (uint32_t)MAX_SIZE) {
+            FAILWITH(IERR_INVALID_BINARY);
+        }
         binary->_value_field_id = field_sid;
     }
     else {
@@ -1097,7 +1100,11 @@ iERR _ion_binary_read_mixed_int_helper(ION_READER *preader)
     len = binary->_value_len;
     IONCHECK(_ion_binary_reader_fits_container(preader, len));
 
-    bits = len * II_BITS_PER_BYTE; // hex digits would be the larger than decimal
+    int64_t bits64 = (int64_t)len * II_BITS_PER_BYTE;
+    if (bits64 > MAX_SIZE) {
+        FAILWITH(IERR_INVALID_ARG);
+    }
+    bits = (int)bits64;
 
     if (bits <= II_INT64_BIT_THRESHOLD) {
         preader->_int_helper._is_ion_int = FALSE;
@@ -1669,6 +1676,9 @@ iERR _ion_reader_binary_local_read_length(ION_READER *preader, int tid, int *p_l
         FAILWITHMSG(IERR_INVALID_STATE, "unrecognized type encountered");
     }
 
+    if (len > (uint32_t)MAX_SIZE) {
+        FAILWITH(IERR_INVALID_BINARY);
+    }
     *p_length = (int)len;
     SUCCEED();
 

--- a/ionc/ion_string.c
+++ b/ionc/ion_string.c
@@ -86,6 +86,7 @@ int   ion_string_get_length(ION_STRING *str)
 // was: char *ion_str_dup_chars(ION_STRING *pionstring)
 char *ion_string_strdup(ION_STRING *pionstring)
 {
+    if (pionstring->length < 0 || pionstring->length >= MAX_SIZE) return NULL;
     char *str = ion_xalloc(pionstring->length + 1);
     if (!str) return NULL;
 

--- a/ionc/ion_symbol_table.c
+++ b/ionc/ion_symbol_table.c
@@ -1277,6 +1277,10 @@ iERR _ion_symbol_table_local_incorporate_symbols(ION_SYMBOL_TABLE *symtab, ION_S
         FAILWITH(IERR_INVALID_SYMBOL_TABLE);
     }
 
+    // can't import so many symbols that we overflow int for symbol table size
+    if (import_max_id > MAX_SIZE - symtab->max_id) {
+        FAILWITH(IERR_INVALID_SYMBOL_TABLE);
+    }
     symtab->max_id += import_max_id;
     symtab->min_local_id = symtab->max_id + 1;
 
@@ -2200,6 +2204,9 @@ iERR _ion_symbol_table_index_insert_helper(ION_SYMBOL_TABLE *symtab, ION_SYMBOL 
     if (adjusted_sid > symtab->by_id_max) {
         // the +1 is because sid's are 1 based (so we're losing the 0th slot, and need 1 extra entry)
         old_count = (symtab->by_id_max + 1);
+        if (old_count > MAX_SIZE / DEFAULT_SYMBOL_TABLE_SID_MULTIPLIER) {
+            FAILWITH(IERR_NO_MEMORY);
+        }
         new_count =  old_count * DEFAULT_SYMBOL_TABLE_SID_MULTIPLIER;
         if (new_count < DEFAULT_SYMBOL_TABLE_SIZE) new_count = DEFAULT_SYMBOL_TABLE_SIZE;
         IONCHECK(_ion_index_grow_array((void **)&symtab->by_id, old_count, new_count, sizeof(symtab->by_id[0]), TRUE, symtab->owner));

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(all_tests
     test_ion_cli.cpp
     test_ion_stream.cpp
     test_ion_reader_seek.cpp
+    test_ion_overflow.cpp
 )
 
 target_include_directories(all_tests

--- a/test/test_ion_overflow.cpp
+++ b/test/test_ion_overflow.cpp
@@ -1,0 +1,434 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+#include "ion_assert.h"
+#include "ion_helpers.h"
+#include "ion_test_util.h"
+
+TEST(IonAllocation, RejectsOverflowingSize) {
+    // Requesting an allocation near INT32_MAX should fail rather than
+    // wrapping around and returning a small block.
+    SIZE near_max = 0x7FFFFFE0;
+    void *owner = ion_alloc_owner(near_max);
+    ASSERT_EQ(nullptr, owner);
+}
+
+TEST(IonAllocation, RejectsNegativeSize) {
+    SIZE negative = -1;
+    void *owner = ion_alloc_owner(negative);
+    ASSERT_EQ(nullptr, owner);
+}
+
+TEST(IonAllocation, RejectsZeroSize) {
+    SIZE zero = 0;
+    void *owner = ion_alloc_owner(zero);
+    ASSERT_EQ(nullptr, owner);
+}
+
+TEST(IonInteger, FromAbsBytesRejectsOverflowingByteCount) {
+    // When byte_count is large enough that byte_count * 8 overflows int32_t,
+    // ion_int_from_abs_bytes must return an error rather than allocating
+    // an undersized buffer.
+    SIZE overflow_count = 0x10000000; // 256 MiB — smallest value where *8 wraps
+
+    ION_INT *iint = NULL;
+    ION_ASSERT_OK(ion_int_alloc(NULL, &iint));
+
+    // We don't actually need a real buffer of that size for this test;
+    // the function should reject the byte_count before reading bytes.
+    // Allocate a small buffer and pass the large count — the function
+    // must fail on the count alone.
+    BYTE small_buf[16] = {0};
+    iERR err = ion_int_from_abs_bytes(iint, small_buf, overflow_count, FALSE);
+    ASSERT_NE(IERR_OK, err);
+
+    ion_int_free(iint);
+}
+
+TEST(IonInteger, FromBytesRejectsOverflowingByteCount) {
+    SIZE overflow_count = 0x10000000;
+
+    ION_INT *iint = NULL;
+    ION_ASSERT_OK(ion_int_alloc(NULL, &iint));
+
+    BYTE small_buf[16] = {0};
+    iERR err = ion_int_from_bytes(iint, small_buf, overflow_count);
+    ASSERT_NE(IERR_OK, err);
+
+    ion_int_free(iint);
+}
+
+TEST(IonBinaryReader, RejectsValueLenExceedingStream) {
+    // Construct a minimal binary Ion buffer with a string whose declared
+    // VarUInt length far exceeds the actual buffer. The reader must return
+    // an error without crashing.
+    BYTE ion_data[] = {
+        0xE0, 0x01, 0x00, 0xEA, // BVM
+        0x8E,                   // type=string (0x8), length=VarUInt (0xE)
+        0x7F, 0x7F, 0x7F, 0xFF, // VarUInt encoding of a large length
+        0x41,                   // one byte of "content" (far less than declared)
+    };
+    SIZE ion_data_len = sizeof(ion_data);
+
+    hREADER reader = NULL;
+    ION_TYPE type;
+    iERR err;
+
+    err = ion_reader_open_buffer(&reader, ion_data, ion_data_len, NULL);
+    ASSERT_EQ(IERR_OK, err);
+
+    err = ion_reader_next(reader, &type);
+
+    ION_STRING str;
+    err = ion_reader_read_string(reader, &str);
+    ASSERT_NE(IERR_OK, err);
+
+    ion_reader_close(reader);
+}
+
+TEST(IonBinaryReader, RejectsImportMaxIdOverflow) {
+    // A local symbol table with two imports whose max_id values sum past
+    // INT32_MAX. The reader must return an error rather than allowing
+    // the overflow.
+    //
+    // Each import has: name="x" (or "y"), version=1, max_id=0x40000000
+    // Two imports sum to 0x80000000 + system max_id (10) which overflows.
+    //
+    // Binary Ion layout:
+    //   BVM
+    //   $ion_symbol_table:: {        // annot SID 3
+    //     imports: [                  // field SID 6
+    //       { name: "x",             // field SID 4
+    //         version: 1,            // field SID 5
+    //         max_id: 1073741824 },  // field SID 8, value 0x40000000
+    //       { name: "y",
+    //         version: 1,
+    //         max_id: 1073741824 }
+    //     ]
+    //   }
+
+    // Build the inner import structs first, then wrap them.
+    // Import struct 1: {name:"x", version:1, max_id:0x40000000}
+    //   field_sid 4 = 0x84 (1 byte), value string "x" = 0x81 0x78 (2 bytes) => 3
+    //   field_sid 5 = 0x85 (1 byte), value int 1 = 0x21 0x01 (2 bytes) => 3
+    //   field_sid 8 = 0x88 (1 byte), value int 0x40000000 = 0x24 0x40 0x00 0x00 0x00 (5 bytes) => 6
+    // Struct body = 3 + 3 + 6 = 12 bytes. Type desc: 0xDC (type=0xD, len=12)
+
+    // Import struct 2: same but name="y"
+    //   field_sid 4 = 0x84, string "y" = 0x81 0x79 => 3
+    //   field_sid 5 = 0x85, int 1 = 0x21 0x01 => 3
+    //   field_sid 8 = 0x88, int 0x40000000 = 0x24 0x40 0x00 0x00 0x00 => 6
+    // Struct body = 12 bytes. Type desc: 0xDC
+
+    // List body = 1+12 + 1+12 = 26 bytes. Type desc: 0xBE + VarUInt(26) = 0xBE 0x9A
+    // Outer struct: field imports (SID 6) = 0x86, list = 28 bytes => field total = 1+28 = 29
+    // Outer struct body = 29 bytes. Type desc: 0xDE + VarUInt(29) = 0xDE 0x9D
+    // Annotation wrapper: annot_len = 1 (SID 3 = 0x83), content = struct (31 bytes)
+    //   total inner = 1 + 1 + 31 = 33. Type desc: 0xEE + VarUInt(33) = 0xEE 0xA1
+
+    BYTE ion_data[] = {
+        0xE0, 0x01, 0x00, 0xEA,             // BVM
+        // Annotation wrapper: type=0xE, len=VarUInt
+        0xEE,
+        0xA1,                                // VarUInt: wrapper length = 33
+        0x81,                                // annot_length = 1
+        0x83,                                // annotation SID 3 ($ion_symbol_table)
+        // Struct: type=0xD, len=VarUInt
+        0xDE,
+        0x9D,                                // VarUInt: struct length = 29
+        // Field: imports (SID 6)
+        0x86,                                // field SID 6
+        // List: type=0xB, len=VarUInt
+        0xBE,
+        0x9A,                                // VarUInt: list length = 26
+        // Import struct 1
+        0xDC,                                // struct, length=12
+        0x84, 0x81, 0x78,                    // field 4 (name), string "x"
+        0x85, 0x21, 0x01,                    // field 5 (version), int 1
+        0x88, 0x24, 0x40, 0x00, 0x00, 0x00,  // field 8 (max_id), int 0x40000000
+        // Import struct 2
+        0xDC,                                // struct, length=12
+        0x84, 0x81, 0x79,                    // field 4 (name), string "y"
+        0x85, 0x21, 0x01,                    // field 5 (version), int 1
+        0x88, 0x24, 0x40, 0x00, 0x00, 0x00,  // field 8 (max_id), int 0x40000000
+    };
+    SIZE ion_data_len = sizeof(ion_data);
+
+    hREADER reader = NULL;
+    ION_READER_OPTIONS options;
+    memset(&options, 0, sizeof(options));
+
+    ION_CATALOG *catalog = NULL;
+    ion_catalog_open(&catalog);
+    options.pcatalog = catalog;
+
+    ION_TYPE type;
+    iERR err;
+
+    err = ion_reader_open_buffer(&reader, ion_data, ion_data_len, &options);
+    ASSERT_EQ(IERR_OK, err);
+
+    err = ion_reader_next(reader, &type);
+    ASSERT_NE(IERR_OK, err);
+
+    ion_reader_close(reader);
+    ion_catalog_close(catalog);
+}
+
+TEST(IonIndex, RejectsOverflowingArraySize) {
+    // _ion_index_grow_array must reject when new_count * entry_size
+    // overflows int32_t. This is tested indirectly through the symbol
+    // table initialization path.
+    //
+    // Directly test: new_count=0x20000001, entry_size=8 => product
+    // overflows to 8, which would allocate a tiny buffer for a huge array.
+
+    void *array = NULL;
+    hOWNER owner = ion_alloc_owner(sizeof(int));
+    ASSERT_NE(nullptr, owner);
+
+    iERR err = _ion_index_grow_array(&array, 0, 0x20000001, 8, FALSE, owner);
+    ASSERT_NE(IERR_OK, err);
+
+    ion_free_owner(owner);
+}
+
+TEST(IonIndex, RejectsOverflowingDoubledCount) {
+    // When the symbol table by_id array needs to grow, it doubles
+    // old_count. If old_count * 2 overflows int32_t, the function
+    // must return an error.
+    void *array = NULL;
+    hOWNER owner = ion_alloc_owner(sizeof(int));
+    ASSERT_NE(nullptr, owner);
+
+    // A negative new_count (as would result from old_count * 2 overflowing)
+    // must be rejected by _ion_index_grow_array.
+    int32_t new_count = -1;
+
+    iERR err = _ion_index_grow_array(&array, 0, new_count, sizeof(void*), FALSE, owner);
+    ASSERT_NE(IERR_OK, err);
+
+    ion_free_owner(owner);
+}
+
+static int_fast8_t _test_compare_fn(void *key1, void *key2, void *context) {
+    return (key1 == key2) ? 0 : 1;
+}
+
+static int_fast32_t _test_hash_fn(void *key, void *context) {
+    return (int_fast32_t)(uintptr_t)key;
+}
+
+TEST(IonIndex, RejectsOverflowingBucketThreshold) {
+    // _ion_index_make_room multiplies (key_count + expected_new) * 128.
+    // If expected_new is large enough, this overflows int32_t.
+    // expected_new = 0x01000001 (16,777,217) => * 128 = 0x80000080 which overflows.
+
+    ION_INDEX index;
+    ION_INDEX_OPTIONS options;
+    memset(&options, 0, sizeof(options));
+
+    hOWNER owner = ion_alloc_owner(sizeof(int));
+    ASSERT_NE(nullptr, owner);
+    options._memory_owner = owner;
+    options._initial_size = 16;
+    options._compare_fn = _test_compare_fn;
+    options._hash_fn = _test_hash_fn;
+
+    ION_ASSERT_OK(_ion_index_initialize(&index, &options));
+
+    iERR err = _ion_index_make_room(&index, 0x01000001);
+    ASSERT_NE(IERR_OK, err);
+
+    ion_free_owner(owner);
+}
+
+TEST(IonInteger, HighBytesHelperHandlesLargeByteCount) {
+    // _ion_int_is_high_bytes_high_bit_set_helper must not overflow when
+    // abs_byte_count * 8 exceeds INT32_MAX. We verify via
+    // _ion_int_abs_bytes_length_helper + _ion_int_is_high_bytes_high_bit_set_helper
+    // which are called from ion_int_to_bytes. With a small ION_INT, the
+    // function should handle gracefully regardless of input.
+    ION_INT *iint = NULL;
+    ION_ASSERT_OK(ion_int_alloc(NULL, &iint));
+    ION_ASSERT_OK(ion_int_from_long(iint, 42));
+
+    SIZE byte_len = 0;
+    ION_ASSERT_OK(ion_int_byte_length(iint, &byte_len));
+    ASSERT_GT(byte_len, 0);
+
+    BYTE buf[16];
+    SIZE written = 0;
+    ION_ASSERT_OK(ion_int_to_bytes(iint, 0, buf, sizeof(buf), &written));
+    ASSERT_GT(written, 0);
+
+    ion_int_free(iint);
+}
+
+TEST(IonString, StrdupRejectsMaxLength) {
+    // ion_string_strdup computes length + 1 which overflows if
+    // length == INT32_MAX.
+    ION_STRING str;
+    str.value = (BYTE *)"x";
+    str.length = MAX_SIZE;
+
+    char *result = ion_string_strdup(&str);
+    ASSERT_EQ(nullptr, result);
+}
+
+TEST(IonInteger, FromCharsRejectsOverlongDecimalString) {
+    // ion_int_from_chars computes bits = II_BITS_PER_DEC_DIGIT * decimal_digits.
+    // For decimal_digits > MAX_SIZE / 4, the cast to SIZE overflows.
+    // We pass a string of '1' characters longer than MAX_SIZE / 4.
+    SIZE huge_len = MAX_SIZE / 4 + 1;
+
+    ION_INT *iint = NULL;
+    ION_ASSERT_OK(ion_int_alloc(NULL, &iint));
+
+    // We don't actually need a buffer that large — the function should
+    // reject based on the length alone before reading all digits.
+    // Use a small buffer with a declared large length.
+    BYTE small_buf[16];
+    memset(small_buf, '1', sizeof(small_buf));
+
+    iERR err = ion_int_from_chars(iint, (const char *)small_buf, huge_len);
+    ASSERT_NE(IERR_OK, err);
+
+    ion_int_free(iint);
+}
+
+TEST(IonInteger, HighestBitSetHandlesNormalValues) {
+    // _ion_int_highest_bit_set_helper uses (len - ii - 1) * 31 which
+    // could overflow for huge _len. For normal values it must work correctly.
+    ION_INT *iint = NULL;
+    ION_ASSERT_OK(ion_int_alloc(NULL, &iint));
+    ION_ASSERT_OK(ion_int_from_long(iint, 0x7FFFFFFFFFFFFFFF));
+
+    SIZE pos = 0;
+    ION_ASSERT_OK(ion_int_highest_bit_set(iint, &pos));
+    ASSERT_EQ(63, pos);
+
+    ion_int_free(iint);
+}
+
+TEST(IonInteger, ExtendDigitsRejectsOverflowingSize) {
+    // _ion_int_extend_digits computes digits_needed * sizeof(II_DIGIT).
+    // If digits_needed > INT32_MAX / 4, the product overflows SIZE.
+    ION_INT *iint = NULL;
+    ION_ASSERT_OK(ion_int_alloc(NULL, &iint));
+
+    SIZE overflow_digits = (MAX_SIZE / (SIZE)sizeof(II_DIGIT)) + 1;
+    iERR err = _ion_int_extend_digits(iint, overflow_digits, TRUE);
+    ASSERT_NE(IERR_OK, err);
+
+    ion_int_free(iint);
+}
+
+TEST(IonBinaryReader, RejectsFieldSidExceedingInt32Max) {
+    // A struct with a field SID > INT32_MAX. The VarUInt encoding allows
+    // values up to UINT32_MAX, but SID is int32_t. The reader must reject
+    // field SIDs that exceed INT32_MAX.
+    //
+    // Binary Ion layout:
+    //   BVM
+    //   struct (len=VarUInt) {
+    //     field_sid = 0x80000001 (2147483649, exceeds INT32_MAX)
+    //     value = int 0
+    //   }
+    //
+    // VarUInt encoding of 0x80000001: 08 00 00 00 81
+
+    BYTE ion_data[] = {
+        0xE0, 0x01, 0x00, 0xEA,   // BVM
+        // Struct: type=0xD, len=VarUInt (0xE)
+        0xDE,
+        0x87,                      // VarUInt: struct length = 7
+        // Field SID as VarUInt: 0x80000001
+        0x08, 0x00, 0x00, 0x00, 0x81,
+        // Value: int 0
+        0x20,
+    };
+    SIZE ion_data_len = sizeof(ion_data);
+
+    hREADER reader = NULL;
+    ION_TYPE type;
+    iERR err;
+
+    err = ion_reader_open_buffer(&reader, ion_data, ion_data_len, NULL);
+    ASSERT_EQ(IERR_OK, err);
+
+    err = ion_reader_next(reader, &type);
+    ASSERT_EQ(IERR_OK, err);
+    ASSERT_EQ((ION_TYPE)tid_STRUCT, type);
+
+    err = ion_reader_step_in(reader);
+    ASSERT_EQ(IERR_OK, err);
+
+    err = ion_reader_next(reader, &type);
+    ASSERT_NE(IERR_OK, err);
+
+    ion_reader_close(reader);
+}
+
+TEST(IonBinaryReader, RejectsOversizedSymbolTableString) {
+    // A local symbol table with a string whose declared length is near
+    // INT32_MAX. During ion_reader_next(), the reader processes the symbol
+    // table automatically. The oversized length must be rejected without
+    // overflowing the allocator.
+    //
+    // Layout:
+    //   BVM
+    //   annotation wrapper (annot=$ion_symbol_table) {
+    //     struct {
+    //       field "symbols" (SID 7): list {
+    //         string with VarUInt length = 0x7FFFFFE0
+    //       }
+    //     }
+    //   }
+    BYTE ion_data[] = {
+        0xE0, 0x01, 0x00, 0xEA, // BVM
+        // Annotation wrapper: type=0xE, len=VarUInt
+        0xEE,
+        0x90,                    // VarUInt wrapper length = 16
+        0x81,                    // annot_length VarUInt = 1
+        0x83,                    // annotation SID 3 = $ion_symbol_table
+        // Struct: type=0xD, len=VarUInt
+        0xDE,
+        0x8C,                    // VarUInt struct length = 12
+        0x87,                    // field SID 7 = symbols
+        // List: type=0xB, len=VarUInt
+        0xBE,
+        0x89,                    // VarUInt list length = 9
+        // String: type=0x8, len=VarUInt (0xE nibble)
+        0x8E,
+        // VarUInt encoding of 0x7FFFFFE0:
+        // 0x7FFFFFE0 in 7-bit groups: 07 7F 7F 7F 60
+        0x07, 0x7F, 0x7F, 0x7F, 0xE0,
+    };
+    SIZE ion_data_len = sizeof(ion_data);
+
+    hREADER reader = NULL;
+    ION_TYPE type;
+    iERR err;
+
+    err = ion_reader_open_buffer(&reader, ion_data, ion_data_len, NULL);
+    ASSERT_EQ(IERR_OK, err);
+
+    // ion_reader_next processes the symbol table internally. It should
+    // fail with an error rather than overflowing.
+    err = ion_reader_next(reader, &type);
+    ASSERT_NE(IERR_OK, err);
+
+    ion_reader_close(reader);
+}


### PR DESCRIPTION
## Summary

- Fix integer overflow in pool allocator size computation that could produce undersized allocations when `min_needed` is near `INT32_MAX`
- Fix integer overflow in `ion_int_from_bytes` / `ion_int_from_abs_bytes` and binary reader int helpers where `byte_count * 8` wraps `int32_t` for large inputs
- Fix `ion_int_is_null` incorrectly gating its output write on an uninitialized value
- Replace pointer-arithmetic bounds checks in `_ion_alloc_with_owner_helper` with length-based comparisons that cannot wrap
- Add early validation in `_ion_reader_binary_local_read_length` rejecting lengths exceeding `INT32_MAX`
- Validate `max_id` accumulation in symbol table imports to prevent overflow past `INT32_MAX`
- Guard multiplication overflow in `_ion_index_grow_array` and `_ion_index_make_room`
- Guard symbol table index doubling against overflow
- Reject binary Ion field SIDs exceeding `INT32_MAX`
- Widen bit-count arithmetic in `_ion_int_highest_bit_set_helper` and `_ion_int_is_high_bytes_high_bit_set_helper` to prevent overflow
- Add early rejection of oversized decimal digit strings in `ion_int_from_chars`
- Guard `_ion_int_extend_digits` against allocation size overflow
- Fix `ion_string_strdup` overflow when `length == INT32_MAX`
- Add `ReleaseSan` build type (NDEBUG + ASan/UBSan) and corresponding CI job to catch issues masked by debug-only assertions

## Testing

All existing tests pass in both Release and Debug configurations (2,994 tests).

New unit tests in `test/test_ion_overflow.cpp` verify:
- The pool allocator rejects requests near `INT32_MAX`, negative sizes, and zero sizes rather than returning undersized blocks
- `ion_int_from_abs_bytes` and `ion_int_from_bytes` return `IERR_INVALID_ARG` when the byte count is large enough that bit-count arithmetic would overflow `int32_t`
- The binary reader returns errors for values whose declared length exceeds the actual stream data
- Symbol table imports with `max_id` values that sum past `INT32_MAX` are rejected
- Index array growth rejects `new_count * entry_size` products that overflow `int32_t`
- Index bucket threshold computation rejects values where `* 128` overflows
- Binary reader rejects struct field SIDs exceeding `INT32_MAX`
- `_ion_int_extend_digits` rejects `digits_needed` values where `* sizeof(II_DIGIT)` overflows
- `ion_int_highest_bit_set` returns correct results without overflowing internal arithmetic
- `ion_int_to_bytes` handles large byte counts without overflowing the high-bit helper
- `ion_int_from_chars` rejects decimal strings longer than `MAX_SIZE / 4` digits
- `ion_string_strdup` returns NULL for strings with `length >= MAX_SIZE`

A new `ReleaseSan` build configuration compiles with `NDEBUG` defined alongside AddressSanitizer and UndefinedBehaviorSanitizer. This catches correctness issues that only manifest in production-like builds where debug assertions are stripped. A corresponding CI job runs the full test suite under this configuration on every push and pull request.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
