### PR TITLE
Harden container depth

### DIFF
--- a/ionc/include/ionc/ion_error_codes.h
+++ b/ionc/include/ionc/ion_error_codes.h
@@ -92,6 +92,11 @@
     ERROR_CODE( IERR_INVALID_LEADING_ZEROS,     52 )
     ERROR_CODE( IERR_INVALID_LOB_TERMINATOR,    53 )
 
+    /** Container nesting exceeded the configured `max_container_depth`, or exceeded
+     * ION_MAX_RECURSION_DEPTH within one of the library's recursive helpers.
+     */
+    ERROR_CODE( IERR_STACK_OVERFLOW,            54 )
+
 
 // if it was defined we undefine it now
 #undef ERROR_CODE

--- a/ionc/include/ionc/ion_extractor.h
+++ b/ionc/include/ionc/ion_extractor.h
@@ -55,9 +55,10 @@
 #endif
 
 /**
- * Default maximum length of any path. DEFAULT_WRITER_STACK_DEPTH is chosen as the default because this is the default
- * maximum depth to which readers can descend. Unless the reader is configured with a higher `max_container_depth`,
- * attempting to match paths longer than this will fail.
+ * Default maximum length of any path. This bounds the depth to which `ion_extractor_match` will
+ * recurse, and sizes fixed-length arrays in the extractor (see ION_EXTRACTOR._path_components),
+ * so it is deliberately kept small and is independent of the reader's `max_container_depth`.
+ * A reader may descend deeper than this; paths simply cannot match below this depth.
  * NOTE: this is a constant that may not be redefined by the user.
  */
 #define ION_EXTRACTOR_MAX_PATH_LENGTH_DEFAULT DEFAULT_WRITER_STACK_DEPTH

--- a/ionc/include/ionc/ion_reader.h
+++ b/ionc/include/ionc/ion_reader.h
@@ -56,7 +56,7 @@ typedef struct _ion_reader_context_change_notifier {
  * All fields in the structure are defaulted to 0, except for the following:
  *
  * #define DEFAULT_ANNOTATION_LIMIT         10
- * #define DEFAULT_WRITER_STACK_DEPTH       10
+ * #define DEFAULT_MAX_CONTAINER_DEPTH    1000
  * #define DEFAULT_CHUNK_THRESHOLD     DEFAULT_BLOCK_SIZE
  * #define DEFAULT_SYMBOL_THRESHOLD        512
  *
@@ -80,7 +80,9 @@ typedef struct _ion_reader_options
      */
     int  new_line_char;
 
-    /** The max container depth defaults to 10
+    /** The maximum container nesting depth this reader will descend to. Defaults to 1000.
+     *  Stepping in beyond this depth fails with IERR_STACK_OVERFLOW. May not be set
+     *  below 2.
      *
      */
     SIZE max_container_depth;

--- a/ionc/include/ionc/ion_writer.h
+++ b/ionc/include/ionc/ion_writer.h
@@ -63,7 +63,9 @@ typedef struct _ion_writer_options
      */
     BOOL flush_every_value;
 
-    /** The max container depth defaults to 10
+    /** The maximum container nesting depth this writer will accept. Defaults to 1000.
+     *  Starting a container beyond this depth fails with IERR_STACK_OVERFLOW. May not
+     *  be set below 2.
      *
      */
     SIZE max_container_depth;

--- a/ionc/ion_const.h
+++ b/ionc/ion_const.h
@@ -27,6 +27,17 @@ extern "C" {
 #define DEFAULT_ANNOTATION_LIMIT         10
 #define DEFAULT_WRITER_STACK_DEPTH       10
 
+    // default limit on container nesting for readers and writers. Deeper nesting
+    // is rejected with IERR_STACK_OVERFLOW. Distinct from DEFAULT_WRITER_STACK_DEPTH,
+    // which also sizes fixed extractor arrays and must stay small.
+#define DEFAULT_MAX_CONTAINER_DEPTH     1000
+
+    // Independent ceiling for the library's recursive reader/writer consumers, which
+    // consume a C stack frame per level and so cannot be bounded by a user-supplied
+    // option. Measured overflow is above 50000 frames on an 8MB stack; this leaves
+    // a wide margin while permitting far deeper nesting than DEFAULT_MAX_CONTAINER_DEPTH.
+#define ION_MAX_RECURSION_DEPTH         5000
+
 //#define DEFAULT_CHUNK_THRESHOLD     DEFAULT_BLOCK_SIZE // TODO - get the right size here!
     // default block size is (currently) 64k, it has been 256k and 128mb
     // so the current user alloc limit now would be 16k (it was 2k before this)

--- a/ionc/ion_reader.c
+++ b/ionc/ion_reader.c
@@ -353,9 +353,9 @@ void _ion_reader_initialize_option_defaults(ION_READER_OPTIONS* p_options)
         p_options->new_line_char = '\n';
     }
 
-    // the max container depth defaults to 10
+    // the max container depth defaults to DEFAULT_MAX_CONTAINER_DEPTH
     if (!p_options->max_container_depth) {
-        p_options->max_container_depth = DEFAULT_WRITER_STACK_DEPTH;
+        p_options->max_container_depth = DEFAULT_MAX_CONTAINER_DEPTH;
     }
 
     // the max number of annotations on 1 value, defaults to 10
@@ -601,6 +601,10 @@ iERR _ion_reader_step_in_helper(ION_READER *preader)
     iENTER;
 
     ASSERT(preader);
+
+    if (preader->_depth >= preader->options.max_container_depth) {
+        FAILWITHMSG(IERR_STACK_OVERFLOW, "Container nesting exceeds max_container_depth.");
+    }
 
     switch(preader->type) {
     case ion_type_text_reader:

--- a/ionc/ion_writer.c
+++ b/ionc/ion_writer.c
@@ -264,6 +264,8 @@ iERR _ion_writer_open_helper(ION_WRITER **p_pwriter, ION_STREAM *stream, ION_WRI
     }
     _ion_writer_initialize_option_defaults(&(pwriter->options));
 
+    IONCHECK(_ion_writer_validate_options(&(pwriter->options)));
+
     // initialize decimal context
     if (pwriter->options.decimal_context == NULL) {
         decContextDefault(&pwriter->deccontext, DEC_INIT_DECQUAD);
@@ -344,9 +346,9 @@ void _ion_writer_initialize_option_defaults(ION_WRITER_OPTIONS *p_options)
         p_options->temp_buffer_size = ION_WRITER_TEMP_BUFFER_DEFAULT;
     }
 
-    // the max container depth defaults to 10
+    // the max container depth defaults to DEFAULT_MAX_CONTAINER_DEPTH
     if (!p_options->max_container_depth) {
-        p_options->max_container_depth = DEFAULT_WRITER_STACK_DEPTH;
+        p_options->max_container_depth = DEFAULT_MAX_CONTAINER_DEPTH;
     }
 
     // the max number of annotations on 1 value, defaults to 10
@@ -360,6 +362,27 @@ void _ion_writer_initialize_option_defaults(ION_WRITER_OPTIONS *p_options)
     }
 
     return;
+}
+
+iERR _ion_writer_validate_options(ION_WRITER_OPTIONS* p_options)
+{
+    iENTER;
+    char *msg;
+    ASSERT(p_options != NULL);
+
+    // the max container depth defaults to DEFAULT_MAX_CONTAINER_DEPTH
+    if (p_options->max_container_depth < MIN_WRITER_STACK_DEPTH) {
+        msg = "max container depth below min of " STR(MIN_WRITER_STACK_DEPTH);
+        FAILWITHMSG(IERR_INVALID_ARG, msg);
+    }
+
+    // the max number of annotations on 1 value, defaults to 10
+    if (p_options->max_annotation_count < MIN_ANNOTATION_LIMIT) {
+        msg = "max annotation count below min of " STR(MIN_ANNOTATION_LIMIT);
+        FAILWITHMSG(IERR_INVALID_ARG, msg);
+    }
+
+    iRETURN;
 }
 
 
@@ -2288,6 +2311,9 @@ iERR ion_writer_start_container(hWRITER hwriter, ION_TYPE container_type)
     IONCHECK(_ion_writer_transition_to_symtab_intercept_state(pwriter, container_type));
     if (pwriter->_current_symtab_intercept_state != iWSIS_NONE) {
         // A symbol table is being intercepted. Don't write the start of the container, but record the depth.
+        if (pwriter->depth >= pwriter->options.max_container_depth) {
+            FAILWITHMSG(IERR_STACK_OVERFLOW, "Container nesting exceeds max_container_depth.");
+        }
         pwriter->depth++;
         SUCCEED();
     }
@@ -2302,6 +2328,10 @@ iERR _ion_writer_start_container_helper(ION_WRITER *pwriter, ION_TYPE container_
 
     ASSERT(pwriter);
     ASSERT(container_type == tid_STRUCT || container_type == tid_LIST || container_type == tid_SEXP);
+
+    if (pwriter->depth >= pwriter->options.max_container_depth) {
+        FAILWITHMSG(IERR_STACK_OVERFLOW, "Container nesting exceeds max_container_depth.");
+    }
 
     switch (pwriter->type) {
     case ion_type_text_writer:

--- a/ionc/ion_writer.c
+++ b/ionc/ion_writer.c
@@ -2737,6 +2737,14 @@ iERR _ion_writer_write_all_values_helper(ION_WRITER *pwriter, ION_READER *preade
     ASSERT(pwriter);
     ASSERT(preader);
 
+    // This helper is mutually recursive with _ion_writer_write_one_value_helper, one C
+    // stack frame per container. max_container_depth cannot bound it, since a caller may
+    // legitimately configure a depth far beyond what the stack can hold, so the recursion
+    // needs its own ceiling. preader->_depth already tracks the nesting level.
+    if (preader->_depth >= ION_MAX_RECURSION_DEPTH) {
+        FAILWITHMSG(IERR_STACK_OVERFLOW, "Container nesting exceeds ION_MAX_RECURSION_DEPTH.");
+    }
+
     // Temporarily configure the reader to notify the writer of symbol table context changes.
     preader->context_change_notifier.context = pwriter;
     preader->context_change_notifier.notify = &_ion_writer_add_imported_tables_helper_fn;

--- a/ionc/ion_writer.c
+++ b/ionc/ion_writer.c
@@ -287,8 +287,20 @@ iERR _ion_writer_open_helper(ION_WRITER **p_pwriter, ION_STREAM *stream, ION_WRI
         writer_type = ion_type_text_writer;
     }
 
-    // calculate annotations size by writer option's max_annotation_count field
-    SIZE temp_buffer_size = pwriter->options.max_annotation_count * sizeof(ION_SYMBOL) + ION_WRITER_TEMP_BUFFER_DEFAULT;
+    // The temp buffer is a bump allocator with no free, and the text writer's container
+    // stack is allocated from it, doubling as it grows without reclaiming the old array.
+    // Reserve enough for the full configured depth plus the doubling waste (bounded by
+    // 2x the final size), or the stack would exhaust the buffer with a misleading
+    // IERR_NO_MEMORY long before max_container_depth was reached.
+    SIZE stack_entry_size = (SIZE)(sizeof(ION_TYPE) + sizeof(BYTE) + 2 * sizeof(void *));
+    int64_t stack_reserve = 2 * (int64_t)pwriter->options.max_container_depth * stack_entry_size;
+    int64_t temp_buffer_size_64 = (int64_t)pwriter->options.max_annotation_count * (int64_t)sizeof(ION_SYMBOL)
+                                + (int64_t)pwriter->options.temp_buffer_size
+                                + stack_reserve;
+    if (temp_buffer_size_64 > MAX_SIZE) {
+        FAILWITHMSG(IERR_INVALID_ARG, "max_container_depth requires too large a temp buffer.");
+    }
+    SIZE temp_buffer_size = (SIZE)temp_buffer_size_64;
     IONCHECK(ion_temp_buffer_init(pwriter, &pwriter->temp_buffer, temp_buffer_size));
 
     // allocate a temp pool we can reset from time to time

--- a/ionc/ion_writer_impl.h
+++ b/ionc/ion_writer_impl.h
@@ -207,6 +207,7 @@ iERR _ion_writer_open_buffer_helper(ION_WRITER **p_pwriter, BYTE *buffer, SIZE b
 iERR _ion_writer_open_stream_helper(ION_WRITER **p_pwriter, ION_STREAM p_stream, void *handler_state, ION_WRITER_OPTIONS *p_options);
 iERR _ion_writer_open_helper(ION_WRITER **p_pwriter, ION_STREAM *stream, ION_WRITER_OPTIONS *p_options);
 void _ion_writer_initialize_option_defaults(ION_WRITER_OPTIONS *p_options);
+iERR _ion_writer_validate_options(ION_WRITER_OPTIONS *p_options);
 iERR _ion_writer_initialize(ION_WRITER *pwriter, ION_OBJ_TYPE writer_type);
 
 iERR _ion_writer_get_depth_helper(ION_WRITER *pwriter, SIZE *p_depth);

--- a/ionc/ion_writer_text.c
+++ b/ionc/ion_writer_text.c
@@ -107,6 +107,12 @@ iERR _ion_writer_text_grow_stack(ION_WRITER *pwriter)
 {
     iENTER;
 
+    // Never grow past the configured depth; _ion_writer_start_container_helper rejects
+    // anything deeper with IERR_STACK_OVERFLOW, so a larger stack could never be used.
+    if (TEXTWRITER(pwriter)->_stack_size >= pwriter->options.max_container_depth) {
+        FAILWITHMSG(IERR_STACK_OVERFLOW, "Container nesting exceeds max_container_depth.");
+    }
+
     int       old_type_size = TEXTWRITER(pwriter)->_stack_size * sizeof(*(TEXTWRITER(pwriter)->_stack_parent_type));
     int       old_flag_size = TEXTWRITER(pwriter)->_stack_size * sizeof(*(TEXTWRITER(pwriter)->_stack_flags));
     int       new_type_size = 2 * old_type_size;

--- a/test/test_ion_overflow.cpp
+++ b/test/test_ion_overflow.cpp
@@ -474,16 +474,22 @@ TEST(IonTextReader, DeeplyNestedContainersDoNotCrash) {
     // the inner deeply-nested list. This triggers _ion_scanner_skip_container.
     const int DEPTH = 1000;
     std::string ion_text;
-    ion_text += '[  ';
+    ion_text += "[  ";
     ion_text += std::string(DEPTH, '[');
     ion_text += std::string(DEPTH, ']');
-    ion_text += '  ]';
+    ion_text += "  ]";
 
     hREADER reader = NULL;
     ION_TYPE type;
     iERR err;
 
-    err = ion_reader_open_buffer(&reader, (BYTE *)ion_text.c_str(), (SIZE)ion_text.size(), NULL);
+    // Raise max_container_depth above DEPTH so this exercises the scanner's skip-depth
+    // guard rather than tripping the reader's own container depth limit first.
+    ION_READER_OPTIONS options;
+    memset(&options, 0, sizeof(options));
+    options.max_container_depth = DEPTH + 10;
+
+    err = ion_reader_open_buffer(&reader, (BYTE *)ion_text.c_str(), (SIZE)ion_text.size(), &options);
     ASSERT_EQ(IERR_OK, err);
 
     err = ion_reader_next(reader, &type);
@@ -504,6 +510,161 @@ TEST(IonTextReader, DeeplyNestedContainersDoNotCrash) {
     ASSERT_NE(IERR_OK, err);
 
     ion_reader_close(reader);
+}
+
+TEST(IonContainerDepth, ReaderRejectsNestingBeyondMaxContainerDepth) {
+    const int LIMIT = 20;
+    std::string ion_text = std::string(LIMIT + 5, '[') + std::string(LIMIT + 5, ']');
+
+    ION_READER_OPTIONS options;
+    memset(&options, 0, sizeof(options));
+    options.max_container_depth = LIMIT;
+
+    hREADER reader = NULL;
+    ION_TYPE type;
+    ASSERT_EQ(IERR_OK, ion_reader_open_buffer(&reader, (BYTE *)ion_text.c_str(),
+                                              (SIZE)ion_text.size(), &options));
+
+    // Descends to exactly LIMIT, then refuses.
+    int depth = 0;
+    iERR err;
+    for (;;) {
+        err = ion_reader_next(reader, &type);
+        if (err != IERR_OK) break;
+        if (type == tid_EOF) break;
+        err = ion_reader_step_in(reader);
+        if (err != IERR_OK) break;
+        depth++;
+    }
+    ASSERT_EQ(IERR_STACK_OVERFLOW, err);
+    ASSERT_EQ(LIMIT, depth);
+
+    ion_reader_close(reader);
+}
+
+TEST(IonContainerDepth, ReaderDefaultDepthAcceptsModeratelyNestedData) {
+    // The default was formerly 10, which is below the depth used by ion-tests
+    // vectors such as good/equivs/lists.ion (23 deep).
+    const int DEPTH = 100;
+    std::string ion_text = std::string(DEPTH, '[') + std::string(DEPTH, ']');
+
+    hREADER reader = NULL;
+    ION_TYPE type;
+    ASSERT_EQ(IERR_OK, ion_reader_open_buffer(&reader, (BYTE *)ion_text.c_str(),
+                                              (SIZE)ion_text.size(), NULL));
+    for (int i = 0; i < DEPTH; i++) {
+        ASSERT_EQ(IERR_OK, ion_reader_next(reader, &type));
+        ASSERT_EQ((ION_TYPE)tid_LIST, type);
+        ASSERT_EQ(IERR_OK, ion_reader_step_in(reader));
+    }
+    ion_reader_close(reader);
+}
+
+TEST(IonContainerDepth, WriterRejectsNestingBeyondMaxContainerDepth) {
+    // Covers both writers: the text writer previously failed at 80 containers with
+    // IERR_NO_MEMORY due to temp buffer exhaustion, regardless of this option.
+    const BOOL binary_flags[] = {TRUE, FALSE};
+    for (int i = 0; i < 2; i++) {
+        const int LIMIT = 500;
+        hWRITER writer = NULL;
+        ION_STREAM *stream = NULL;
+        ION_WRITER_OPTIONS options;
+        memset(&options, 0, sizeof(options));
+        options.output_as_binary = binary_flags[i];
+        options.max_container_depth = LIMIT;
+
+        ASSERT_EQ(IERR_OK, ion_stream_open_memory_only(&stream));
+        ASSERT_EQ(IERR_OK, ion_writer_open(&writer, stream, &options));
+
+        int opened = 0;
+        iERR err = IERR_OK;
+        for (int j = 0; j < LIMIT + 5; j++) {
+            err = ion_writer_start_container(writer, tid_LIST);
+            if (err != IERR_OK) break;
+            opened++;
+        }
+        ASSERT_EQ(IERR_STACK_OVERFLOW, err) << "output_as_binary=" << binary_flags[i];
+        ASSERT_EQ(LIMIT, opened) << "output_as_binary=" << binary_flags[i];
+
+        ion_writer_close(writer);
+        ion_stream_close(stream);
+    }
+}
+
+TEST(IonContainerDepth, TextWriterDepthIsIndependentOfAnnotationCount) {
+    // The temp buffer was sized from max_annotation_count, so it silently governed
+    // nesting depth: 10 annotations allowed 80 containers, 100 allowed 320.
+    const int annotation_counts[] = {10, 100};
+    for (int i = 0; i < 2; i++) {
+        const int DEPTH = 400;
+        hWRITER writer = NULL;
+        ION_STREAM *stream = NULL;
+        ION_WRITER_OPTIONS options;
+        memset(&options, 0, sizeof(options));
+        options.output_as_binary = FALSE;
+        options.max_container_depth = DEPTH;
+        options.max_annotation_count = annotation_counts[i];
+
+        ASSERT_EQ(IERR_OK, ion_stream_open_memory_only(&stream));
+        ASSERT_EQ(IERR_OK, ion_writer_open(&writer, stream, &options));
+
+        for (int j = 0; j < DEPTH; j++) {
+            ASSERT_EQ(IERR_OK, ion_writer_start_container(writer, tid_LIST))
+                << "failed at depth " << j << " with max_annotation_count="
+                << annotation_counts[i];
+        }
+        ion_writer_close(writer);
+        ion_stream_close(stream);
+    }
+}
+
+TEST(IonContainerDepth, WriteAllValuesDoesNotExhaustTheStack) {
+    // ion_writer_write_all_values recurses per container. A high max_container_depth
+    // must not be taken as permission to recurse past ION_MAX_RECURSION_DEPTH; this
+    // previously segfaulted.
+    const int DEPTH = 60000;
+    std::string ion_text = std::string(DEPTH, '[') + std::string(DEPTH, ']');
+
+    hREADER reader = NULL;
+    ION_READER_OPTIONS r_options;
+    memset(&r_options, 0, sizeof(r_options));
+    r_options.max_container_depth = DEPTH + 10;
+    ASSERT_EQ(IERR_OK, ion_reader_open_buffer(&reader, (BYTE *)ion_text.c_str(),
+                                              (SIZE)ion_text.size(), &r_options));
+
+    hWRITER writer = NULL;
+    ION_STREAM *stream = NULL;
+    ION_WRITER_OPTIONS w_options;
+    memset(&w_options, 0, sizeof(w_options));
+    w_options.output_as_binary = TRUE;
+    w_options.max_container_depth = DEPTH + 10;
+    ASSERT_EQ(IERR_OK, ion_stream_open_memory_only(&stream));
+    ASSERT_EQ(IERR_OK, ion_writer_open(&writer, stream, &w_options));
+
+    ASSERT_EQ(IERR_STACK_OVERFLOW, ion_writer_write_all_values(writer, reader));
+
+    ion_writer_close(writer);
+    ion_stream_close(stream);
+    ion_reader_close(reader);
+}
+
+TEST(IonContainerDepth, OptionsBelowMinimumAreRejected) {
+    ION_READER_OPTIONS r_options;
+    memset(&r_options, 0, sizeof(r_options));
+    r_options.max_container_depth = 1;
+    hREADER reader = NULL;
+    const char *text = "[]";
+    ASSERT_EQ(IERR_INVALID_ARG, ion_reader_open_buffer(&reader, (BYTE *)text, 2, &r_options));
+
+    // The writer previously performed no options validation at all.
+    ION_WRITER_OPTIONS w_options;
+    memset(&w_options, 0, sizeof(w_options));
+    w_options.max_container_depth = 1;
+    hWRITER writer = NULL;
+    ION_STREAM *stream = NULL;
+    ASSERT_EQ(IERR_OK, ion_stream_open_memory_only(&stream));
+    ASSERT_EQ(IERR_INVALID_ARG, ion_writer_open(&writer, stream, &w_options));
+    ion_stream_close(stream);
 }
 
 TEST(IonTextReader, Base64DecodeDoesNotOverflowBuffer) {

--- a/tools/events/ion_event_stream.cpp
+++ b/tools/events/ion_event_stream.cpp
@@ -446,6 +446,11 @@ iERR _ion_event_stream_read_all_recursive(hREADER hreader, IonEventStream *strea
     iENTER;
     ION_SET_ERROR_CONTEXT(&stream->location, NULL);
     ION_TYPE t;
+    // Mutually recursive with ion_event_stream_read, one C stack frame per container.
+    // Without this the CLI segfaults on deeply nested input rather than reporting an error.
+    if (depth >= ION_EVENT_CONTAINER_DEPTH_MAX) {
+        IONFAILSTATE(IERR_STACK_OVERFLOW, "Container nesting exceeds ION_EVENT_CONTAINER_DEPTH_MAX.");
+    }
     for (;;) {
         IONCREAD(ion_reader_next(hreader, &t));
         if (t == tid_EOF) {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

## Summary

`max_container_depth` has been present in `ION_READER_OPTIONS` and `ION_WRITER_OPTIONS` since the initial commit, but no code ever compared it against a live container depth. It was defaulted, partially validated, and documented as enforced, yet had no effect. As a result deeply nested input was accepted to arbitrary depth, and the library's recursive helpers could exhaust the C stack.

`ion process` segfaulted on a 30 KB file consisting only of `[` characters. The brackets did not even need to be balanced.

These commits enforce the option, raise its default from 10 to 1000, bound the recursive helpers independently, and fix a related bug that capped the text writer at 80 containers with a misleading `IERR_NO_MEMORY`.

## Motivation

Three separate defects, all reachable from untrusted input:

**1. The option was inert.** With default options (`max_container_depth == 10`), a plain `ion_reader_step_in` loop descends 100,000 levels and reports no error. All 11 references to the field were writes or comments; there were zero reads for comparison.

**2. Unbounded recursion.** `_ion_writer_write_all_values_helper` is mutually recursive with `_ion_writer_write_one_value_helper`, and `_ion_event_stream_read_all_recursive` with `ion_event_stream_read`, consuming a C stack frame per nesting level with no guard. On an 8 MB stack, `ion process` crashed between 25,000 and 30,000 levels.

**3. The text writer failed at 80 containers.** Its container stack is allocated from the writer's temp buffer, a bump allocator with no free. `_ion_writer_text_grow_stack` doubles the stack and abandons the previous array, so nesting failed with `IERR_NO_MEMORY` once the fixed 1,584-byte buffer was exhausted, entirely unrelated to `max_container_depth`.

Defect 3 also coupled nesting depth to an unrelated option, since the buffer was sized from `max_annotation_count`:

| `max_annotation_count` | containers before failure |
|---|---|
| 10 (default) | 80 |
| 100 | 320 |
| 1000 | 2560 |

The binary writer, which uses heap-backed collections, had no such limit, so the effective depth silently differed by output format. The reported `IERR_NO_MEMORY` was misleading; the process was not out of memory.

## Changes

Five commits, each independently reviewable:

**`7a6235f` Add container depth constants and `IERR_STACK_OVERFLOW`**

Adds `DEFAULT_MAX_CONTAINER_DEPTH` (1000) and `ION_MAX_RECURSION_DEPTH` (5000), plus a new error code. No behavior change on its own.

`DEFAULT_MAX_CONTAINER_DEPTH` is deliberately a new constant rather than a change to `DEFAULT_WRITER_STACK_DEPTH`. That existing constant also defines `ION_EXTRACTOR_MAX_PATH_LENGTH_DEFAULT` and therefore sizes fixed-length arrays: raising it to 1000 would grow `ION_EXTRACTOR._path_components` from 3,840 to 384,000 bytes and place a 24,000-byte array on the stack in `ion_extractor.c`.

**`aae98c7` Enforce `max_container_depth` in reader and writer**

Enforces the option at the two points that already track depth, `_ion_reader_step_in_helper` and `_ion_writer_start_container_helper`, plus the symbol-table intercept path which increments depth separately. Exceeding it now fails with `IERR_STACK_OVERFLOW`.

Raises the default from 10 to 1000. A limit of 10 rejects `good/equivs/lists.ion` from ion-tests, which nests 23 deep; that vector passes today only because the test harness raises the limit to 100. 1000 is 10x that harness value.

Also adds `_ion_writer_validate_options`, mirroring the reader, so an out-of-range `max_container_depth` or `max_annotation_count` is rejected at open rather than silently failing every container. The writer previously performed no options validation at all.

Corrects the `ion_extractor.h` comment that documented this limit as already enforced.

**`40babc3` Size the writer temp buffer for the configured container depth**

Reserves space for the configured depth plus the doubling waste, and caps growth at `max_container_depth` so the failure is `IERR_STACK_OVERFLOW`. A 64-bit intermediate rejects a `max_container_depth` whose buffer would overflow `SIZE`. Also honors `options.temp_buffer_size`, which was defaulted but never read.

Text and binary writers now both stop at exactly `max_container_depth`.

**`92ea701` Bound the recursive reader/writer consumers independently**

`max_container_depth` cannot bound these helpers, because a caller may legitimately configure a depth far beyond what the stack can hold, which silently re-arms the crash. With `max_container_depth` at 200,000, `ion_writer_write_all_values` still segfaulted on 150,000-deep input. Both are now guarded against fixed ceilings using the depth each already tracks.

The extractor's `_ion_extractor_match_helper` needs no such guard: its recursion is bounded by `max_path_length`, which `ion_extractor_open` validates against the compile-time `ION_EXTRACTOR_MAX_PATH_LENGTH` (10 by default). Verified with 200,000-deep binary input at a reader limit of 1,000,000.

**`53fb551` Add container depth tests; fix multi-character literals in existing test**

`DeeplyNestedContainersDoNotCrash` built its input with `'[  '` and `'  ]'`, which are multi-character character constants rather than strings. The first appended a single space and the second a lone `]`, so the intended outer list was absent and the document ended with an unmatched bracket. The test passed for the wrong reason. It also relied on `step_in` succeeding 1000 levels deep, which only worked because the limit was unenforced, so it now sets an explicit limit and still exercises the scanner's skip-depth guard.

Adds six tests covering the reader and writer limits, the writer's independence from `max_annotation_count`, recursion in `ion_writer_write_all_values`, and options validation.

## Verification

- Full suite passes: **3003 tests, 47 suites**, under both `Release` and `ReleaseSanitizers` (ASan + UBSan clean).
- All 2626 ion-tests vector cases pass, including the 982 `BadVector` cases that must still be rejected.
- `ion process` on 30 KB of `[` characters and on a 100,000-deep balanced document now exit with `IERR_STACK_OVERFLOW` and a diagnostic instead of `SIGSEGV`.
- `good/equivs/lists.ion` (23 deep) parses at default options for the first time.
- Ordinary data round-trips unchanged (`{a:1,b:[2,3],c:{d:"x"}}` → binary → text).
- The new tests were run against a build containing only the constants commit and none of the fixes: three fail on assertions and `WriteAllValuesDoesNotExhaustTheStack` segfaults, confirming each targets a real defect rather than passing vacuously.

## Compatibility

This changes observable behavior. Callers who relied on the limit being unenforced will now receive `IERR_STACK_OVERFLOW` beyond 1000 levels of nesting, where previously nesting was unbounded. A default of 10 was not a viable choice, since it rejects Ion's own conformance data.

Because the temp buffer is now sized from `max_container_depth`, per-writer allocation grows with that option: roughly 50 KB at the new default, up from 1,584 bytes. A caller setting an extreme value gets a proportionally large allocation, rejected only if it would overflow `SIZE`. An explicit upper bound on the option may be worth considering as a follow-up.

## Follow-ups not included here

- The cleaner fix for the temp buffer is to stop leaking on `_ion_writer_text_grow_stack` altogether, by allocating the container stack from the writer's owner pool rather than the bump arena. That is a structural change and is deliberately out of scope.
- UBSan reports signed-integer overflow from left shifts at `ion_symbol_table.c:2184`, in a hash computation. It is unrelated to container depth and does not fail the suite, but it is in the area touched by the two preceding hardening commits and may warrant a separate look.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
