### PR TITLE
Additional overflow hardening.

### DIFF
--- a/ionc/ion_int.c
+++ b/ionc/ion_int.c
@@ -274,14 +274,17 @@ iERR _ion_int_from_chars_helper(ION_INT *iint, const char *str, SIZE len)
     if (cp >= end) FAILWITH(IERR_INVALID_SYNTAX);
 
     switch(*cp) {
-    case 'n':
-        if (strncmp(cp, "null", 5) ||  strncmp(cp, "null.int", 9)) {
-            FAILWITH(IERR_INVALID_SYNTAX);
+    case 'n': {
+        SIZE remaining = (SIZE)(end - cp);
+        if ((remaining == 4 && memcmp(cp, "null", 4) == 0)
+            || (remaining == 8 && memcmp(cp, "null.int", 8) == 0)) {
+            iint->_signum = 0;
+            iint->_len = 0;
+            iint->_digits = NULL;
+            SUCCEED();
         }
-        iint->_signum = 0;
-        iint->_len = 0;
-        iint->_digits = NULL;
-        SUCCEED();
+        FAILWITH(IERR_INVALID_SYNTAX);
+    }
     case II_MINUS:
         signum = -1;
         // fall through to plus, then to default

--- a/ionc/ion_scanner.c
+++ b/ionc/ion_scanner.c
@@ -1288,7 +1288,7 @@ iERR _ion_scanner_skip_sexp(ION_SCANNER *scanner)
 {
     iENTER;
 
-    IONCHECK(_ion_scanner_skip_container(scanner, ')'));
+    IONCHECK(_ion_scanner_skip_container(scanner, ')', 0));
 
     iRETURN;
 }
@@ -1297,7 +1297,7 @@ iERR _ion_scanner_skip_list(ION_SCANNER *scanner)
 {
     iENTER;
 
-    IONCHECK(_ion_scanner_skip_container(scanner, ']'));
+    IONCHECK(_ion_scanner_skip_container(scanner, ']', 0));
 
     iRETURN;
 }
@@ -1306,15 +1306,19 @@ iERR _ion_scanner_skip_struct(ION_SCANNER *scanner)
 {
     iENTER;
 
-    IONCHECK(_ion_scanner_skip_container(scanner, '}'));
+    IONCHECK(_ion_scanner_skip_container(scanner, '}', 0));
 
     iRETURN;
 }
 
-iERR _ion_scanner_skip_container(ION_SCANNER *scanner, int close_char)
+iERR _ion_scanner_skip_container(ION_SCANNER *scanner, int close_char, int depth)
 {
     iENTER;
     int c;
+
+    if (depth >= ION_SCANNER_MAX_SKIP_DEPTH) {
+        FAILWITH(IERR_UNEXPECTED_EOF);
+    }
 
     for (;;) {
         IONCHECK(_ion_scanner_read_past_whitespace(scanner, &c));
@@ -1362,14 +1366,14 @@ just_another_char: // yes this is evil
                         IONCHECK(_ion_scanner_skip_single_quoted_string(scanner));
                     }
                 }
-                IONCHECK(_ion_scanner_skip_container(scanner, '}'));
+                IONCHECK(_ion_scanner_skip_container(scanner, '}', depth + 1));
             }
             break;
         case '[':
-            IONCHECK(_ion_scanner_skip_container(scanner, ']'));
+            IONCHECK(_ion_scanner_skip_container(scanner, ']', depth + 1));
             break;
         case '(':
-            IONCHECK(_ion_scanner_skip_container(scanner, ')'));
+            IONCHECK(_ion_scanner_skip_container(scanner, ')', depth + 1));
             break;
         case EOF:
             FAILWITH(IERR_UNEXPECTED_EOF);
@@ -2098,9 +2102,11 @@ iERR _ion_scanner_read_as_base64(ION_SCANNER *scanner, BYTE *buf, SIZE len, SIZE
         // are present or not, that is the value is high bit justified.
 
         // we first move as many as we can into the caller buffer
-        while (output_length-- && remaining--) {
+        while (output_length > 0 && remaining > 0) {
             *dst++ = (b64_block & 0xff0000) >> 16;
             b64_block <<= 8;
+            output_length--;
+            remaining--;
         }
 
         // and if there's anything left we move it into the scanners temp

--- a/ionc/ion_scanner.h
+++ b/ionc/ion_scanner.h
@@ -439,7 +439,8 @@ iERR _ion_scanner_skip_blob                         (ION_SCANNER *scanner);
 iERR _ion_scanner_skip_sexp                         (ION_SCANNER *scanner);
 iERR _ion_scanner_skip_list                         (ION_SCANNER *scanner);
 iERR _ion_scanner_skip_struct                       (ION_SCANNER *scanner);
-iERR _ion_scanner_skip_container                    (ION_SCANNER *scanner, int close_char);
+#define ION_SCANNER_MAX_SKIP_DEPTH 512
+iERR _ion_scanner_skip_container                    (ION_SCANNER *scanner, int close_char, int depth);
 
 iERR _ion_scanner_read_cached_bytes                 (ION_SCANNER *scanner, BYTE *buf, SIZE len, SIZE *p_bytes_written);
 

--- a/test/test_ion_overflow.cpp
+++ b/test/test_ion_overflow.cpp
@@ -435,7 +435,7 @@ TEST(IonBinaryReader, RejectsOversizedSymbolTableString) {
 
 TEST(IonInteger, FromCharsHandlesNullLiterals) {
     // _ion_int_from_chars_helper uses strncmp on non-NUL-terminated strings
-    // and has broken || logic. After the fix, "null" and "null.int" should
+    // and had broken || logic. After the fix, "null" and "null.int" should
     // be accepted, "n" alone should be rejected, and no OOB read should occur.
 
     ION_INT *iint = NULL;

--- a/test/test_ion_overflow.cpp
+++ b/test/test_ion_overflow.cpp
@@ -507,9 +507,9 @@ TEST(IonTextReader, DeeplyNestedContainersDoNotCrash) {
 }
 
 TEST(IonTextReader, Base64DecodeDoesNotOverflowBuffer) {
-    // _ion_scanner_read_as_base64 has a post-decrement underflow when
-    // buf_max % 3 == 2. The 'remaining' counter wraps to -1 and the
-    // decode loop writes past the caller's buffer.
+    // _ion_scanner_read_as_base64 had a post-decrement underflow when
+    // buf_max % 3 == 2. The 'remaining' counter wrapped to -1 and the
+    // decode loop wrote past the caller's buffer.
     //
     // Text Ion blob: {{ AQID }} which is base64 for bytes 0x01 0x02 0x03
     // We read with buf_max=2 so the 3-byte decode hits the boundary.

--- a/test/test_ion_overflow.cpp
+++ b/test/test_ion_overflow.cpp
@@ -474,10 +474,10 @@ TEST(IonTextReader, DeeplyNestedContainersDoNotCrash) {
     // the inner deeply-nested list. This triggers _ion_scanner_skip_container.
     const int DEPTH = 1000;
     std::string ion_text;
-    ion_text += '[';
+    ion_text += '[  ';
     ion_text += std::string(DEPTH, '[');
     ion_text += std::string(DEPTH, ']');
-    ion_text += ']';
+    ion_text += '  ]';
 
     hREADER reader = NULL;
     ION_TYPE type;

--- a/test/test_ion_overflow.cpp
+++ b/test/test_ion_overflow.cpp
@@ -432,3 +432,116 @@ TEST(IonBinaryReader, RejectsOversizedSymbolTableString) {
 
     ion_reader_close(reader);
 }
+
+TEST(IonInteger, FromCharsHandlesNullLiterals) {
+    // _ion_int_from_chars_helper uses strncmp on non-NUL-terminated strings
+    // and has broken || logic. After the fix, "null" and "null.int" should
+    // be accepted, "n" alone should be rejected, and no OOB read should occur.
+
+    ION_INT *iint = NULL;
+    ION_ASSERT_OK(ion_int_alloc(NULL, &iint));
+
+    // "null" (length 4) should succeed and produce a null int
+    iERR err = ion_int_from_chars(iint, "null", 4);
+    ASSERT_EQ(IERR_OK, err);
+
+    // "null.int" (length 8) should succeed
+    err = ion_int_from_chars(iint, "null.int", 8);
+    ASSERT_EQ(IERR_OK, err);
+
+    // "n" (length 1) should fail with IERR_INVALID_SYNTAX, not OOB read
+    err = ion_int_from_chars(iint, "n", 1);
+    ASSERT_EQ(IERR_INVALID_SYNTAX, err);
+
+    // "nu" (length 2) should fail
+    err = ion_int_from_chars(iint, "nu", 2);
+    ASSERT_EQ(IERR_INVALID_SYNTAX, err);
+
+    // "null.in" (length 7) should fail — not a complete literal
+    err = ion_int_from_chars(iint, "null.in", 7);
+    ASSERT_EQ(IERR_INVALID_SYNTAX, err);
+
+    ion_int_free(iint);
+}
+
+TEST(IonTextReader, DeeplyNestedContainersDoNotCrash) {
+    // _ion_scanner_skip_container recurses with no depth limit.
+    // Nesting deeper than ION_SCANNER_MAX_SKIP_DEPTH should return an
+    // error rather than exhausting the stack.
+    //
+    // Format: [  [[[...1000 brackets...]]]  ]
+    // We step into the outer list, then call next() which must skip
+    // the inner deeply-nested list. This triggers _ion_scanner_skip_container.
+    const int DEPTH = 1000;
+    std::string ion_text;
+    ion_text += '[';
+    ion_text += std::string(DEPTH, '[');
+    ion_text += std::string(DEPTH, ']');
+    ion_text += ']';
+
+    hREADER reader = NULL;
+    ION_TYPE type;
+    iERR err;
+
+    err = ion_reader_open_buffer(&reader, (BYTE *)ion_text.c_str(), (SIZE)ion_text.size(), NULL);
+    ASSERT_EQ(IERR_OK, err);
+
+    err = ion_reader_next(reader, &type);
+    ASSERT_EQ(IERR_OK, err);
+    ASSERT_EQ((ION_TYPE)tid_LIST, type);
+
+    err = ion_reader_step_in(reader);
+    ASSERT_EQ(IERR_OK, err);
+
+    // This next() must skip the deeply nested inner list.
+    // It should fail with an error rather than recursing unboundedly.
+    err = ion_reader_next(reader, &type);
+    if (err == IERR_OK) {
+        // If first next succeeds (returns the inner list), calling next again
+        // will skip it via the scanner's skip_container.
+        err = ion_reader_next(reader, &type);
+    }
+    ASSERT_NE(IERR_OK, err);
+
+    ion_reader_close(reader);
+}
+
+TEST(IonTextReader, Base64DecodeDoesNotOverflowBuffer) {
+    // _ion_scanner_read_as_base64 has a post-decrement underflow when
+    // buf_max % 3 == 2. The 'remaining' counter wraps to -1 and the
+    // decode loop writes past the caller's buffer.
+    //
+    // Text Ion blob: {{ AQID }} which is base64 for bytes 0x01 0x02 0x03
+    // We read with buf_max=2 so the 3-byte decode hits the boundary.
+
+    const char *ion_text = "{{ AQID }}";
+    SIZE ion_text_len = (SIZE)strlen(ion_text);
+
+    hREADER reader = NULL;
+    ION_TYPE type;
+    iERR err;
+
+    err = ion_reader_open_buffer(&reader, (BYTE *)ion_text, ion_text_len, NULL);
+    ASSERT_EQ(IERR_OK, err);
+
+    err = ion_reader_next(reader, &type);
+    ASSERT_EQ(IERR_OK, err);
+    ASSERT_EQ((ION_TYPE)tid_BLOB, type);
+
+    // Read with buf_max=2 (% 3 == 2) to trigger the boundary condition.
+    // The function should write at most 2 bytes and not corrupt memory.
+    BYTE read_buf[64];
+    memset(read_buf, 0xCC, sizeof(read_buf));
+    SIZE bytes_read = 0;
+
+    err = ion_reader_read_lob_partial_bytes(reader, read_buf, 2, &bytes_read);
+    ASSERT_EQ(IERR_OK, err);
+    ASSERT_LE(bytes_read, 2);
+
+    // Verify no write past the 2-byte boundary
+    for (int i = 2; i < 64; i++) {
+        ASSERT_EQ(0xCC, read_buf[i]) << "Buffer overwrite at offset " << i;
+    }
+
+    ion_reader_close(reader);
+}

--- a/test/test_ion_overflow.cpp
+++ b/test/test_ion_overflow.cpp
@@ -465,7 +465,7 @@ TEST(IonInteger, FromCharsHandlesNullLiterals) {
 }
 
 TEST(IonTextReader, DeeplyNestedContainersDoNotCrash) {
-    // _ion_scanner_skip_container recurses with no depth limit.
+    // _ion_scanner_skip_container should not recurse without a depth limit.
     // Nesting deeper than ION_SCANNER_MAX_SKIP_DEPTH should return an
     // error rather than exhausting the stack.
     //


### PR DESCRIPTION
## Summary

- Fix heap overflow in `_ion_scanner_read_as_base64` where post-decrement underflow causes the decode loop to write past the caller's buffer
- Add recursion depth limit to `_ion_scanner_skip_container` to prevent stack exhaustion from deeply nested text Ion containers
- Fix out-of-bounds read and broken logic in `_ion_int_from_chars_helper` null literal parsing that used `strncmp` on non-NUL-terminated strings

## Testing

New unit tests in `test/test_ion_overflow.cpp` verify:
- `ion_reader_read_lob_partial_bytes` with `buf_max % 3 == 2` does not write past the provided buffer when decoding base64 blobs
- Text Ion input with 1000-deep nested containers returns an error rather than recursing unboundedly when the scanner skips a container value
- `ion_int_from_chars` correctly accepts "null" (length 4) and "null.int" (length 8), rejects partial matches like "n" (length 1), and never reads past the declared string length

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
